### PR TITLE
Use array-based bindings in RenderContext

### DIFF
--- a/Material.cpp
+++ b/Material.cpp
@@ -505,55 +505,50 @@ void Material::Bind(ID3D12GraphicsCommandList* cmdList, const RenderContext& ctx
         switch (p.type) {
         case RootParameterInfo::Constants:
         {
-            auto it = ctx.constants.find(reg);
-            if (it != ctx.constants.end() && !it->second.empty()) {
-                if (isCompute_) { cmdList->SetComputeRoot32BitConstants(p.rootIndex, (UINT)it->second.size(), it->second.data(), 0); }
-                else { cmdList->SetGraphicsRoot32BitConstants(p.rootIndex, (UINT)it->second.size(), it->second.data(), 0); }
+            if (reg < RenderContext::kMaxBindings && !ctx.constants[reg].empty()) {
+                auto& vals = ctx.constants[reg];
+                if (isCompute_) { cmdList->SetComputeRoot32BitConstants(p.rootIndex, (UINT)vals.size(), vals.data(), 0); }
+                else { cmdList->SetGraphicsRoot32BitConstants(p.rootIndex, (UINT)vals.size(), vals.data(), 0); }
             }
             break;
         }
         case RootParameterInfo::CBV:
         {
-            auto it = ctx.cbv.find(reg);
-            if (it != ctx.cbv.end()) {
-                if (isCompute_) { cmdList->SetComputeRootConstantBufferView(p.rootIndex, it->second); }
-                else { cmdList->SetGraphicsRootConstantBufferView(p.rootIndex, it->second); }
+            if (reg < RenderContext::kMaxBindings && ctx.cbv[reg] != 0) {
+                if (isCompute_) { cmdList->SetComputeRootConstantBufferView(p.rootIndex, ctx.cbv[reg]); }
+                else { cmdList->SetGraphicsRootConstantBufferView(p.rootIndex, ctx.cbv[reg]); }
             }
             break;
         }
         case RootParameterInfo::SRV:
         {
-            auto it = ctx.srv.find(reg);
-            if (it != ctx.srv.end()) {
-                if (isCompute_) { cmdList->SetComputeRootShaderResourceView(p.rootIndex, it->second); }
-                else { cmdList->SetGraphicsRootShaderResourceView(p.rootIndex, it->second); }
+            if (reg < RenderContext::kMaxBindings && ctx.srv[reg] != 0) {
+                if (isCompute_) { cmdList->SetComputeRootShaderResourceView(p.rootIndex, ctx.srv[reg]); }
+                else { cmdList->SetGraphicsRootShaderResourceView(p.rootIndex, ctx.srv[reg]); }
             }
             break;
         }
         case RootParameterInfo::UAV:
         {
-            auto it = ctx.uav.find(reg);
-            if (it != ctx.uav.end()) {
-                if (isCompute_) { cmdList->SetComputeRootUnorderedAccessView(p.rootIndex, it->second); }
-                else { cmdList->SetGraphicsRootUnorderedAccessView(p.rootIndex, it->second); }
+            if (reg < RenderContext::kMaxBindings && ctx.uav[reg] != 0) {
+                if (isCompute_) { cmdList->SetComputeRootUnorderedAccessView(p.rootIndex, ctx.uav[reg]); }
+                else { cmdList->SetGraphicsRootUnorderedAccessView(p.rootIndex, ctx.uav[reg]); }
             }
             break;
         }
         case RootParameterInfo::Table:
         {
-            auto it = ctx.table.find(reg);
-            if (it != ctx.table.end()) {
-                if (isCompute_) { cmdList->SetComputeRootDescriptorTable(p.rootIndex, it->second); }
-                else { cmdList->SetGraphicsRootDescriptorTable(p.rootIndex, it->second); }
+            if (reg < RenderContext::kMaxBindings && ctx.table[reg].ptr != 0) {
+                if (isCompute_) { cmdList->SetComputeRootDescriptorTable(p.rootIndex, ctx.table[reg]); }
+                else { cmdList->SetGraphicsRootDescriptorTable(p.rootIndex, ctx.table[reg]); }
             }
             break;
         }
         case RootParameterInfo::TableSampler:
         {
-            auto it = ctx.samplerTable.find(reg);
-            if (it != ctx.samplerTable.end()) {
-                if (isCompute_) { cmdList->SetComputeRootDescriptorTable(p.rootIndex, it->second); }
-                else { cmdList->SetGraphicsRootDescriptorTable(p.rootIndex, it->second); }
+            if (reg < RenderContext::kMaxBindings && ctx.samplerTable[reg].ptr != 0) {
+                if (isCompute_) { cmdList->SetComputeRootDescriptorTable(p.rootIndex, ctx.samplerTable[reg]); }
+                else { cmdList->SetGraphicsRootDescriptorTable(p.rootIndex, ctx.samplerTable[reg]); }
             }
             break;
         }

--- a/RenderContext.h
+++ b/RenderContext.h
@@ -1,24 +1,26 @@
 #pragma once
 #include <d3d12.h>
-#include <unordered_map>
+#include <array>
 #include <string>
 #include <vector>
 
 // CBV, SRV, UAV по ключу (например, "viewProj", "instanceBuffer" и т.д.)
 struct RenderContext {
-    std::unordered_map<uint32_t, D3D12_GPU_VIRTUAL_ADDRESS> cbv;
-    std::unordered_map<uint32_t, std::vector<uint32_t>> constants;
-    std::unordered_map<uint32_t, D3D12_GPU_VIRTUAL_ADDRESS> srv;
-    std::unordered_map<uint32_t, D3D12_GPU_VIRTUAL_ADDRESS> uav;
-    std::unordered_map<uint32_t, D3D12_GPU_DESCRIPTOR_HANDLE> table;
-    std::unordered_map<uint32_t, D3D12_GPU_DESCRIPTOR_HANDLE> samplerTable;
+    static constexpr size_t kMaxBindings = 16;
+
+    std::array<D3D12_GPU_VIRTUAL_ADDRESS, kMaxBindings> cbv{};
+    std::array<std::vector<uint32_t>, kMaxBindings> constants{};
+    std::array<D3D12_GPU_VIRTUAL_ADDRESS, kMaxBindings> srv{};
+    std::array<D3D12_GPU_VIRTUAL_ADDRESS, kMaxBindings> uav{};
+    std::array<D3D12_GPU_DESCRIPTOR_HANDLE, kMaxBindings> table{};
+    std::array<D3D12_GPU_DESCRIPTOR_HANDLE, kMaxBindings> samplerTable{};
 
     void ClearFast() {
-        cbv.clear();
-        constants.clear();
-        srv.clear();
-        uav.clear();
-        table.clear();
-        samplerTable.clear();
+        cbv.fill(0);
+        for (auto& v : constants) { v.clear(); }
+        srv.fill(0);
+        uav.fill(0);
+        table.fill({0});
+        samplerTable.fill({0});
     }
 };


### PR DESCRIPTION
## Summary
- Replace per-slot unordered_map containers in RenderContext with fixed-size arrays
- Update Material binding logic to index into arrays directly
- Ensure ClearFast resets arrays without reallocation

## Testing
- `g++ -fsyntax-only RenderContext.h` *(fails: fatal error: d3d12.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b992c2be308329937e39267f291fbc