### PR TITLE
Add GPU frame timing to profiler

### DIFF
--- a/Profiler.cpp
+++ b/Profiler.cpp
@@ -29,6 +29,7 @@ void Profiler::BeginFrame(uint64_t frameNo) {
     frameSamples_.clear();
 #if PROF_GPU_ENABLED
     gpuFrameSamples_.clear();
+    gpuFrameSampleIdx_.store(SIZE_MAX, std::memory_order_relaxed);
 #endif
     frameNo_ = frameNo;
     frameOpen_ = true;
@@ -333,6 +334,31 @@ void Profiler::CollectGpuResults() {
         }
         gpuReadback_->Unmap(0, nullptr);
     }
+#endif
+}
+
+void Profiler::BeginGpuFrame(ID3D12GraphicsCommandList* cl) {
+#if PROF_ENABLED
+    if (!GetEnabled()) {
+        gpuFrameSampleIdx_.store(SIZE_MAX, std::memory_order_relaxed);
+        return;
+    }
+    const size_t idx = BeginGpuSample(cl, "GPU.Frame", 0);
+    gpuFrameSampleIdx_.store(idx, std::memory_order_relaxed);
+#else
+    (void)cl;
+#endif
+}
+
+void Profiler::EndGpuFrame(ID3D12GraphicsCommandList* cl) {
+#if PROF_ENABLED
+    const size_t idx = gpuFrameSampleIdx_.load(std::memory_order_relaxed);
+    if (idx != SIZE_MAX) {
+        EndGpuSample(cl, idx);
+    }
+    gpuFrameSampleIdx_.store(SIZE_MAX, std::memory_order_relaxed);
+#else
+    (void)cl;
 #endif
 }
 

--- a/Profiler.h
+++ b/Profiler.h
@@ -74,6 +74,8 @@ public:
     // Инициализация и сбор результатов GPU
     void InitGpu(ID3D12Device* device, ID3D12CommandQueue* queue, UINT maxQueries = 1024);
     void CollectGpuResults();
+    void BeginGpuFrame(ID3D12GraphicsCommandList* cl);
+    void EndGpuFrame(ID3D12GraphicsCommandList* cl);
 #endif
 
     // Скоповая отметка (CPU)
@@ -256,6 +258,7 @@ private:
     std::vector<GpuSampleRange> gpuPending_;
     std::vector<GpuSampleRange> gpuResolved_;
     bool gpuInitialized_ = false;
+    std::atomic<size_t> gpuFrameSampleIdx_{ SIZE_MAX };
 #endif
 #endif
 };
@@ -268,4 +271,8 @@ inline void Profiler::EmitOverlay(TextManager*, int, int, int) {}
 inline void Profiler::SetMaxCooldownSeconds(double) {}
 inline double Profiler::GetMaxCooldownSeconds() const { return 0.0; }
 inline void Profiler::ResetMaxNow() {}
+#if PROF_GPU_ENABLED
+inline void Profiler::BeginGpuFrame(ID3D12GraphicsCommandList*) {}
+inline void Profiler::EndGpuFrame(ID3D12GraphicsCommandList*) {}
+#endif
 #endif

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -545,7 +545,19 @@ void Renderer::ExecuteTimelineAndPresent() {
     }
 
     std::vector<ID3D12CommandList*> fixedLists;
-    fixedLists.reserve(lists.size() * 2);
+    fixedLists.reserve(lists.size() * 2 + 3);
+#if PROF_GPU_ENABLED
+    {
+        auto& fr = frameResources_[currentFrameIndex_];
+        ID3D12CommandAllocator* alloc =
+            fr->AcquireCommandAllocator(device_.Get(), D3D12_COMMAND_LIST_TYPE_DIRECT);
+        ID3D12GraphicsCommandList* cl =
+            fr->AcquireCommandList(device_.Get(), D3D12_COMMAND_LIST_TYPE_DIRECT, alloc);
+        Profiler::Get().BeginGpuFrame(cl);
+        ThrowIfFailed(cl->Close());
+        fixedLists.push_back(cl);
+    }
+#endif
 
     {
         // локальная копия глобальных стейтов на момент сабмита
@@ -629,6 +641,9 @@ void Renderer::ExecuteTimelineAndPresent() {
         b.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 
         cl->ResourceBarrier(1, &b);
+#if PROF_GPU_ENABLED
+        Profiler::Get().EndGpuFrame(cl);
+#endif
         ThrowIfFailed(cl->Close());
         epilogueCL = cl;
     }


### PR DESCRIPTION
## Summary
- add dedicated GPU frame timing support to the profiler
- record begin/end timestamp command lists around the frame submission timeline

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd53f5f8bc8329842e9aaa67834caa