### PR TITLE
Optimize profiler overlay and text rendering

### DIFF
--- a/FontAtlas.h
+++ b/FontAtlas.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <vector>
 #include <string>
 #include <cstdint>
@@ -32,6 +32,6 @@ public:
 private:
     Texture2D tex_;
     int pxSize_=0, spread_=0, atlasW_=0, atlasH_=0, ascent_=0, descent_=0, lineAdvance_=0;
-    std::unordered_map<uint32_t, FontGlyph> map_;
-    std::unordered_map<uint64_t, int> kern_;
+    robin_hood::unordered_flat_map<uint32_t, FontGlyph> map_;
+    robin_hood::unordered_flat_map<uint64_t, int> kern_;
 };

--- a/Profiler.cpp
+++ b/Profiler.cpp
@@ -1,6 +1,6 @@
 #include "Profiler.h"
-#include<unordered_set>
-#include"third_party/robin_hood.h"
+#include <cwchar>
+#include "third_party/robin_hood.h"
 #include "TextManager.h"
 
 
@@ -65,6 +65,12 @@ void Profiler::EndFrame() {
             row.avgMs = kv.second.avgMs;
             row.maxMs = kv.second.maxMs;
             row.usages = kv.second.lastCount;
+            const double perUse = (row.usages ? (row.avgMs / (double)row.usages) : 0.0);
+            wchar_t buf[128];
+            std::swprintf(buf, sizeof(buf) / sizeof(wchar_t),
+                L"%-40s  avg:%6.2f  max:%6.2f  p/u:%6.2f  usages:%u",
+                row.name.c_str(), row.avgMs, row.maxMs, perUse, row.usages);
+            row.formatted = buf;
             current.emplace(row.name, std::move(row));
         }
 
@@ -93,7 +99,7 @@ void Profiler::EndFrame() {
             lastOverlaySort_ = now;
         }
         else {
-            std::unordered_set<std::wstring> used; used.reserve(current.size());
+            robin_hood::unordered_flat_set<std::wstring> used; used.reserve(current.size());
             for (const OverlayRow& prev : readRows) {
                 const std::wstring& key = prev.name;
                 auto it = current.find(key);
@@ -133,6 +139,11 @@ void Profiler::EndFrame() {
             self.avgMs = endFrameAsyncAvgMs_;
             self.maxMs = endFrameAsyncMaxMs_;
             self.usages = 1u;
+            wchar_t buf[128];
+            std::swprintf(buf, sizeof(buf) / sizeof(wchar_t),
+                L"%-40s  avg:%6.2f  max:%6.2f  p/u:%6.2f  usages:%u",
+                self.name.c_str(), self.avgMs, self.maxMs, self.avgMs, self.usages);
+            self.formatted = buf;
             writeRows.insert(writeRows.begin(), std::move(self));
         }
 
@@ -174,10 +185,10 @@ void Profiler::EmitOverlay(TextManager* tm, int x, int y, int maxLines) {
     tm->RegionSetAutoMeasure(reg, false);
 
     // заголовок
-    tm->AddTextf(reg, 18.0f, float4(1, 1, 0.6f, 0.95f),
+    tm->AddTextFmt(reg, 18.0f, float4(1, 1, 0.6f, 0.95f),
         L"[CPU profiler] frame=%llu  (max reset: %.1fs, sort every: %.2fs)",
         (unsigned long long)frameNo_, GetMaxCooldownSeconds(), GetOverlayResortIntervalSeconds());
-    tm->AddTextf(reg, 18.0f, float4(1, 1, 0.6f, 0.95f), L" ");
+    tm->AddTextFmt(reg, 18.0f, float4(1, 1, 0.6f, 0.95f), L" ");
 
     // строки
     int shown = 0;
@@ -185,10 +196,7 @@ void Profiler::EmitOverlay(TextManager* tm, int x, int y, int maxLines) {
     const float4 colEven = { 0.5f, 0.5f, 0.5f, 0.92f };
     for (const auto& r : rows) {
         if (shown >= maxLines) { break; }
-        const double perUse = (r.usages ? (r.avgMs / (double)r.usages) : 0.0);
-        tm->AddTextf(reg, 16.0f, (shown & 1) ? colOdd : colEven,
-            L"%-40s  avg:%6.2f  max:%6.2f  p/u:%6.2f  usages:%u",
-            r.name.c_str(), r.avgMs, r.maxMs, perUse, r.usages);
+        tm->AddText(reg, 16.0f, (shown & 1) ? colOdd : colEven, r.formatted);
         shown++;
     }
 }

--- a/Profiler.h
+++ b/Profiler.h
@@ -2,7 +2,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <mutex>
 #include <chrono>
 #include <thread>
@@ -139,14 +139,15 @@ private:
         double   avgMs = 0.0;
         double   maxMs = 0.0;
         uint32_t usages = 0;
+        std::wstring formatted; // заранее отформатированная строка
     };
 
 private:
 #if PROF_ENABLED
     // сбор статистики
     std::mutex mtx_;
-    std::unordered_map<std::string, ScopeStats> stats_;
-    std::unordered_map<std::thread::id, std::string> threadNames_;
+    robin_hood::unordered_flat_map<std::string, ScopeStats> stats_;
+    robin_hood::unordered_flat_map<std::thread::id, std::string> threadNames_;
 
     std::vector<ScopeSample> frameSamples_;
     uint64_t  frameNo_ = 0;

--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -16,28 +16,6 @@
 
 using Microsoft::WRL::ComPtr;
 
-// форматтеры
-static std::string VFormat_(const char* fmt, va_list args) {
-    if (fmt == nullptr) { return std::string(); }
-    va_list copy; va_copy(copy, args);
-    int needed = std::vsnprintf(nullptr, 0, fmt, copy);
-    va_end(copy);
-    if (needed <= 0) { return std::string(); }
-    std::string s; s.resize((size_t)needed);
-    std::vsnprintf(s.data(), (size_t)needed + 1, fmt, args);
-    return s;
-}
-static std::wstring VFormatW_(const wchar_t* fmt, va_list args) {
-    if (fmt == nullptr) { return std::wstring(); }
-    va_list copy; va_copy(copy, args);
-    int needed = std::vswprintf(nullptr, 0, fmt, copy);
-    va_end(copy);
-    if (needed <= 0) { return std::wstring(); }
-    std::wstring s; s.resize((size_t)needed);
-    std::vswprintf(s.data(), (size_t)needed + 1, fmt, args);
-    return s;
-}
-
 // utf8 → wide
 std::wstring TextManager::UTF8toW(std::string_view s) {
     if (s.empty()) { return L""; }
@@ -111,10 +89,20 @@ void TextManager::AddText(int x, int y, const float4& color, float px, std::stri
 }
 void TextManager::AddTextf(int x, int y, const float4& color, float px, const wchar_t* fmt, ...) {
     if (fmt == nullptr) { return; }
+    wchar_t buf[256];
     va_list args; va_start(args, fmt);
-    std::wstring s = VFormatW_(fmt, args);
+    int len = std::vswprintf(buf, sizeof(buf) / sizeof(wchar_t), fmt, args);
     va_end(args);
-    if (!s.empty()) { AddText(x, y, color, px, std::wstring_view(s)); }
+    if (len > 0) { AddText(x, y, color, px, std::wstring_view(buf, (size_t)len)); }
+}
+
+void TextManager::AddTextFmt(int x, int y, const float4& color, float px, const wchar_t* fmt, ...) {
+    if (fmt == nullptr) { return; }
+    wchar_t buf[256];
+    va_list args; va_start(args, fmt);
+    int len = std::vswprintf(buf, sizeof(buf) / sizeof(wchar_t), fmt, args);
+    va_end(args);
+    if (len > 0) { AddText(x, y, color, px, std::wstring_view(buf, (size_t)len)); }
 }
 
 // регионы
@@ -171,10 +159,20 @@ void TextManager::AddText(RegionId id, float px, const float4& color, std::strin
 }
 void TextManager::AddTextf(RegionId id, float px, const float4& color, const wchar_t* fmt, ...) {
     if (fmt == nullptr) { return; }
+    wchar_t buf[256];
     va_list args; va_start(args, fmt);
-    std::wstring s = VFormatW_(fmt, args);
+    int len = std::vswprintf(buf, sizeof(buf) / sizeof(wchar_t), fmt, args);
     va_end(args);
-    if (!s.empty()) { AddText(id, px, color, std::wstring_view(s)); }
+    if (len > 0) { AddText(id, px, color, std::wstring_view(buf, (size_t)len)); }
+}
+
+void TextManager::AddTextFmt(RegionId id, float px, const float4& color, const wchar_t* fmt, ...) {
+    if (fmt == nullptr) { return; }
+    wchar_t buf[256];
+    va_list args; va_start(args, fmt);
+    int len = std::vswprintf(buf, sizeof(buf) / sizeof(wchar_t), fmt, args);
+    va_end(args);
+    if (len > 0) { AddText(id, px, color, std::wstring_view(buf, (size_t)len)); }
 }
 
 // ======== СБОРКА / ОТРИСОВКА ========

--- a/TextManager.h
+++ b/TextManager.h
@@ -24,6 +24,7 @@ public:
     void AddText(int x, int y, const float4& color, float px, std::wstring_view text);
     void AddText(int x, int y, const float4& color, float px, std::string_view utf8);
     void AddTextf(int x, int y, const float4& color, float px, const wchar_t* fmt, ...);
+    void AddTextFmt(int x, int y, const float4& color, float px, const wchar_t* fmt, ...);
 
     // -------------------- Регионы --------------------
     RegionId CreateRegion(int x, int y, Align align = Align::Left);
@@ -41,6 +42,7 @@ public:
     void AddText(RegionId id, float px, const float4& color, std::wstring_view text);
     void AddText(RegionId id, float px, const float4& color, std::string_view utf8);
     void AddTextf(RegionId id, float px, const float4& color, const wchar_t* fmt, ...);
+    void AddTextFmt(RegionId id, float px, const float4& color, const wchar_t* fmt, ...);
 
     void Build(Renderer* r, ID3D12GraphicsCommandList* cl);
     void Draw(Renderer* r, ID3D12GraphicsCommandList* cl);


### PR DESCRIPTION
## Summary
- Pre-format profiler overlay rows to avoid per-frame string formatting
- Adopt robin_hood hash containers in profiler and font atlas hot paths
- Add stack-based formatting helpers in TextManager to reduce heap churn

## Testing
- `g++ -std=c++17 -fsyntax-only Profiler.cpp TextManager.cpp FontAtlas.cpp 2>&1 | head -n 5` *(fails: wrl/client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b98cb41eb8832995a98086926961c7