### PR TITLE
Refactor task system to use enkiTS dependencies

### DIFF
--- a/Material.cpp
+++ b/Material.cpp
@@ -854,7 +854,7 @@ bool MaterialManager::RequestFSProbeAsync()
         return false;
     }
 
-    TaskSystem::Get().Submit([this]() {
+    TaskSystem::Get().SubmitDetach([this]() {
         for (auto& kv : materials_) {
             auto& mat = kv.second;
             if (mat) {

--- a/Profiler.cpp
+++ b/Profiler.cpp
@@ -30,7 +30,8 @@ void Profiler::EndFrame() {
     if (!GetEnabled()) { return; }
 
     // 0) ждём прошлую асинхронную сборку (минимум работы в главном потоке)
-    TaskSystem::Get().WaitGroup(&overlayGroup_);
+    TaskSystem::Get().Wait(overlayTask_);
+    overlayTask_ = nullptr;
 
     // 1) заберём сэмплы текущего кадра и закроем кадр (быстро)
     std::vector<ScopeSample> samples;
@@ -43,7 +44,7 @@ void Profiler::EndFrame() {
     }
 
     // 2) асинхронно свернём статистику и обновим дабл-буфер оверлея
-    TaskSystem::Get().Submit([this, samples = std::move(samples)]() mutable {
+    overlayTask_ = TaskSystem::Get().Submit([this, samples = std::move(samples)]() mutable {
         const auto t0 = CoolClock::now();
 
         // A) свёртка сэмплов в stats_ (под мьютексом) + EMA/lastCount
@@ -150,7 +151,7 @@ void Profiler::EndFrame() {
 
         // F) флипним read-буфер
         overlayReadBuf_.store(writeIdx, std::memory_order_release);
-        }, &overlayGroup_);
+        });
 }
 
 void Profiler::PushSample(const char* name, uint64_t /*id*/, double ms) {

--- a/Profiler.h
+++ b/Profiler.h
@@ -178,7 +178,7 @@ private:
     // Ширина оверлей-региона (фикс) — сглаженная оценка, чтобы не мерить строки
     double overlayWidthPx_ = 640.0;
 
-    TaskGroup overlayGroup_;
+    TaskSystem::TaskHandle overlayTask_ = nullptr;
 #endif
 };
 

--- a/RenderGraph.h
+++ b/RenderGraph.h
@@ -14,7 +14,6 @@ public:
         Renderer* renderer = nullptr;
         size_t      batchIndex = (size_t)-1;
         std::string passName;
-        TaskGroup* group = nullptr;   // группа для внутренних тасок пасса (опц.)
     };
 
     using ExecFn = std::function<void(PassContext)>;
@@ -80,42 +79,32 @@ public:
 
         const size_t N = passes_.size();
 
-        // Группа «готовности пасса»: именно эти группы используются как зависимости
-        std::vector<std::unique_ptr<TaskGroup>> passDone(N);
-        for (size_t i = 0; i < N; ++i) {
-            passDone[i] = std::make_unique<TaskGroup>();
-        }
+        std::vector<TaskSystem::TaskHandle> passDone(N, nullptr);
 
         for (const auto& n : flat) {
             const size_t passIdx = n.pass;
             if (!passes_[passIdx].exec) { continue; }
 
-            // Обёртка-пасс: ждём mt-deps, исполняем тело, ждём внутренние саб-таски пасса
-            tasks.Submit([this, renderer, n, passIdx, &passDone]() {
-                // 1) дождаться всех указанных рантайм-зависимостей
-                for (size_t dep : passes_[passIdx].mtDeps) {
-                    if (dep < passDone.size()) {
-                        passDone[dep]->Wait();
-                    }
+            std::vector<TaskSystem::TaskHandle> deps;
+            for (size_t dep : passes_[passIdx].mtDeps) {
+                if (dep < passDone.size() && passDone[dep]) {
+                    deps.push_back(passDone[dep]);
                 }
+            }
 
-                // 2) собственная группа этого пасса (для внутренних Dispatch’ей)
+            auto handle = tasks.Submit([this, renderer, n, passIdx]() {
                 PassContext ctx;
                 ctx.renderer = renderer;
                 ctx.batchIndex = n.batch;
                 ctx.passName = passes_[passIdx].name;
-                ctx.group = passDone[passIdx].get();
-
-                // тело пасса (внутри можно вызывать Dispatch(..., ctx.group))
                 passes_[passIdx].exec(ctx);
+            }, deps);
 
-                }, passDone[passIdx].get()); // эта таска завершится — пасс «готов»
+            passDone[passIdx] = handle;
         }
 
         for (size_t i = 0; i < N; ++i) {
-            if (passDone[i]) {
-                passDone[i]->Wait();
-            }
+            tasks.Wait(passDone[i]);
         }
     }
 
@@ -165,7 +154,6 @@ private:
                     ctx.renderer = renderer;
                     ctx.batchIndex = batch;
                     ctx.passName = p.name;
-                    ctx.group = nullptr; // последовательный путь: группе тут делать нечего
                     p.exec(ctx);
                 }
                 else if (outFlat != nullptr) {

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -374,7 +374,7 @@ void Scene::RenderObjectBatch(Renderer* renderer,
     const size_t N = objects.size();
     const size_t chunkSize = 64;
 
-    tasks.Dispatch((N + chunkSize - 1) / chunkSize,
+    tasks.DispatchDetach((N + chunkSize - 1) / chunkSize,
         [renderer, view, proj, &objects, useBundles, chunkSize, batchIndex, bindGbufOrScene](std::size_t jobIndex)
         {
             const size_t begin = jobIndex * chunkSize;
@@ -424,7 +424,7 @@ void Scene::RenderShadowBatch(Renderer* renderer,
         chunkSize = 32;
     }
 
-    tasks.Dispatch((N + chunkSize - 1) / chunkSize,
+    tasks.DispatchDetach((N + chunkSize - 1) / chunkSize,
         [renderer, &objects, &lightView, &lightProj, cascadeIndex, chunkSize, batchIndex](std::size_t jobIndex)
         {
             const size_t begin = jobIndex * chunkSize;
@@ -477,7 +477,7 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
     cachedSplitsVS_[3] = 100.0f;
     cachedSplitsVS_[4] = zFarShadow;
 
-    TaskSystem::Get().Dispatch(kCascades, [this, renderer, &buckets, &invView, &invProj, &proj, camDir, sunDirWS = dirLight_.dir, batchIndex](std::size_t idx)
+    TaskSystem::Get().DispatchDetach(kCascades, [this, renderer, &buckets, &invView, &invProj, &proj, camDir, sunDirWS = dirLight_.dir, batchIndex](std::size_t idx)
     {
         CPU_SCOPE("CSM.PerCascade");
         const auto& D = renderer->GetDeferredForFrame();
@@ -559,7 +559,7 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
         {
             RenderShadowBatch(renderer, it->second, batchIndex, cachedLightView_[idx], cachedLightProj_[idx], (UINT)idx, /*chunk*/64);
         }
-    }, 1, ctx.group);
+    }, 1);
 }
 
 void Scene::Pass_GBuffer(Renderer* renderer, RenderGraph::PassContext ctx,

--- a/TaskSystem.cpp
+++ b/TaskSystem.cpp
@@ -24,8 +24,9 @@ void TaskSystem::Stop() {
 namespace {
 struct LambdaTaskSet : enki::ITaskSet {
     TaskSystem::Task fn;
-    LambdaTaskSet(TaskSystem::Task&& f)
-        : enki::ITaskSet(1), fn(std::move(f)) {}
+    std::vector<enki::Dependency> deps;
+    LambdaTaskSet(TaskSystem::Task&& f, size_t depCount)
+        : enki::ITaskSet(1), fn(std::move(f)), deps(depCount) {}
     void ExecuteRange(enki::TaskSetPartition, uint32_t) override {
         if (fn) {
             fn();
@@ -35,8 +36,9 @@ struct LambdaTaskSet : enki::ITaskSet {
 
 struct RangeTaskSet : enki::ITaskSet {
     std::function<void(std::size_t)> fn;
-    RangeTaskSet(std::size_t count, std::function<void(std::size_t)> f)
-        : enki::ITaskSet(static_cast<uint32_t>(count)), fn(std::move(f)) {}
+    std::vector<enki::Dependency> deps;
+    RangeTaskSet(std::size_t count, std::function<void(std::size_t)> f, size_t depCount)
+        : enki::ITaskSet(static_cast<uint32_t>(count)), fn(std::move(f)), deps(depCount) {}
     void ExecuteRange(enki::TaskSetPartition range, uint32_t) override {
         for (uint32_t i = range.start; i < range.end; ++i) {
             fn(i);
@@ -51,52 +53,77 @@ struct AutoDelete : enki::ICompletable {
     explicit AutoDelete(enki::ITaskSet* t) : task(t) {
         SetDependency(dep, task);
     }
-    void OnDependenciesComplete(enki::TaskScheduler*, uint32_t) override {
+    void OnDependenciesComplete(enki::TaskScheduler* pTS, uint32_t thread) override {
+        ICompletable::OnDependenciesComplete(pTS, thread);
         delete task;
         delete this;
     }
 };
 }
 
-void TaskSystem::Submit(const Task& t, TaskGroup* group) { Submit(Task(t), group); }
-
-void TaskSystem::Submit(Task&& t, TaskGroup* group) {
-    if (group) {
-        auto taskPtr = std::make_unique<LambdaTaskSet>(std::move(t));
-        scheduler_.AddTaskSetToPipe(taskPtr.get());
-        group->tasks.push_back(std::move(taskPtr));
-    } else {
-        auto* taskPtr = new LambdaTaskSet(std::move(t));
-        new AutoDelete(taskPtr);
-        scheduler_.AddTaskSetToPipe(taskPtr);
+TaskSystem::TaskHandle TaskSystem::Submit(Task t, std::initializer_list<TaskHandle> deps) {
+    if (!t) { return nullptr; }
+    auto* taskPtr = new LambdaTaskSet(std::move(t), deps.size());
+    size_t i = 0;
+    for (auto* d : deps) {
+        if (d) { taskPtr->SetDependency(taskPtr->deps[i], d); }
+        ++i;
     }
+    scheduler_.AddTaskSetToPipe(taskPtr);
+    return taskPtr;
 }
 
-void TaskSystem::Dispatch(std::size_t jobCount,
+void TaskSystem::SubmitDetach(Task t, std::initializer_list<TaskHandle> deps) {
+    if (!t) { return; }
+    auto* taskPtr = new LambdaTaskSet(std::move(t), deps.size());
+    size_t i = 0;
+    for (auto* d : deps) {
+        if (d) { taskPtr->SetDependency(taskPtr->deps[i], d); }
+        ++i;
+    }
+    new AutoDelete(taskPtr);
+    scheduler_.AddTaskSetToPipe(taskPtr);
+}
+
+TaskSystem::TaskHandle TaskSystem::Dispatch(std::size_t jobCount,
                           std::function<void(std::size_t)> fn,
                           std::size_t batchSize,
-                          TaskGroup* group) {
-    if (jobCount == 0 || !fn) { return; }
+                          std::initializer_list<TaskHandle> deps) {
+    if (jobCount == 0 || !fn) { return nullptr; }
     if (batchSize == 0) { batchSize = 1; }
-    if (group) {
-        auto taskPtr = std::make_unique<RangeTaskSet>(jobCount, std::move(fn));
-        taskPtr->m_MinRange = static_cast<uint32_t>(batchSize);
-        scheduler_.AddTaskSetToPipe(taskPtr.get());
-        group->tasks.push_back(std::move(taskPtr));
-    } else {
-        auto* taskPtr = new RangeTaskSet(jobCount, std::move(fn));
-        taskPtr->m_MinRange = static_cast<uint32_t>(batchSize);
-        new AutoDelete(taskPtr);
-        scheduler_.AddTaskSetToPipe(taskPtr);
+    auto* taskPtr = new RangeTaskSet(jobCount, std::move(fn), deps.size());
+    taskPtr->m_MinRange = static_cast<uint32_t>(batchSize);
+    size_t i = 0;
+    for (auto* d : deps) {
+        if (d) { taskPtr->SetDependency(taskPtr->deps[i], d); }
+        ++i;
     }
+    scheduler_.AddTaskSetToPipe(taskPtr);
+    return taskPtr;
 }
 
-void TaskSystem::WaitGroup(TaskGroup* group) {
-    if (!group) { return; }
-    for (auto& t : group->tasks) {
-        scheduler_.WaitforTask(t.get());
+void TaskSystem::DispatchDetach(std::size_t jobCount,
+                          std::function<void(std::size_t)> fn,
+                          std::size_t batchSize,
+                          std::initializer_list<TaskHandle> deps) {
+    if (jobCount == 0 || !fn) { return; }
+    if (batchSize == 0) { batchSize = 1; }
+    auto* taskPtr = new RangeTaskSet(jobCount, std::move(fn), deps.size());
+    taskPtr->m_MinRange = static_cast<uint32_t>(batchSize);
+    size_t i = 0;
+    for (auto* d : deps) {
+        if (d) { taskPtr->SetDependency(taskPtr->deps[i], d); }
+        ++i;
     }
-    group->tasks.clear();
+    new AutoDelete(taskPtr);
+    scheduler_.AddTaskSetToPipe(taskPtr);
+}
+
+void TaskSystem::Wait(TaskHandle handle) {
+    if (handle) {
+        scheduler_.WaitforTask(handle);
+        delete handle;
+    }
 }
 
 void TaskSystem::WaitForAll() {

--- a/TaskSystem.h
+++ b/TaskSystem.h
@@ -4,49 +4,48 @@
 #include <vector>
 #include <cstddef>
 #include <memory>
+#include <initializer_list>
 
 #include "third_party/enkiTS/src/TaskScheduler.h"
-
-class TaskSystem;
-
-struct TaskGroup {
-    std::vector<std::unique_ptr<enki::ITaskSet>> tasks;
-    void Wait();
-};
 
 class TaskSystem {
 public:
     using Task = std::function<void()>;
+    using TaskHandle = enki::ICompletable*;
 
     static TaskSystem& Get();
 
     void Start(unsigned threadCount = 0);
     void Stop();
 
-    void Submit(const Task& t, TaskGroup* group = nullptr);
-    void Submit(Task&& t, TaskGroup* group = nullptr);
+    // manual handle-returning versions
+    TaskHandle Submit(Task t, std::initializer_list<TaskHandle> deps = {});
+    TaskHandle Dispatch(std::size_t jobCount,
+                        std::function<void(std::size_t)> fn,
+                        std::size_t batchSize = 1,
+                        std::initializer_list<TaskHandle> deps = {});
 
-    void Dispatch(std::size_t jobCount,
-                  std::function<void(std::size_t)> fn,
-                  std::size_t batchSize = 1,
-                  TaskGroup* group = nullptr);
+    // fire-and-forget versions (auto delete)
+    void SubmitDetach(Task t, std::initializer_list<TaskHandle> deps = {});
+    void DispatchDetach(std::size_t jobCount,
+                        std::function<void(std::size_t)> fn,
+                        std::size_t batchSize = 1,
+                        std::initializer_list<TaskHandle> deps = {});
 
-    void WaitGroup(TaskGroup* group);
+    void Wait(TaskHandle handle);
 
     template<class F>
     static void ParallelFor(std::size_t jobCount, F&& fn, std::size_t batchSize)
     {
-        TaskGroup g;
-        Get().Dispatch(jobCount, std::forward<F>(fn), batchSize, &g);
-        Get().WaitGroup(&g);
+        auto h = Get().Dispatch(jobCount, std::forward<F>(fn), batchSize);
+        Get().Wait(h);
     }
 
     template<class F>
     static void ParallelForNoHelp(std::size_t jobCount, F&& fn, std::size_t batchSize)
     {
-        TaskGroup g;
-        Get().Dispatch(jobCount, std::forward<F>(fn), batchSize, &g);
-        Get().WaitGroup(&g);
+        auto h = Get().Dispatch(jobCount, std::forward<F>(fn), batchSize);
+        Get().Wait(h);
     }
 
     void WaitForAll();
@@ -62,7 +61,5 @@ private:
 
 private:
     enki::TaskScheduler scheduler_;
-}; 
-
-inline void TaskGroup::Wait() { TaskSystem::Get().WaitGroup(this); }
+};
 


### PR DESCRIPTION
## Summary
- split TaskSystem API between handle-returning and fire-and-forget helpers
- delete tasks via AutoDelete created before scheduling and calling base completion
- drop unintended waits in scene rendering and cascaded shadow setup
- use detached task submission for async material shader probing

## Testing
- `g++ -std=c++17 -c TaskSystem.cpp -Ithird_party/enkiTS/src -I.`
- `g++ -std=c++17 -c Scene.cpp -Ithird_party/enkiTS/src -I.` *(fails: fatal error: d3d12.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68bae8a209cc832999d5382f58cf8dce