### PR TITLE
Add GPU timestamp query profiling

### DIFF
--- a/App.cpp
+++ b/App.cpp
@@ -81,6 +81,9 @@ void App::InitWindow(HINSTANCE hInstance, int nCmdShow) {
     ShowWindow(hWnd, nCmdShow);
     renderer_.InitD3D12(hWnd);
     input_.Initialize(hWnd);
+#if PROF_GPU_ENABLED
+    Profiler::Get().InitGpu(renderer_.GetDevice(), renderer_.GetCommandQueue());
+#endif
 }
 
 void App::InitScene()
@@ -123,8 +126,12 @@ void App::Run(HINSTANCE hInstance, int nCmdShow) {
     MSG msg = {};
     double lastTime = GetTimeSeconds();
     while (isRunning_) {
-        Profiler::Get().BeginFrame(renderer_.GetTotalFrameNumber() + 1); //will be increased in Renderer::BeginFrame
-        
+        Profiler::Get().BeginFrame(renderer_.GetTotalFrameNumber());
+        renderer_.BeginFrame();
+#if PROF_GPU_ENABLED
+        Profiler::Get().CollectGpuResults();
+#endif
+
         {
             CPU_SCOPE("Whole Cycle");
             input_.NewFrame();

--- a/Profiler.cpp
+++ b/Profiler.cpp
@@ -11,10 +11,25 @@ Profiler& Profiler::Get() {
     return g;
 }
 
+#if PROF_GPU_ENABLED
+Profiler::ScopedGpu::ScopedGpu(ID3D12GraphicsCommandList* cl, const char* name, uint64_t id)
+    : cl_(cl)
+{
+    idx_ = Profiler::Get().BeginGpuSample(cl, name, id);
+}
+
+Profiler::ScopedGpu::~ScopedGpu() {
+    Profiler::Get().EndGpuSample(cl_, idx_);
+}
+#endif
+
 void Profiler::BeginFrame(uint64_t frameNo) {
     if (!GetEnabled()) { return; }
     std::lock_guard<std::mutex> lk(mtx_);
     frameSamples_.clear();
+#if PROF_GPU_ENABLED
+    gpuFrameSamples_.clear();
+#endif
     frameNo_ = frameNo;
     frameOpen_ = true;
 
@@ -35,16 +50,34 @@ void Profiler::EndFrame() {
 
     // 1) заберём сэмплы текущего кадра и закроем кадр (быстро)
     std::vector<ScopeSample> samples;
+#if PROF_GPU_ENABLED
+    std::vector<ScopeSample> gpuSamples;
+#endif
     {
         std::lock_guard<std::mutex> lk(mtx_);
         if (!frameOpen_) { return; }
         samples = std::move(frameSamples_);
         frameSamples_.clear();
+#if PROF_GPU_ENABLED
+        gpuSamples = std::move(gpuFrameSamples_);
+        gpuFrameSamples_.clear();
+#endif
         frameOpen_ = false;
     }
 
-    // 2) асинхронно свернём статистику и обновим дабл-буфер оверлея
+#if PROF_GPU_ENABLED
+    // 2) prepare gpu samples for next frame
+    gpuResolved_ = std::move(gpuPending_);
+    gpuPending_.clear();
+    lastGpuQueryCount_ = nextGpuQuery_;
+    nextGpuQuery_ = 0;
+#endif
+
+#if PROF_GPU_ENABLED
+    overlayTask_ = TaskSystem::Get().Submit([this, samples = std::move(samples), gpuSamples = std::move(gpuSamples)]() mutable {
+#else
     overlayTask_ = TaskSystem::Get().Submit([this, samples = std::move(samples)]() mutable {
+#endif
         const auto t0 = CoolClock::now();
 
         // A) свёртка сэмплов в stats_ (под мьютексом) + EMA/lastCount
@@ -57,6 +90,16 @@ void Profiler::EndFrame() {
         }
         samples.clear();
 
+#if PROF_GPU_ENABLED
+        for (const auto& s : gpuSamples) {
+            auto& st = gpuStats_[s.name ? s.name : "unknown"];
+            st.Accumulate(s.ms);
+        }
+        for (auto& kv : gpuStats_) {
+            kv.second.CommitFrame(emaAlpha_);
+        }
+        gpuSamples.clear();
+#endif
         // B) формируем текущий набор строк (без лока)
         robin_hood::unordered_flat_map<std::wstring, OverlayRow> current;
         current.reserve(stats_.size() * 2u);
@@ -75,6 +118,25 @@ void Profiler::EndFrame() {
             current.emplace(row.name, std::move(row));
         }
 
+#if PROF_GPU_ENABLED
+        robin_hood::unordered_flat_map<std::wstring, OverlayRow> gpuCurrent;
+        gpuCurrent.reserve(gpuStats_.size());
+        for (const auto& kv : gpuStats_) {
+            OverlayRow row;
+            row.name.assign(kv.first.begin(), kv.first.end());
+            row.avgMs = kv.second.avgMs;
+            row.maxMs = kv.second.maxMs;
+            row.usages = kv.second.lastCount;
+            const double perUse = (row.usages ? (row.avgMs / (double)row.usages) : 0.0);
+            wchar_t buf[128];
+            std::swprintf(buf, sizeof(buf) / sizeof(wchar_t),
+                L"%-40s  avg:%6.2f  max:%6.2f  p/u:%6.3f  usages:%u",
+                row.name.c_str(), row.avgMs, row.maxMs, perUse, row.usages);
+            row.formatted = buf;
+            gpuCurrent.emplace(row.name, std::move(row));
+        }
+#endif
+
         // C) редкая сортировка или стабильное обновление порядка
         const auto now = CoolClock::now();
         const double secSinceSort = std::chrono::duration<double>(now - lastOverlaySort_).count();
@@ -87,6 +149,15 @@ void Profiler::EndFrame() {
         writeRows.clear();
         writeRows.reserve(current.size() + 1u); // +1 под строку EndFrame.Async
 
+#if PROF_GPU_ENABLED
+        const int gpuReadIdx = gpuOverlayReadBuf_.load(std::memory_order_acquire);
+        const int gpuWriteIdx = gpuReadIdx ^ 1;
+        auto& gpuReadRows = gpuOverlayRows_[gpuReadIdx];
+        auto& gpuWriteRows = gpuOverlayRows_[gpuWriteIdx];
+        gpuWriteRows.clear();
+        gpuWriteRows.reserve(gpuCurrent.size());
+#endif
+
         if (needResort) {
             std::vector<OverlayRow> tmp; tmp.reserve(current.size());
             for (auto& kv : current) {
@@ -96,8 +167,17 @@ void Profiler::EndFrame() {
                 if (a.avgMs == b.avgMs) { return a.name < b.name; }
                 return a.avgMs > b.avgMs;
             });
-
             writeRows = std::move(tmp);
+
+#if PROF_GPU_ENABLED
+            std::vector<OverlayRow> gtmp; gtmp.reserve(gpuCurrent.size());
+            for (auto& kv : gpuCurrent) { gtmp.push_back(std::move(kv.second)); }
+            std::sort(gtmp.begin(), gtmp.end(), [](const OverlayRow& a, const OverlayRow& b) {
+                if (a.avgMs == b.avgMs) { return a.name < b.name; }
+                return a.avgMs > b.avgMs;
+            });
+            gpuWriteRows = std::move(gtmp);
+#endif
             lastOverlaySort_ = now;
         }
         else {
@@ -115,6 +195,23 @@ void Profiler::EndFrame() {
                     writeRows.push_back(std::move(kv.second));
                 }
             }
+
+#if PROF_GPU_ENABLED
+            robin_hood::unordered_flat_set<std::wstring> gused; gused.reserve(gpuCurrent.size());
+            for (const OverlayRow& prev : gpuReadRows) {
+                const std::wstring& key = prev.name;
+                auto it = gpuCurrent.find(key);
+                if (it != gpuCurrent.end()) {
+                    gpuWriteRows.push_back(std::move(it->second));
+                    gused.insert(key);
+                }
+            }
+            for (auto& kv : gpuCurrent) {
+                if (gused.find(kv.first) == gused.end()) {
+                    gpuWriteRows.push_back(std::move(kv.second));
+                }
+            }
+#endif
         }
 
         // D) кулдаун сброса максимумов (под локаом для stats_)
@@ -149,9 +246,14 @@ void Profiler::EndFrame() {
             writeRows.insert(writeRows.begin(), std::move(self));
         }
 
-        // F) флипним read-буфер
+#if PROF_GPU_ENABLED
+        // F) флипним read-буферы
         overlayReadBuf_.store(writeIdx, std::memory_order_release);
-        });
+        gpuOverlayReadBuf_.store(gpuWriteIdx, std::memory_order_release);
+#else
+        overlayReadBuf_.store(writeIdx, std::memory_order_release);
+#endif
+    });
 }
 
 void Profiler::PushSample(const char* name, uint64_t /*id*/, double ms) {
@@ -160,14 +262,106 @@ void Profiler::PushSample(const char* name, uint64_t /*id*/, double ms) {
     if (!frameOpen_) { return; }
     frameSamples_.push_back({ name, 0u, ms });
 }
+#if PROF_GPU_ENABLED
+void Profiler::PushGpuSample(const char* name, uint64_t /*id*/, double ms) {
+    if (!GetEnabled()) { return; }
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (!frameOpen_) { return; }
+    gpuFrameSamples_.push_back({ name, 0u, ms });
+}
+
+void Profiler::InitGpu(ID3D12Device* device, ID3D12CommandQueue* queue, UINT maxQueries) {
+#if PROF_ENABLED
+    if (!device || !queue) { return; }
+    gpuQueue_ = queue;
+    maxGpuQueries_ = maxQueries;
+
+    D3D12_QUERY_HEAP_DESC qh{};
+    qh.Count = maxQueries;
+    qh.Type = D3D12_QUERY_HEAP_TYPE_TIMESTAMP;
+    qh.NodeMask = 0;
+    device->CreateQueryHeap(&qh, IID_PPV_ARGS(&gpuQueryHeap_));
+
+    UINT64 bufSize = (UINT64)maxQueries * sizeof(UINT64);
+    D3D12_HEAP_PROPERTIES hp{};
+    hp.Type = D3D12_HEAP_TYPE_READBACK;
+    D3D12_RESOURCE_DESC rd{};
+    rd.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+    rd.Width = bufSize;
+    rd.Height = 1;
+    rd.DepthOrArraySize = 1;
+    rd.MipLevels = 1;
+    rd.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+    rd.SampleDesc.Count = 1;
+    device->CreateCommittedResource(&hp, D3D12_HEAP_FLAG_NONE, &rd,
+        D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&gpuReadback_));
+
+    queue->GetTimestampFrequency(&gpuFreq_);
+    gpuInitialized_ = true;
+#else
+    (void)device; (void)queue; (void)maxQueries;
+#endif
+}
+
+void Profiler::CollectGpuResults() {
+#if PROF_ENABLED
+    if (!gpuInitialized_ || gpuResolved_.empty()) { return; }
+    UINT64* data = nullptr;
+    D3D12_RANGE range{ 0, (SIZE_T)lastGpuQueryCount_ * sizeof(UINT64) };
+    if (SUCCEEDED(gpuReadback_->Map(0, &range, reinterpret_cast<void**>(&data)))) {
+        for (const auto& s : gpuResolved_) {
+            if (s.end > s.start && s.end < lastGpuQueryCount_) {
+                UINT64 a = data[s.start];
+                UINT64 b = data[s.end];
+                double ms = (double)(b - a) * 1000.0 / (double)gpuFreq_;
+                PushGpuSample(s.name, 0, ms);
+            }
+        }
+        gpuReadback_->Unmap(0, nullptr);
+    }
+    gpuResolved_.clear();
+#endif
+}
+
+size_t Profiler::BeginGpuSample(ID3D12GraphicsCommandList* cl, const char* name, uint64_t id) {
+#if PROF_ENABLED
+    if (!gpuInitialized_ || !cl) { return SIZE_MAX; }
+    if (nextGpuQuery_ + 2 >= maxGpuQueries_) { return SIZE_MAX; }
+    UINT start = nextGpuQuery_++;
+    cl->EndQuery(gpuQueryHeap_.Get(), D3D12_QUERY_TYPE_TIMESTAMP, start);
+    gpuPending_.push_back({ name, start, UINT_MAX });
+    return gpuPending_.size() - 1;
+#else
+    (void)cl; (void)name; (void)id; return SIZE_MAX;
+#endif
+}
+
+void Profiler::EndGpuSample(ID3D12GraphicsCommandList* cl, size_t idx) {
+#if PROF_ENABLED
+    if (!gpuInitialized_ || !cl || idx == SIZE_MAX) { return; }
+    if (nextGpuQuery_ + 1 >= maxGpuQueries_) { return; }
+    UINT end = nextGpuQuery_++;
+    cl->EndQuery(gpuQueryHeap_.Get(), D3D12_QUERY_TYPE_TIMESTAMP, end);
+    cl->ResolveQueryData(gpuQueryHeap_.Get(), D3D12_QUERY_TYPE_TIMESTAMP,
+        gpuPending_[idx].start, 2, gpuReadback_.Get(), gpuPending_[idx].start * sizeof(UINT64));
+    gpuPending_[idx].end = end;
+#else
+    (void)cl; (void)idx;
+#endif
+}
+#endif // PROF_GPU_ENABLED
 
 void Profiler::EmitOverlay(TextManager* tm, int x, int y, int maxLines) {
     if (!tm || !GetEnabled()) { return; }
     CPU_SCOPE("Profiler::EmitOverlay");
 
-    // читаем актуальный read-буфер БЕЗ локов
+    // читаем актуальные read-буферы БЕЗ локов
     const int readIdx = overlayReadBuf_.load(std::memory_order_acquire);
     const auto& rows = overlayRows_[readIdx];
+#if PROF_GPU_ENABLED
+    const int gpuReadIdx = gpuOverlayReadBuf_.load(std::memory_order_acquire);
+    const auto& gpuRows = gpuOverlayRows_[gpuReadIdx];
+#endif
 
     // оценка ширины региона «в лоб», без измерения строк
     // Формат строки: "%-40s  avg:%6.2f  max:%6.2f  p/u:%6.2f  usages:%u"
@@ -178,8 +372,12 @@ void Profiler::EmitOverlay(TextManager* tm, int x, int y, int maxLines) {
     const double needW = charW * (double)lineCols;
     overlayWidthPx_ = overlayWidthPx_ * 0.9 + needW * 0.1;
     const double boxW = std::max(overlayWidthPx_, 480.0);
+#if PROF_GPU_ENABLED
+    gpuOverlayWidthPx_ = gpuOverlayWidthPx_ * 0.9 + needW * 0.1;
+    const double gpuBoxW = std::max(gpuOverlayWidthPx_, 480.0);
+#endif
 
-    // рисуем через TextManager::Region (фикс ширины, без измерений)
+    // CPU region
     auto reg = tm->CreateRegion(x, y, TextManager::Align::Left);
     tm->RegionSetPadding(reg, 8, 6);
     tm->RegionSetBackground(reg, float4(0.00f, 0.00f, 0.05f, 0.55f));
@@ -201,6 +399,28 @@ void Profiler::EmitOverlay(TextManager* tm, int x, int y, int maxLines) {
         tm->AddText(reg, 16.0f, (shown & 1) ? colOdd : colEven, r.formatted);
         shown++;
     }
+
+#if PROF_GPU_ENABLED
+    // GPU region to the right of CPU
+    const int gpuX = x + (int)boxW + 16;
+    auto regGpu = tm->CreateRegion(gpuX, y, TextManager::Align::Left);
+    tm->RegionSetPadding(regGpu, 8, 6);
+    tm->RegionSetBackground(regGpu, float4(0.00f, 0.05f, 0.00f, 0.55f));
+    tm->RegionSetFixedWidth(regGpu, (float)gpuBoxW);
+    tm->RegionSetAutoMeasure(regGpu, false);
+
+    tm->AddTextf(regGpu, 18.0f, float4(0.6f, 1, 0.6f, 0.95f),
+        L"[GPU profiler] frame=%llu  (max reset: %.1fs, sort every: %.2fs)",
+        (unsigned long long)frameNo_, GetMaxCooldownSeconds(), GetOverlayResortIntervalSeconds());
+    tm->AddText(regGpu, 18.0f, float4(0.6f, 1, 0.6f, 0.95f), L" ");
+
+    int gshown = 0;
+    for (const auto& r : gpuRows) {
+        if (gshown >= maxLines) { break; }
+        tm->AddText(regGpu, 16.0f, (gshown & 1) ? colOdd : colEven, r.formatted);
+        gshown++;
+    }
+#endif
 }
 
 void Profiler::SetMaxCooldownSeconds(double sec) {
@@ -223,6 +443,11 @@ void Profiler::ResetMax_Unsafe() {
     for (auto& kv : stats_) {
         kv.second.maxMs = kv.second.avgMs;
     }
+    #if PROF_GPU_ENABLED
+    for (auto& kv : gpuStats_) {
+        kv.second.maxMs = kv.second.avgMs;
+    }
+    #endif
 }
 
 #endif // PROF_ENABLED

--- a/Profiler.h
+++ b/Profiler.h
@@ -16,6 +16,15 @@
 #define PROF_ENABLED 1
 #endif
 
+#ifndef PROF_GPU_ENABLED
+#define PROF_GPU_ENABLED 0
+#endif
+
+#if PROF_GPU_ENABLED
+#include <d3d12.h>
+#include <wrl/client.h>
+#endif
+
 class TextManager; // forward
 
 // Профайлер CPU: скоупы, EMA-среднее, кулдаун сброса максимумов,
@@ -61,6 +70,12 @@ public:
     void BeginFrame(uint64_t frameNo);
     void EndFrame();
 
+#if PROF_GPU_ENABLED
+    // Инициализация и сбор результатов GPU
+    void InitGpu(ID3D12Device* device, ID3D12CommandQueue* queue, UINT maxQueries = 1024);
+    void CollectGpuResults();
+#endif
+
     // Скоповая отметка (CPU)
     class ScopedCpu {
     public:
@@ -91,6 +106,35 @@ public:
 #else
 #define CPU_SCOPE(nameLiteral)       do { } while (0)
 #define CPU_SCOPE_N(nameLiteral, id) do { } while (0)
+#endif
+
+#if PROF_GPU_ENABLED
+    // Скоповая отметка (GPU)
+    class ScopedGpu {
+    public:
+        ScopedGpu(ID3D12GraphicsCommandList* cl, const char* name, uint64_t nameId = 0);
+        ~ScopedGpu();
+    private:
+#if PROF_ENABLED
+        ID3D12GraphicsCommandList* cl_ = nullptr;
+        size_t idx_ = SIZE_MAX;
+#endif
+    };
+
+#if PROF_ENABLED
+#define GPU_SCOPE(cmdList, nameLiteral)       Profiler::ScopedGpu _prof_gpu_scope_##__LINE__(cmdList, nameLiteral, 0)
+#define GPU_SCOPE_N(cmdList, nameLiteral, id) Profiler::ScopedGpu _prof_gpu_scope_##__LINE__(cmdList, nameLiteral, (id))
+#else
+#define GPU_SCOPE(cmdList, nameLiteral)       do { } while (0)
+#define GPU_SCOPE_N(cmdList, nameLiteral, id) do { } while (0)
+#endif
+#else
+    class ScopedGpu {
+    public:
+        ScopedGpu(... ) {}
+    };
+#define GPU_SCOPE(cmdList, nameLiteral)       do { } while (0)
+#define GPU_SCOPE_N(cmdList, nameLiteral, id) do { } while (0)
 #endif
 
     // Оверлей с табличкой (читает дабл-буфер без локов)
@@ -128,6 +172,11 @@ public:
 private:
     Profiler() = default;
     void PushSample(const char* name, uint64_t id, double ms);
+#if PROF_GPU_ENABLED
+    void PushGpuSample(const char* name, uint64_t id, double ms);
+    size_t BeginGpuSample(ID3D12GraphicsCommandList* cl, const char* name, uint64_t id);
+    void EndGpuSample(ID3D12GraphicsCommandList* cl, size_t idx);
+#endif
 
 #if PROF_ENABLED
     void ResetMax_Unsafe(); // вызывать под mtx_
@@ -147,9 +196,15 @@ private:
     // сбор статистики
     std::mutex mtx_;
     robin_hood::unordered_map<std::string, ScopeStats> stats_;
+#if PROF_GPU_ENABLED
+    robin_hood::unordered_map<std::string, ScopeStats> gpuStats_;
+#endif
     robin_hood::unordered_flat_map<std::thread::id, std::string> threadNames_;
 
     std::vector<ScopeSample> frameSamples_;
+#if PROF_GPU_ENABLED
+    std::vector<ScopeSample> gpuFrameSamples_;
+#endif
     uint64_t  frameNo_ = 0;
     bool      frameOpen_ = false;
 
@@ -170,6 +225,10 @@ private:
     // Оверлей: дабл-буфер строк (EndFrame пишет, EmitOverlay читает)
     std::vector<OverlayRow> overlayRows_[2];
     std::atomic<int>        overlayReadBuf_{ 0 }; // 0 или 1
+#if PROF_GPU_ENABLED
+    std::vector<OverlayRow> gpuOverlayRows_[2];
+    std::atomic<int>        gpuOverlayReadBuf_{ 0 };
+#endif
 
     // Переcортировка по avgMs раз в N сек
     CoolClock::time_point lastOverlaySort_{};
@@ -177,8 +236,26 @@ private:
 
     // Ширина оверлей-региона (фикс) — сглаженная оценка, чтобы не мерить строки
     double overlayWidthPx_ = 640.0;
+#if PROF_GPU_ENABLED
+    double gpuOverlayWidthPx_ = 640.0;
+#endif
 
     TaskSystem::TaskHandle overlayTask_ = nullptr;
+
+#if PROF_GPU_ENABLED
+    // GPU timestamp queries
+    Microsoft::WRL::ComPtr<ID3D12QueryHeap> gpuQueryHeap_;
+    Microsoft::WRL::ComPtr<ID3D12Resource> gpuReadback_;
+    ID3D12CommandQueue* gpuQueue_ = nullptr;
+    UINT64 gpuFreq_ = 0;
+    UINT maxGpuQueries_ = 0;
+    UINT nextGpuQuery_ = 0;
+    UINT lastGpuQueryCount_ = 0;
+    struct GpuSampleRange { const char* name; UINT start; UINT end; };
+    std::vector<GpuSampleRange> gpuPending_;
+    std::vector<GpuSampleRange> gpuResolved_;
+    bool gpuInitialized_ = false;
+#endif
 #endif
 };
 

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -255,7 +255,6 @@ void Scene::Render(Renderer* renderer) {
     int y = 8;
     tb->AddTextf(8, 8, float4(1, 1, 1, 0.5f), 32.0f, L"FPS:%.0f MS:%0.2f", renderer->GetFPS(), 1000.0f / renderer->GetFPS());
 
-    renderer->BeginFrame();
     renderer->BeginSubmitTimeline();
 
     // матрицы кадра и параметры камеры/света (как у тебя)
@@ -389,6 +388,7 @@ void Scene::RenderObjectBatch(Renderer* renderer,
             }
             else {
                 auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
+                GPU_SCOPE(t.cl, "RenderObjectBatch");
                 if (bindGbufOrScene)
                 {
                     renderer->BindGBuffer(t.cl, Renderer::ClearMode::None); // без очистки!
@@ -433,6 +433,7 @@ void Scene::RenderShadowBatch(Renderer* renderer,
             // каждый чанк — отдельный direct CL
             auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
             t.cl->SetName(L"RenderShadowBatch");
+            GPU_SCOPE(t.cl, "RenderShadowBatch");
 
             // важное: привязываем нужный тайл атласа каскада, без очистки
             renderer->BindShadowTarget(t.cl, cascadeIndex, /*clear=*/false);
@@ -450,6 +451,7 @@ void Scene::Pass_PrologueClear(Renderer* r, RenderGraph::PassContext ctx)
 {
     auto t = r->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_PrologueClear");
     r->RecordBindAndClear(t.cl);
     r->EndThreadCommandList(t, ctx.batchIndex);
 }
@@ -461,6 +463,7 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
 {
     auto d = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     d.cl->SetName(L"CSM");
+    GPU_SCOPE(d.cl, "Pass_CSM");
     const auto& D = renderer->GetDeferredForFrame();
     renderer->Transition(d.cl, D.shadow.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE);
     renderer->BindShadowTarget(d.cl, 0, /*clear=*/true);
@@ -570,6 +573,7 @@ void Scene::Pass_GBuffer(Renderer* renderer, RenderGraph::PassContext ctx,
     RenderGraph rgGB(ctx.batchIndex);
     rgGB.AddPass("GBuffer.Driver", {}, [renderer](RenderGraph::PassContext sub) {
         auto driver = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
+        GPU_SCOPE(driver.cl, "GBuffer.Driver");
 
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(driver.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
@@ -609,6 +613,7 @@ void Scene::Pass_Lighting(Renderer* renderer, RenderGraph::PassContext ctx,
 {
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_Lighting");
     const auto& D = renderer->GetDeferredForFrame();
     renderer->Transition(t.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
     renderer->Transition(t.cl, D.gb1.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -677,6 +682,7 @@ void Scene::Pass_PointLights(Renderer* renderer, RenderGraph::PassContext ctx,
 
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_PointLights");
 
     const auto& D = renderer->GetDeferredForFrame();
 
@@ -712,6 +718,7 @@ void Scene::Pass_Skybox(Renderer* renderer, RenderGraph::PassContext ctx,
     if (!skyBox_) { return; }
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_Skybox");
 
     const auto& D = renderer->GetDeferredForFrame();
     renderer->Transition(t.cl, D.light.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
@@ -732,6 +739,7 @@ void Scene::Pass_SSR(Renderer* renderer, RenderGraph::PassContext ctx,
 {
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_SSR");
     const auto& D = renderer->GetDeferredForFrame();
 
     renderer->Transition(t.cl, D.depth.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -768,6 +776,7 @@ void Scene::Pass_SSR_Blur(Renderer* renderer, RenderGraph::PassContext ctx)
 {
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_SSR.Blur");
     const auto& D = renderer->GetDeferredForFrame();
     // X Pass---
     renderer->Transition(t.cl, D.ssr.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -820,6 +829,7 @@ void Scene::Pass_Compose(Renderer* renderer, RenderGraph::PassContext ctx,
 {
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_Compose");
     const auto& D = renderer->GetDeferredForFrame();
     renderer->Transition(t.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
     renderer->Transition(t.cl, D.gb1.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -872,6 +882,7 @@ void Scene::Pass_Transparent(Renderer* renderer, RenderGraph::PassContext ctx,
     // Driver: RTV=SceneColor, DSV=GBuffer. Без очистки. НЕ закрываем.
     rgTr.AddPass("Transparent.Driver", {}, [renderer](RenderGraph::PassContext sub) {
         auto driver = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
+        GPU_SCOPE(driver.cl, "Transparent.Driver");
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(driver.cl, D.scene.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
         renderer->Transition(driver.cl, D.depth.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE);
@@ -902,6 +913,7 @@ void Scene::Pass_Tonemap(Renderer* renderer, RenderGraph::PassContext ctx)
 {
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_Tonemap");
     const auto& D = renderer->GetDeferredForFrame();
     renderer->Transition(t.cl, D.scene.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
     renderer->RecordBindDefaultsNoClear(t.cl);
@@ -928,6 +940,7 @@ void Scene::Pass_Debug(Renderer* renderer, RenderGraph::PassContext ctx)
     const auto& D = renderer->GetDeferredForFrame();
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+    GPU_SCOPE(t.cl, "Pass_Debug");
     renderer->RecordBindDefaultsNoClear(t.cl);
 
     auto h = renderer->GetRenderContextPool()->Acquire();
@@ -948,6 +961,7 @@ void Scene::Pass_Overlay(Renderer* renderer, RenderGraph::PassContext ctx)
     if (auto* tm = renderer->GetTextManager()) {
         auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
+        GPU_SCOPE(t.cl, "Pass_Overlay");
         renderer->RecordBindDefaultsNoClear(t.cl);
         if (showProfiler_)
         {


### PR DESCRIPTION
## Summary
- add `PROF_GPU_ENABLED` define to toggle GPU profiling independently of CPU scopes
- guard GPU initialization, macros, and overlay code with the new define
- reorder frame loop so profiler begins before renderer and GPU results are collected afterward

## Testing
- `g++ -std=c++17 -I. -c Profiler.cpp` *(fails: TextManager.h: wrl/client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a130c5708329acd01b377fc81ac7