### PR TITLE
Pool region lines to reduce glyph run allocations

### DIFF
--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -78,6 +78,7 @@ void TextManager::Begin(UINT vpW, UINT vpH, float dpiScale) {
 
     verts_.clear();   idx_.clear();
     rectVerts_.clear(); rectIdx_.clear();
+    RecycleRegionLines();
     regions_.clear();
 }
 
@@ -128,11 +129,10 @@ void TextManager::AddText(RegionId id, float px, const float4& color, std::wstri
     if (id >= regions_.size() || font_ == nullptr || text.empty()) { return; }
     Region& rg = regions_[id];
 
-    RegionLine ln;
+    const size_t charCount = text.size();
+    RegionLine ln = AcquireRegionLine(charCount);
     ln.color = color;
     ln.px = px;
-
-    const size_t charCount = text.size();
     BuildGlyphRun(text, ln.px, ln.run, ln.widthPx);
     const size_t glyphReserve = (ln.run.ready ? ln.run.glyphs.size() : charCount);
     ln.glyphCount = (uint32_t)std::min<size_t>(glyphReserve, std::numeric_limits<uint32_t>::max());
@@ -296,6 +296,54 @@ void TextManager::Clear() {
     matText_.reset(); matRect_.reset();
     verts_.clear(); idx_.clear();
     rectVerts_.clear(); rectIdx_.clear();
+    RecycleRegionLines();
+}
+
+TextManager::RegionLine TextManager::AcquireRegionLine(size_t glyphReserveHint) {
+    RegionLine ln;
+    if (!regionLinePool_.empty()) {
+        ln = std::move(regionLinePool_.back());
+        regionLinePool_.pop_back();
+    }
+
+    ln.color = {};
+    ln.px = 16.0f;
+    ln.widthPx = 0.0f;
+    ln.glyphCount = 0;
+
+    ln.run.glyphs.clear();
+    ln.run.xOffsets.clear();
+    ln.run.scale = 1.0f;
+    ln.run.ready = false;
+
+    if (glyphReserveHint > 0) {
+        if (ln.run.glyphs.capacity() < glyphReserveHint) {
+            ln.run.glyphs.reserve(glyphReserveHint);
+        }
+        if (ln.run.xOffsets.capacity() < glyphReserveHint) {
+            ln.run.xOffsets.reserve(glyphReserveHint);
+        }
+    }
+
+    return ln;
+}
+
+void TextManager::RecycleRegionLines() {
+    for (Region& rg : regions_) {
+        for (RegionLine& ln : rg.lines) {
+            ln.run.glyphs.clear();
+            ln.run.xOffsets.clear();
+            ln.run.ready = false;
+            ln.widthPx = 0.0f;
+            ln.glyphCount = 0;
+            regionLinePool_.push_back(std::move(ln));
+        }
+        rg.lines.clear();
+        rg.maxLineWidth = 0.0f;
+        rg.totalLines = 0;
+        rg.glyphCount = 0;
+        rg.lineStepPx = 18;
+    }
 }
 
 // ===== приватные =====

--- a/TextManager.h
+++ b/TextManager.h
@@ -98,6 +98,9 @@ private:
     // Рисунок прямоугольника (фон)
     void  EmitRect(int x, int y, float w, float h, const float4& color);
 
+    RegionLine AcquireRegionLine(size_t glyphReserveHint);
+    void       RecycleRegionLines();
+
 private:
     FontAtlas* font_ = nullptr;
 
@@ -115,6 +118,7 @@ private:
     D3D12_INDEX_BUFFER_VIEW  rectIBV_{};
 
     std::vector<Region> regions_;
+    std::vector<RegionLine> regionLinePool_;
 
     UINT  vpW_ = 1, vpH_ = 1;
     float dpi_ = 1.0f;


### PR DESCRIPTION
## Summary
- add helper methods to recycle RegionLine instances between frames
- update region text submission to reuse pooled glyph buffers rather than recreating them
- recycle stored lines during Begin/Clear so BuildGlyphRun no longer allocates on every call

## Testing
- not run (project requires a Windows/MSVC toolchain that is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd5ecd1dfc8329b8b850d04997271f