### PR TITLE
Add compile-time constant buffer field IDs

### DIFF
--- a/CBFieldID.h
+++ b/CBFieldID.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+#include <string_view>
+
+using CBFieldID = uint32_t;
+
+// FNV-1a 32-bit hash for compile-time constant generation of CB field identifiers
+constexpr CBFieldID ComputeCBFieldID(std::string_view s)
+{
+    CBFieldID hash = 2166136261u; // FNV offset basis
+    for (char c : s) {
+        hash ^= static_cast<uint8_t>(c);
+        hash *= 16777619u; // FNV prime
+    }
+    return hash;
+}
+
+// Helper macro for computing a field ID from a string literal at compile time
+#define CB_FIELD_ID(str) ::ComputeCBFieldID(std::string_view(str))
+

--- a/Material.cpp
+++ b/Material.cpp
@@ -900,6 +900,20 @@ bool Material::GetCBFieldInfo(UINT bRegister, const std::string& name, CBufferFi
     return true;
 }
 
+bool Material::GetCBFieldInfo(UINT bRegister, CBFieldID id, CBufferField& out) const
+{
+    const CBufferInfo* cb = GetCBInfo(bRegister);
+    if (!cb) { return false; }
+    auto it = cb->fieldsById.find(id);
+    if (it == cb->fieldsById.end()) { return false; }
+    out = it->second;
+    if (out.elementStride == 0) {
+        out.elementStride = (out.size > 0 ? out.size : 16);
+        out.elementCount = 1;
+    }
+    return true;
+}
+
 bool Material::GetCBFieldOffset(UINT bRegister, const std::string& name, UINT& outOffset, UINT& outSize) const {
     auto* cb = GetCBInfo(bRegister);
     if (!cb)
@@ -972,8 +986,10 @@ void Material::ProcessReflection(ID3D12ShaderReflection* refl,
             }
             f.elementCount = elements;
             f.elementStride = stride;
+            f.id = ComputeCBFieldID(f.name);
 
             dst.fieldsByName[f.name] = f;
+            dst.fieldsById[f.id] = f;
         }
     }
 }

--- a/Material.h
+++ b/Material.h
@@ -13,6 +13,8 @@
 #include "RenderContext.h"
 #include "robin_hood.h"
 #include <cassert>
+#include <algorithm>
+#include "CBFieldID.h"
 
 using namespace Microsoft::WRL;
 
@@ -120,18 +122,21 @@ public:
     struct CBufferField {
         std::string name;
         UINT        offset = 0;         // байтовый сдвиг поля в cbuffer
-        UINT        size = 0;         // общий размер поля (если массив — размер всего массива)
+        UINT        size = 0;           // общий размер поля (если массив — размер всего массива)
         UINT        elementStride = 0;  // шаг одного элемента массива в байтах (или size, если не массив)
-        UINT        elementCount = 1;  // ёмкость массива (1 — если не массив)
+        UINT        elementCount = 1;   // ёмкость массива (1 — если не массив)
+        CBFieldID   id = 0;             // хеш-идентификатор имени
     };
     struct CBufferInfo {
         UINT bindRegister = 0;    // bN
         UINT sizeBytes = 0;
         robin_hood::unordered_flat_map<std::string, CBufferField> fieldsByName; // name -> {offset,size}
+        robin_hood::unordered_flat_map<CBFieldID, CBufferField>   fieldsById;   // id -> {offset,size}
     };
 
     const CBufferInfo* GetCBInfo(UINT bRegister) const;
     bool GetCBFieldInfo(UINT bRegister, const std::string& name, CBufferField& out) const;
+    bool GetCBFieldInfo(UINT bRegister, CBFieldID id, CBufferField& out) const;
     bool GetCBFieldOffset(UINT bRegister, const std::string& name, UINT& outOffset, UINT& outSize) const;
     UINT GetCBSizeBytes(UINT bRegister) const {const CBufferInfo* cb = GetCBInfo(bRegister); return cb ? cb->sizeBytes : 0u; }
     UINT GetCBSizeBytesAligned(UINT bRegister, UINT alignment) const {
@@ -171,11 +176,50 @@ public:
     }
 
     template<typename T>
+    bool UpdateCBField(UINT bRegister, CBFieldID id,
+        const T& value, uint8_t* destCB,
+        std::optional<UINT> arrayIdxParam = std::nullopt)
+    {
+        UINT destCBSizeBytes = GetCBSizeBytes(bRegister);
+        if (!destCB || destCBSizeBytes == 0) { return false; }
+
+        CBufferField info{};
+        if (!GetCBFieldInfo(bRegister, id, info)) {
+            assert(false && "Bad uniform id!");
+            return false;
+        }
+
+        const UINT stride = (info.elementStride ? info.elementStride : info.size);
+        const UINT count = (info.elementCount ? info.elementCount : 1);
+
+        UINT idx = 0;
+        if (arrayIdxParam) { idx = *arrayIdxParam; }
+        if (idx >= count) { return false; }
+
+        const size_t dstOff = size_t(info.offset) + size_t(idx) * size_t(stride);
+        if (dstOff >= destCBSizeBytes) { return false; }
+        if (dstOff + stride > destCBSizeBytes) { return false; }
+
+        uint8_t* dst = destCB + dstOff;
+        const size_t copyBytes = std::min<size_t>(sizeof(T), stride);
+        std::memcpy(dst, &value, copyBytes);
+        return true;
+    }
+
+    template<typename T>
     bool UpdateCB0Field(const std::string& name,
         const T& value, uint8_t* destCB,
         std::optional<UINT> arrayIdxParam = std::nullopt)
     {
         return UpdateCBField(0, name, value, destCB, arrayIdxParam);
+    }
+
+    template<typename T>
+    bool UpdateCB0Field(CBFieldID id,
+        const T& value, uint8_t* destCB,
+        std::optional<UINT> arrayIdxParam = std::nullopt)
+    {
+        return UpdateCBField(0, id, value, destCB, arrayIdxParam);
     }
 
 private:

--- a/PointLight.cpp
+++ b/PointLight.cpp
@@ -4,6 +4,20 @@
 
 using namespace Math;
 
+namespace {
+    constexpr CBFieldID ID_world        = CB_FIELD_ID("world");
+    constexpr CBFieldID ID_view         = CB_FIELD_ID("view");
+    constexpr CBFieldID ID_proj         = CB_FIELD_ID("proj");
+    constexpr CBFieldID ID_invView      = CB_FIELD_ID("invView");
+    constexpr CBFieldID ID_invProj      = CB_FIELD_ID("invProj");
+    constexpr CBFieldID ID_camPosWS     = CB_FIELD_ID("camPosWS");
+    constexpr CBFieldID ID_screenSize   = CB_FIELD_ID("screenSize");
+    constexpr CBFieldID ID_lightPosWS   = CB_FIELD_ID("lightPosWS");
+    constexpr CBFieldID ID_lightRadius  = CB_FIELD_ID("lightRadius");
+    constexpr CBFieldID ID_lightColor   = CB_FIELD_ID("lightColor");
+    constexpr CBFieldID ID_lightIntensity = CB_FIELD_ID("lightIntensity");
+}
+
 static D3D12_DEPTH_STENCIL_DESC MakeZFail_DS()
 {
     D3D12_DEPTH_STENCIL_DESC ds{};
@@ -100,9 +114,9 @@ void PointLight::RenderZFail(Renderer* r, ID3D12GraphicsCommandList* cl,
 
     // CB b0: world/view/proj
     auto cb = r->GetFrameResource()->AllocDynamic(matZFail_->GetCBSizeBytesAligned(0, 256), 256);
-    matZFail_->UpdateCB0Field("world", BuildModel(), (uint8_t*)cb.cpu);
-    matZFail_->UpdateCB0Field("view",  view,         (uint8_t*)cb.cpu);
-    matZFail_->UpdateCB0Field("proj",  proj,         (uint8_t*)cb.cpu);
+    matZFail_->UpdateCBField(0, ID_world, BuildModel(), (uint8_t*)cb.cpu);
+    matZFail_->UpdateCBField(0, ID_view,  view,         (uint8_t*)cb.cpu);
+    matZFail_->UpdateCBField(0, ID_proj,  proj,         (uint8_t*)cb.cpu);
 
     // Сброс ref → 0 (мы будем тестировать !=0 в цвете)
     cl->OMSetStencilRef(0);
@@ -122,19 +136,19 @@ void PointLight::RenderColor(Renderer* r, ID3D12GraphicsCommandList* cl,
 {
     // CB b0: per-frame
     auto cb0 = r->GetFrameResource()->AllocDynamic(matColorFS_->GetCBSizeBytesAligned(0, 256), 256);
-    matColorFS_->UpdateCB0Field("view",     view,     (uint8_t*)cb0.cpu);
-    matColorFS_->UpdateCB0Field("proj",     proj,     (uint8_t*)cb0.cpu);
-    matColorFS_->UpdateCB0Field("invView",  invView,  (uint8_t*)cb0.cpu);
-    matColorFS_->UpdateCB0Field("invProj",  invProj,  (uint8_t*)cb0.cpu);
-    matColorFS_->UpdateCB0Field("camPosWS", camPos,   (uint8_t*)cb0.cpu);
-    matColorFS_->UpdateCB0Field("screenSize", float2((float)r->GetWidth(), (float)r->GetHeight()), (uint8_t*)cb0.cpu);
+    matColorFS_->UpdateCBField(0, ID_view,     view,     (uint8_t*)cb0.cpu);
+    matColorFS_->UpdateCBField(0, ID_proj,     proj,     (uint8_t*)cb0.cpu);
+    matColorFS_->UpdateCBField(0, ID_invView,  invView,  (uint8_t*)cb0.cpu);
+    matColorFS_->UpdateCBField(0, ID_invProj,  invProj,  (uint8_t*)cb0.cpu);
+    matColorFS_->UpdateCBField(0, ID_camPosWS, camPos,   (uint8_t*)cb0.cpu);
+    matColorFS_->UpdateCBField(0, ID_screenSize, float2((float)r->GetWidth(), (float)r->GetHeight()), (uint8_t*)cb0.cpu);
 
     // CB b1: per-light
     auto cb1 = r->GetFrameResource()->AllocDynamic(matColorFS_->GetCBSizeBytesAligned(1, 256), 256);
-    matColorFS_->UpdateCBField(1, "lightPosWS",   desc_.position,  (uint8_t*)cb1.cpu);
-    matColorFS_->UpdateCBField(1, "lightRadius",  desc_.radius,    (uint8_t*)cb1.cpu);
-    matColorFS_->UpdateCBField(1, "lightColor",   desc_.color,     (uint8_t*)cb1.cpu);
-    matColorFS_->UpdateCBField(1, "lightIntensity", desc_.intensity, (uint8_t*)cb1.cpu);
+    matColorFS_->UpdateCBField(1, ID_lightPosWS,   desc_.position,  (uint8_t*)cb1.cpu);
+    matColorFS_->UpdateCBField(1, ID_lightRadius,  desc_.radius,    (uint8_t*)cb1.cpu);
+    matColorFS_->UpdateCBField(1, ID_lightColor,   desc_.color,     (uint8_t*)cb1.cpu);
+    matColorFS_->UpdateCBField(1, ID_lightIntensity, desc_.intensity, (uint8_t*)cb1.cpu);
 
     // таблица GBuffer SRV: t0..t3 = GB0,GB1,GB2,Depth
     auto tbl = r->StageGBufferSrvTable();


### PR DESCRIPTION
## Summary
- add `CB_FIELD_ID` macro and `CBFieldID` hash utilities
- cache constant buffer fields by hashed ID and expose id-based update API
- update point light rendering to use cached field IDs instead of strings

## Testing
- `g++ -std=c++17 -c Material.cpp` *(fails: d3d12.h: No such file or directory)*
- `cmake .` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a617eee88329a022195003b1d3f1