### PR TITLE
Use robin_hood::unordered_map for cache structures

### DIFF
--- a/ActionMap.h
+++ b/ActionMap.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <string>
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <vector>
 #include <cstdint>
 
@@ -49,7 +49,7 @@ private:
     static int  MouseButtonFromString(const std::string& s);
 
 private:
-    std::unordered_map<std::string, Action> actions_;
+    robin_hood::unordered_map<std::string, Action> actions_;
     float moveSpeed_ = 3.0f;
     float sprintMultiplier_ = 2.5f;
 };

--- a/CBManager.h
+++ b/CBManager.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <cstdint>
 #include <cstring>   // memcpy
 #include <cassert>
@@ -95,7 +95,7 @@ public:
 
 private:
     std::vector<CBField> fields_;
-    std::unordered_map<std::string, size_t> nameToIndex_;
+    robin_hood::unordered_map<std::string, size_t> nameToIndex_;
     uint32_t size_ = 0;
 };
 
@@ -146,5 +146,5 @@ public:
     }
 
 private:
-    std::unordered_map<std::string, ConstantBufferLayout> layouts_;
+    robin_hood::unordered_map<std::string, ConstantBufferLayout> layouts_;
 };

--- a/FontManager.h
+++ b/FontManager.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -33,6 +33,6 @@ public:
 
 private:
     Renderer* renderer_ = nullptr;
-    std::unordered_map<std::wstring, std::unique_ptr<FontAtlas>> fonts_;
+    robin_hood::unordered_map<std::wstring, std::unique_ptr<FontAtlas>> fonts_;
     std::wstring defaultName_;
 };

--- a/InputLayoutManager.h
+++ b/InputLayoutManager.h
@@ -2,7 +2,7 @@
 #include <d3d12.h>
 #include <string>
 #include <vector>
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <cstdint>
 
 class InputLayoutManager {
@@ -71,5 +71,5 @@ private:
         std::vector<std::string>   names; // чтобы .SemanticName жили вечно
         std::vector<D3D12_INPUT_ELEMENT_DESC> descs;
     };
-    std::unordered_map<std::string, Stored> map_;
+    robin_hood::unordered_map<std::string, Stored> map_;
 };

--- a/MaterialDataManager.h
+++ b/MaterialDataManager.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <string>
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <memory>
 #include <vector>
 #include <wrl/client.h>
@@ -44,6 +44,6 @@ public:
     void ClearAll();
 
 private:
-    std::unordered_map<std::string, MaterialPreset> presets_;
-    std::unordered_map<std::string, std::shared_ptr<MaterialData>> cache_;
+    robin_hood::unordered_map<std::string, MaterialPreset> presets_;
+    robin_hood::unordered_map<std::string, std::shared_ptr<MaterialData>> cache_;
 };

--- a/MeshManager.cpp
+++ b/MeshManager.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <cctype>
 #include <algorithm>
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <cstring> // strchr, atoi
 #include <DirectXMath.h>
 #include <queue>
@@ -60,7 +60,7 @@ std::shared_ptr<Mesh> MeshManager::LoadText(const std::string& path,
     std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive,
     const MeshLoadOptions& opt)
 {
-    std::unordered_map<std::string, std::shared_ptr<Mesh>>::iterator it = cache_.find(path);
+    robin_hood::unordered_map<std::string, std::shared_ptr<Mesh>>::iterator it = cache_.find(path);
     if (it != cache_.end()) {
         return it->second;
     }
@@ -84,7 +84,7 @@ std::shared_ptr<Mesh> MeshManager::LoadOBJ(const std::string& path,
     std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive,
     const MeshLoadOptions& opt)
 {
-    std::unordered_map<std::string, std::shared_ptr<Mesh>>::iterator it = cache_.find(path);
+    robin_hood::unordered_map<std::string, std::shared_ptr<Mesh>>::iterator it = cache_.find(path);
     if (it != cache_.end()) {
         return it->second;
     }
@@ -110,7 +110,7 @@ std::shared_ptr<Mesh> MeshManager::CreateFromMemory(const std::string& key,
     std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive,
     bool generateTangentSpace)
 {
-    std::unordered_map<std::string, std::shared_ptr<Mesh>>::iterator it = cache_.find(key);
+    robin_hood::unordered_map<std::string, std::shared_ptr<Mesh>>::iterator it = cache_.find(key);
     if (it != cache_.end()) {
         return it->second;
     }
@@ -124,7 +124,7 @@ std::shared_ptr<Mesh> MeshManager::CreateFromMemory(const std::string& key,
 }
 
 std::shared_ptr<Mesh> MeshManager::Get(const std::string& key) const {
-    std::unordered_map<std::string, std::shared_ptr<Mesh>>::const_iterator it = cache_.find(key);
+    robin_hood::unordered_map<std::string, std::shared_ptr<Mesh>>::const_iterator it = cache_.find(key);
     if (it != cache_.end()) {
         return it->second;
     }
@@ -257,7 +257,7 @@ bool MeshManager::ParseOBJFile(const std::string& path,
     std::vector<DirectX::XMFLOAT2> uv;
     std::vector<DirectX::XMFLOAT3> nrm;
 
-    std::unordered_map<OBJKey, uint32_t, OBJKeyHash> vmap;
+    robin_hood::unordered_map<OBJKey, uint32_t, OBJKeyHash> vmap;
     outVerts.clear();
     outIndices.clear();
 
@@ -327,7 +327,7 @@ bool MeshManager::ParseOBJFile(const std::string& path,
             // выдаёт ID для (v/vt/vn), создавая уникальную вершину
             std::vector<uint32_t> id(face.size());
             for (size_t i = 0; i < face.size(); ++i) {
-                std::unordered_map<OBJKey, uint32_t, OBJKeyHash>::iterator it = vmap.find(face[i]);
+                robin_hood::unordered_map<OBJKey, uint32_t, OBJKeyHash>::iterator it = vmap.find(face[i]);
                 if (it != vmap.end()) {
                     id[i] = it->second;
                 }

--- a/MeshManager.h
+++ b/MeshManager.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <memory>
 #include <string>
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <vector>
 #include <wrl.h>
 #include "Mesh.h"
@@ -61,5 +61,5 @@ private:
                       const MeshLoadOptions& opt);
 
 private:
-    std::unordered_map<std::string, std::shared_ptr<Mesh>> cache_;
+    robin_hood::unordered_map<std::string, std::shared_ptr<Mesh>> cache_;
 };

--- a/Renderer.h
+++ b/Renderer.h
@@ -5,7 +5,6 @@
 
 #include "DescriptorAllocator.h"
 #include "FrameResource.h"
-#include <unordered_map>
 #include "third_party/robin_hood.h"
 #include "Samplermanager.h"
 #include "CBManager.h"
@@ -273,7 +272,7 @@ private:
     UINT                              currentFrameIndex_ = 0;                   // 0..kFrameCount-1
 
     std::mutex knownStatesMtx_;
-    std::unordered_map<ID3D12Resource*, D3D12_RESOURCE_STATES> knownStates_;
+    robin_hood::unordered_map<ID3D12Resource*, D3D12_RESOURCE_STATES> knownStates_;
     struct CLState {
         // первый требуемый стейт ресурса в данном CL (мы его не барьерим внутри CL)
         robin_hood::unordered_flat_map<ID3D12Resource*, D3D12_RESOURCE_STATES> firstUse;

--- a/SamplerManager.h
+++ b/SamplerManager.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <wrl.h>
 #include <d3d12.h>
-#include <unordered_map>
+#include "third_party/robin_hood.h"
 #include <vector>
 #include <initializer_list>
 #include <cstdint>
@@ -71,7 +71,7 @@ private:
 
     ID3D12Device* device_ = nullptr;
 
-    std::unordered_map<SamplerKey, Entry, SamplerKeyHasher> cache_;
+    robin_hood::unordered_map<SamplerKey, Entry, SamplerKeyHasher> cache_;
 
     UINT ensureCpu_(const D3D12_SAMPLER_DESC& desc);
     D3D12_CPU_DESCRIPTOR_HANDLE cpuHandleAt_(UINT idx) const;

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -108,7 +108,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)third_party\mimalloc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)third_party;$(ProjectDir)third_party\mimalloc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -132,7 +132,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>$(ProjectDir)third_party\mimalloc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)third_party;$(ProjectDir)third_party\mimalloc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
## Summary
- replace std::unordered_map caches with robin_hood::unordered_map across managers and action map
- switch OBJ loader's vertex map to robin_hood
- expose third_party directory to project include path

## Testing
- `g++ -std=c++20 -I. -c MaterialDataManager.cpp` *(fails: wrl/client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9974d53f083299938804417216390