### PR TITLE
Pre-stage task dependencies before submission

### DIFF
--- a/RenderGraph.h
+++ b/RenderGraph.h
@@ -81,6 +81,23 @@ public:
 
         std::vector<TaskSystem::TaskHandle> passDone(N, nullptr);
 
+        // create all tasks first
+        for (const auto& n : flat) {
+            const size_t passIdx = n.pass;
+            if (!passes_[passIdx].exec) { continue; }
+
+            auto handle = tasks.CreateTask([this, renderer, n, passIdx]() {
+                PassContext ctx;
+                ctx.renderer = renderer;
+                ctx.batchIndex = n.batch;
+                ctx.passName = passes_[passIdx].name;
+                passes_[passIdx].exec(ctx);
+            }, passes_[passIdx].mtDeps.size());
+
+            passDone[passIdx] = handle;
+        }
+
+        // set up dependencies between created tasks
         for (const auto& n : flat) {
             const size_t passIdx = n.pass;
             if (!passes_[passIdx].exec) { continue; }
@@ -92,15 +109,14 @@ public:
                 }
             }
 
-            auto handle = tasks.Submit([this, renderer, n, passIdx]() {
-                PassContext ctx;
-                ctx.renderer = renderer;
-                ctx.batchIndex = n.batch;
-                ctx.passName = passes_[passIdx].name;
-                passes_[passIdx].exec(ctx);
-            }, deps);
+            tasks.SetDependencies(passDone[passIdx], deps);
+        }
 
-            passDone[passIdx] = handle;
+        // finally submit tasks for execution
+        for (const auto& n : flat) {
+            const size_t passIdx = n.pass;
+            if (!passes_[passIdx].exec) { continue; }
+            tasks.Submit(passDone[passIdx]);
         }
 
         for (size_t i = 0; i < N; ++i) {

--- a/TaskSystem.cpp
+++ b/TaskSystem.cpp
@@ -22,11 +22,16 @@ void TaskSystem::Stop() {
 }
 
 namespace {
-struct LambdaTaskSet : enki::ITaskSet {
-    TaskSystem::Task fn;
+struct TaskWithDeps : enki::ITaskSet {
     std::vector<enki::Dependency> deps;
+    TaskWithDeps(uint32_t range, size_t depCount)
+        : enki::ITaskSet(range), deps(depCount) {}
+};
+
+struct LambdaTaskSet : TaskWithDeps {
+    TaskSystem::Task fn;
     LambdaTaskSet(TaskSystem::Task&& f, size_t depCount)
-        : enki::ITaskSet(1), fn(std::move(f)), deps(depCount) {}
+        : TaskWithDeps(1, depCount), fn(std::move(f)) {}
     void ExecuteRange(enki::TaskSetPartition, uint32_t) override {
         if (fn) {
             fn();
@@ -34,11 +39,10 @@ struct LambdaTaskSet : enki::ITaskSet {
     }
 };
 
-struct RangeTaskSet : enki::ITaskSet {
+struct RangeTaskSet : TaskWithDeps {
     std::function<void(std::size_t)> fn;
-    std::vector<enki::Dependency> deps;
     RangeTaskSet(std::size_t count, std::function<void(std::size_t)> f, size_t depCount)
-        : enki::ITaskSet(static_cast<uint32_t>(count)), fn(std::move(f)), deps(depCount) {}
+        : TaskWithDeps(static_cast<uint32_t>(count), depCount), fn(std::move(f)) {}
     void ExecuteRange(enki::TaskSetPartition range, uint32_t) override {
         for (uint32_t i = range.start; i < range.end; ++i) {
             fn(i);
@@ -61,60 +65,69 @@ struct AutoDelete : enki::ICompletable {
 };
 }
 
-TaskSystem::TaskHandle TaskSystem::Submit(Task t, const std::vector<TaskHandle>& deps) {
+TaskSystem::TaskHandle TaskSystem::Submit(Task t) {
     if (!t) { return nullptr; }
-    auto* taskPtr = new LambdaTaskSet(std::move(t), deps.size());
-    size_t i = 0;
-    for (auto* d : deps) {
-        if (d) { taskPtr->SetDependency(taskPtr->deps[i], d); }
-        ++i;
-    }
+    auto* taskPtr = new LambdaTaskSet(std::move(t), 0);
     scheduler_.AddTaskSetToPipe(taskPtr);
     return taskPtr;
 }
 
-void TaskSystem::SubmitDetach(Task t, const std::vector<TaskHandle>& deps) {
-    if (!t) { return; }
-    auto* taskPtr = new LambdaTaskSet(std::move(t), deps.size());
+TaskSystem::TaskHandle TaskSystem::CreateTask(Task t, std::size_t depCount) {
+    if (!t) { return nullptr; }
+    auto* taskPtr = new LambdaTaskSet(std::move(t), depCount);
+    return taskPtr;
+}
+
+TaskSystem::TaskHandle TaskSystem::CreateRangeTask(std::size_t jobCount,
+                         std::function<void(std::size_t)> fn,
+                         std::size_t batchSize,
+                         std::size_t depCount) {
+    if (jobCount == 0 || !fn) { return nullptr; }
+    if (batchSize == 0) { batchSize = 1; }
+    auto* taskPtr = new RangeTaskSet(jobCount, std::move(fn), depCount);
+    taskPtr->m_MinRange = static_cast<uint32_t>(batchSize);
+    return taskPtr;
+}
+
+void TaskSystem::SetDependencies(TaskHandle handle, const std::vector<TaskHandle>& deps) {
+    if (!handle) { return; }
+    auto* taskPtr = static_cast<TaskWithDeps*>(handle);
+    if (taskPtr->deps.size() < deps.size()) {
+        taskPtr->deps.resize(deps.size());
+    }
     size_t i = 0;
     for (auto* d : deps) {
         if (d) { taskPtr->SetDependency(taskPtr->deps[i], d); }
         ++i;
     }
+}
+
+void TaskSystem::Submit(TaskHandle handle) {
+    if (handle) {
+        scheduler_.AddTaskSetToPipe(static_cast<enki::ITaskSet*>(handle));
+    }
+}
+
+void TaskSystem::SubmitDetach(Task t) {
+    if (!t) { return; }
+    auto* taskPtr = new LambdaTaskSet(std::move(t), 0);
     new AutoDelete(taskPtr);
     scheduler_.AddTaskSetToPipe(taskPtr);
 }
 
 TaskSystem::TaskHandle TaskSystem::Dispatch(std::size_t jobCount,
                           std::function<void(std::size_t)> fn,
-                          std::size_t batchSize,
-                          const std::vector<TaskHandle>& deps) {
-    if (jobCount == 0 || !fn) { return nullptr; }
-    if (batchSize == 0) { batchSize = 1; }
-    auto* taskPtr = new RangeTaskSet(jobCount, std::move(fn), deps.size());
-    taskPtr->m_MinRange = static_cast<uint32_t>(batchSize);
-    size_t i = 0;
-    for (auto* d : deps) {
-        if (d) { taskPtr->SetDependency(taskPtr->deps[i], d); }
-        ++i;
-    }
-    scheduler_.AddTaskSetToPipe(taskPtr);
-    return taskPtr;
+                          std::size_t batchSize) {
+    TaskHandle handle = CreateRangeTask(jobCount, std::move(fn), batchSize);
+    Submit(handle);
+    return handle;
 }
 
 void TaskSystem::DispatchDetach(std::size_t jobCount,
                           std::function<void(std::size_t)> fn,
-                          std::size_t batchSize,
-                          const std::vector<TaskHandle>& deps) {
-    if (jobCount == 0 || !fn) { return; }
-    if (batchSize == 0) { batchSize = 1; }
-    auto* taskPtr = new RangeTaskSet(jobCount, std::move(fn), deps.size());
-    taskPtr->m_MinRange = static_cast<uint32_t>(batchSize);
-    size_t i = 0;
-    for (auto* d : deps) {
-        if (d) { taskPtr->SetDependency(taskPtr->deps[i], d); }
-        ++i;
-    }
+                          std::size_t batchSize) {
+    auto* taskPtr = static_cast<enki::ITaskSet*>(CreateRangeTask(jobCount, std::move(fn), batchSize));
+    if (!taskPtr) { return; }
     new AutoDelete(taskPtr);
     scheduler_.AddTaskSetToPipe(taskPtr);
 }

--- a/TaskSystem.h
+++ b/TaskSystem.h
@@ -19,18 +19,24 @@ public:
     void Stop();
 
     // manual handle-returning versions
-    TaskHandle Submit(Task t, const std::vector<TaskHandle>& deps = {});
+    TaskHandle Submit(Task t);
+    // staged creation to allow setting dependencies before firing
+    TaskHandle CreateTask(Task t, std::size_t depCount = 0);
+    TaskHandle CreateRangeTask(std::size_t jobCount,
+                               std::function<void(std::size_t)> fn,
+                               std::size_t batchSize = 1,
+                               std::size_t depCount = 0);
+    void SetDependencies(TaskHandle handle, const std::vector<TaskHandle>& deps);
+    void Submit(TaskHandle handle);
     TaskHandle Dispatch(std::size_t jobCount,
                         std::function<void(std::size_t)> fn,
-                        std::size_t batchSize = 1,
-                        const std::vector<TaskHandle>& deps = {});
+                        std::size_t batchSize = 1);
 
     // fire-and-forget versions (auto delete)
-    void SubmitDetach(Task t, const std::vector<TaskHandle>& deps = {});
+    void SubmitDetach(Task t);
     void DispatchDetach(std::size_t jobCount,
                         std::function<void(std::size_t)> fn,
-                        std::size_t batchSize = 1,
-                        const std::vector<TaskHandle>& deps = {});
+                        std::size_t batchSize = 1);
 
     void Wait(TaskHandle handle);
 


### PR DESCRIPTION
## Summary
- Remove dependency parameters from Submit/Dispatch in favor of explicit SetDependencies
- Introduce CreateRangeTask to build range tasks prior to submission
- Share dependency handling via TaskWithDeps

## Testing
- `g++ -std=c++17 -Ithird_party/enkiTS/src -c TaskSystem.cpp`
- `g++ -std=c++17 -Ithird_party/enkiTS/src -c Material.cpp` *(fails: d3d12.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0854652ec8329bb5bb61c4bd20d0f