### PR TITLE
Batch UpdateCBField operations asynchronously

### DIFF
--- a/CBUpdateBatcher.h
+++ b/CBUpdateBatcher.h
@@ -1,0 +1,66 @@
+#pragma once
+#include <vector>
+#include <functional>
+#include <mutex>
+#include "TaskSystem.h"
+
+// Simple global batcher for UpdateCBField copy operations.
+// Collects small copy tasks and submits them to TaskSystem when
+// the batch reaches a predefined limit.
+class CBUpdateBatcher {
+public:
+    static CBUpdateBatcher& Get()
+    {
+        static CBUpdateBatcher instance;
+        return instance;
+    }
+
+    // Queue copy task. When enough tasks are collected, they are
+    // executed asynchronously on the TaskSystem.
+    void Enqueue(std::function<void()> fn)
+    {
+        std::vector<std::function<void()>> batch;
+        {
+            std::lock_guard<std::mutex> lock(mtx_);
+            tasks_.emplace_back(std::move(fn));
+            if (tasks_.size() >= kBatchSize)
+            {
+                batch.swap(tasks_);
+            }
+        }
+
+        if (!batch.empty())
+        {
+            TaskSystem::Get().Submit([batch = std::move(batch)]() mutable {
+                for (auto& t : batch) { t(); }
+            });
+        }
+    }
+
+    // Force execution of pending tasks.
+    void Flush()
+    {
+        std::vector<std::function<void()>> batch;
+        {
+            std::lock_guard<std::mutex> lock(mtx_);
+            batch.swap(tasks_);
+        }
+
+        if (!batch.empty())
+        {
+            TaskSystem::Get().Submit([batch = std::move(batch)]() mutable {
+                for (auto& t : batch) { t(); }
+            });
+        }
+    }
+
+private:
+    CBUpdateBatcher() = default;
+    CBUpdateBatcher(const CBUpdateBatcher&) = delete;
+    CBUpdateBatcher& operator=(const CBUpdateBatcher&) = delete;
+
+    static constexpr std::size_t kBatchSize = 32; // threshold
+    std::mutex mtx_;
+    std::vector<std::function<void()>> tasks_;
+};
+

--- a/Material.h
+++ b/Material.h
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <algorithm>
 #include "CBFieldID.h"
+#include "CBUpdateBatcher.h"
 
 using namespace Microsoft::WRL;
 
@@ -179,7 +180,11 @@ public:
             }
         }
 
-        return CopyData(info, value, destCB, destCBSizeBytes, arrayIdxParam ? *arrayIdxParam : 0);
+        UINT arrayIdx = arrayIdxParam ? *arrayIdxParam : 0;
+        CBUpdateBatcher::Get().Enqueue([=, this]() {
+            this->CopyData(info, value, destCB, destCBSizeBytes, arrayIdx);
+        });
+        return true;
     }
 
     template<typename T>
@@ -199,7 +204,11 @@ public:
             }
         }
 
-        return CopyData(info, value, destCB, destCBSizeBytes, arrayIdxParam ? *arrayIdxParam : 0);
+        UINT arrayIdx = arrayIdxParam ? *arrayIdxParam : 0;
+        CBUpdateBatcher::Get().Enqueue([=, this]() {
+            this->CopyData(info, value, destCB, destCBSizeBytes, arrayIdx);
+        });
+        return true;
     }
 
     template<typename T>
@@ -216,6 +225,12 @@ public:
         std::optional<UINT> arrayIdxParam = std::nullopt)
     {
         return UpdateCBField(0, id, value, destCB, arrayIdxParam);
+    }
+
+    // Process any pending UpdateCBField operations immediately.
+    static void FlushPendingCBUpdates()
+    {
+        CBUpdateBatcher::Get().Flush();
     }
 
 private:

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -12,6 +12,7 @@
 #include "RenderGraph.h"
 #include "StaticMesh.h"
 #include "TaskSystem.h"
+#include "Material.h"
 #include "TextManager.h"
 #include "Profiler.h"
 
@@ -343,7 +344,9 @@ void Scene::Render(Renderer* renderer) {
 
     rg.ExecuteParallel(renderer, TaskSystem::Get());
     //rg.Execute(renderer);
-    
+
+    Material::FlushPendingCBUpdates();
+
     {
         CPU_SCOPE("Main Wait");
         TaskSystem::Get().WaitForAll();


### PR DESCRIPTION
## Summary
- Add `CBUpdateBatcher` utility to collect constant-buffer updates and submit them to `TaskSystem` in batches
- Modify `Material::UpdateCBField` to enqueue updates and provide a flush helper
- Ensure `Scene` flushes pending constant-buffer updates before waiting for task completion

## Testing
- `x86_64-w64-mingw32-g++ -std=c++20 -I. -c Scene.cpp` *(fails: fatal error: DirectXMath.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fba14ba48329897b883c78f236f8