### PR TITLE
Add braces to single-line control statements

### DIFF
--- a/CBManager.h
+++ b/CBManager.h
@@ -54,7 +54,9 @@ public:
         uint32_t offset = 0;
         for (const auto& f : fields) {
             uint32_t align = GetCBFieldTypeAlignment(f.second);
-            if (offset % align != 0) offset = ((offset / align) + 1) * align;
+            if (offset % align != 0) {
+                offset = ((offset / align) + 1) * align;
+            }
             fields_.push_back({ f.first, f.second, offset });
             nameToIndex_[f.first] = fields_.size() - 1;
             offset += GetCBFieldTypeSize(f.second);
@@ -67,8 +69,9 @@ public:
 
     const CBField* GetField(const std::string& name) const {
         auto it = nameToIndex_.find(name);
-        if (it != nameToIndex_.end())
+        if (it != nameToIndex_.end()) {
             return &fields_[it->second];
+        }
         return nullptr;
     }
 
@@ -78,7 +81,9 @@ public:
     template<typename T>
     bool SetField(const std::string& name, const T& value, uint8_t* data) const {
         const CBField* field = GetField(name);
-        if (!field) return false;
+        if (!field) {
+            return false;
+        }
         // sizeof(T) и GetCBFieldTypeSize могут не совпадать (например, XMMATRIX = 64, XMFLOAT4 = 16)
         static_assert(sizeof(T) <= 64, "T too big for CB"); // just sanity check
         memcpy(data + field->offset, &value, GetCBFieldTypeSize(field->type));
@@ -88,7 +93,9 @@ public:
     // Для сырых массивов/данных:
     bool SetFieldRaw(const std::string& name, const void* src, size_t size, uint8_t* data) const {
         const CBField* field = GetField(name);
-        if (!field) return false;
+        if (!field) {
+            return false;
+        }
         memcpy(data + field->offset, src, std::min(size, size_t(GetCBFieldTypeSize(field->type))));
         return true;
     }

--- a/Helpers.h
+++ b/Helpers.h
@@ -151,7 +151,10 @@ inline void CreateCheckerTex(std::vector<uint32_t>& outRGBA)
     outRGBA.clear();
     outRGBA.resize(256 * 256);
 
-    for (int y = 0; y < 256; ++y) for (int x = 0; x < 256; ++x) {
-        bool c = ((x >> 5) ^ (y >> 5)) & 1; outRGBA[y * 256 + x] = c ? 0xFFFFFFFF : 0xFF000000;
+    for (int y = 0; y < 256; ++y) {
+        for (int x = 0; x < 256; ++x) {
+            bool c = ((x >> 5) ^ (y >> 5)) & 1;
+            outRGBA[y * 256 + x] = c ? 0xFFFFFFFF : 0xFF000000;
+        }
     }
 }

--- a/Material.cpp
+++ b/Material.cpp
@@ -129,7 +129,11 @@ struct IncludeCaptureDXC : public IDxcIncludeHandler
     }
     ULONG STDMETHODCALLTYPE AddRef() override { return ++refcnt; }
     ULONG STDMETHODCALLTYPE Release() override {
-        ULONG v = --refcnt; if (v == 0) delete this; return v;
+        ULONG v = --refcnt;
+        if (v == 0) {
+            delete this;
+        }
+        return v;
     }
 
     // IDxcIncludeHandler
@@ -213,9 +217,12 @@ static HRESULT CompileDXC(const std::wstring& file,
     }
 
     // Собираем массив LPCWSTR
-    std::vector<LPCWSTR> args; args.reserve(owned.size());
+    std::vector<LPCWSTR> args;
+    args.reserve(owned.size());
     {
-        for (auto& s : owned) args.push_back(s.c_str());
+        for (auto& s : owned) {
+            args.push_back(s.c_str());
+        }
     }
 
     // Компиляция
@@ -242,7 +249,9 @@ static HRESULT CompileDXC(const std::wstring& file,
     ComPtr<IDxcBlob> dxil;
     ComPtr<IDxcBlobUtf16> dummyNameObj;
     result->GetOutput(DXC_OUT_OBJECT, IID_PPV_ARGS(&dxil), dummyNameObj.ReleaseAndGetAddressOf());
-    if (!dxil) return E_FAIL;
+    if (!dxil) {
+        return E_FAIL;
+    }
 
     // Приводим к ID3DBlob через копию (чтобы остальной код не менять)
     ComPtr<ID3DBlob> blob;
@@ -997,7 +1006,9 @@ void Material::ProcessReflection(ID3D12ShaderReflection* refl,
 void Material::ReflectShaderBlob(ID3DBlob* blob,
     robin_hood::unordered_map<UINT, CBufferInfo>& io)
 {
-    if (!blob) return;
+    if (!blob) {
+        return;
+    }
 
     // Сначала попробуем DXIL (DXC)
     {

--- a/MaterialData.cpp
+++ b/MaterialData.cpp
@@ -68,9 +68,15 @@ void MaterialData::StageGBufferBindings(Renderer* r, RenderContext& ctx,
     else {
         std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> srvs;
         srvs.reserve(3);
-        if (hasAlbedo) srvs.push_back(albedo.GetSRVCPU());
-        if (hasMR)     srvs.push_back(mr.GetSRVCPU());
-        if (hasNormal) srvs.push_back(normal.GetSRVCPU());
+        if (hasAlbedo) {
+            srvs.push_back(albedo.GetSRVCPU());
+        }
+        if (hasMR) {
+            srvs.push_back(mr.GetSRVCPU());
+        }
+        if (hasNormal) {
+            srvs.push_back(normal.GetSRVCPU());
+        }
         if (!srvs.empty()) {
             auto tbl = r->StageSrvUavTable(srvs);
             ctx.table[srvTableRegister] = tbl.gpu;

--- a/Mesh.cpp
+++ b/Mesh.cpp
@@ -29,8 +29,12 @@ void Mesh::CreateGPUFlexible(ID3D12Device* device,
 
     // IB (поддержка 16/32-битных индексов)
     UINT ibSize = 0;
-    if (indexFormat_ == DXGI_FORMAT_R16_UINT) ibSize = sizeof(uint16_t) * indexCount_;
-    else                                      ibSize = sizeof(uint32_t) * indexCount_;
+    if (indexFormat_ == DXGI_FORMAT_R16_UINT) {
+        ibSize = sizeof(uint16_t) * indexCount_;
+    }
+    else {
+        ibSize = sizeof(uint32_t) * indexCount_;
+    }
 
     indexBuffer_ = up.CreateBufferWithData(indices, ibSize, D3D12_RESOURCE_FLAG_NONE,
         D3D12_RESOURCE_STATE_INDEX_BUFFER);
@@ -77,7 +81,9 @@ static inline XMVECTOR SafeNormalize(XMVECTOR v) {
     const float eps = 1e-6f;
     XMFLOAT3 f; XMStoreFloat3(&f, v);
     float len2 = f.x * f.x + f.y * f.y + f.z * f.z;
-    if (len2 < eps) return XMVectorSet(0, 1, 0, 0);
+    if (len2 < eps) {
+        return XMVectorSet(0, 1, 0, 0);
+    }
     return XMVector3Normalize(v);
 }
 
@@ -114,7 +120,12 @@ void Mesh::GenerateNormalsTangents(std::vector<VertexPNTUV>& verts,
         float du2 = w2.x - w0.x;
         float dv2 = w2.y - w0.y;
         float r = (du1 * dv2 - du2 * dv1);
-        if (fabsf(r) < 1e-8f) r = 1.0f; else r = 1.0f / r;
+        if (fabsf(r) < 1e-8f) {
+            r = 1.0f;
+        }
+        else {
+            r = 1.0f / r;
+        }
 
         XMVECTOR T = XMVectorScale(XMVectorSubtract(XMVectorScale(e1, dv2), XMVectorScale(e2, dv1)), r);
         XMVECTOR B = XMVectorScale(XMVectorSubtract(XMVectorScale(e2, du1), XMVectorScale(e1, du2)), r);

--- a/RenderableObject.cpp
+++ b/RenderableObject.cpp
@@ -156,7 +156,9 @@ std::wstring RenderableObject::AppendSuffixBeforeExt(const std::wstring& file,
     const std::wstring& suffix)
 {
     auto pos = file.find_last_of(L'.');
-    if (pos == std::wstring::npos) return file + suffix;
+    if (pos == std::wstring::npos) {
+        return file + suffix;
+    }
     return file.substr(0, pos) + suffix + file.substr(pos);
 }
 

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -1120,7 +1120,9 @@ void Renderer::BindGBuffer(ID3D12GraphicsCommandList* cl, ClearMode mode) {
 
     if (mode != ClearMode::None) {
         const float c[4]{ 0,0,0,0 };
-        for (int i = 0; i < 3; ++i) cl->ClearRenderTargetView(rtvs[i], c, 0, nullptr);
+        for (int i = 0; i < 3; ++i) {
+            cl->ClearRenderTargetView(rtvs[i], c, 0, nullptr);
+        }
         if (mode == ClearMode::ColorDepth)
         {
             cl->ClearDepthStencilView(D.dsv, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);

--- a/RootSignatureParser.h
+++ b/RootSignatureParser.h
@@ -13,12 +13,24 @@ inline void ParseRootSignatureFromSource(const std::string& shaderSource, RootSi
     std::smatch m;
 
     auto ParseVisibility = [](const std::string& vis) {
-        if (vis == "all")     return D3D12_SHADER_VISIBILITY_ALL;
-        if (vis == "vertex")  return D3D12_SHADER_VISIBILITY_VERTEX;
-        if (vis == "pixel")   return D3D12_SHADER_VISIBILITY_PIXEL;
-        if (vis == "geometry")return D3D12_SHADER_VISIBILITY_GEOMETRY;
-        if (vis == "hull")    return D3D12_SHADER_VISIBILITY_HULL;
-        if (vis == "domain")  return D3D12_SHADER_VISIBILITY_DOMAIN;
+        if (vis == "all") {
+            return D3D12_SHADER_VISIBILITY_ALL;
+        }
+        if (vis == "vertex") {
+            return D3D12_SHADER_VISIBILITY_VERTEX;
+        }
+        if (vis == "pixel") {
+            return D3D12_SHADER_VISIBILITY_PIXEL;
+        }
+        if (vis == "geometry") {
+            return D3D12_SHADER_VISIBILITY_GEOMETRY;
+        }
+        if (vis == "hull") {
+            return D3D12_SHADER_VISIBILITY_HULL;
+        }
+        if (vis == "domain") {
+            return D3D12_SHADER_VISIBILITY_DOMAIN;
+        }
         return D3D12_SHADER_VISIBILITY_ALL;
         };
 

--- a/SamplerManager.cpp
+++ b/SamplerManager.cpp
@@ -69,7 +69,9 @@ D3D12_GPU_DESCRIPTOR_HANDLE SamplerManager::Get(Renderer* renderer, const D3D12_
 
 D3D12_GPU_DESCRIPTOR_HANDLE SamplerManager::GetTableImpl(Renderer* renderer, const D3D12_SAMPLER_DESC* descs, size_t count) {
     D3D12_GPU_DESCRIPTOR_HANDLE null{}; null.ptr = 0;
-    if (count == 0) return null;
+    if (count == 0) {
+        return null;
+    }
 
     auto& sa = renderer->GetSamplerAlloc();
     GpuDescHandle block = sa.Alloc(static_cast<UINT>(count));

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -244,7 +244,9 @@ void Scene::Tick(float deltaTime) {
 }
 
 void Scene::Render(Renderer* renderer) {
-    if (!renderer) return;
+    if (!renderer) {
+        return;
+    }
     CPU_SCOPE("Scene::Render");
 
     if (actions_->WasActionPressed("Wireframe", *input_)) {
@@ -274,7 +276,9 @@ void Scene::Render(Renderer* renderer) {
         bucket.clear();
     }
     for (const auto& obj : objects_) {
-        if (!obj) continue;
+        if (!obj) {
+            continue;
+        }
         const bool tr = obj->IsTransparent();
         const bool simple = obj->IsSimpleRender();
         const ObjectRenderType key = tr
@@ -373,7 +377,9 @@ void Scene::RenderObjectBatch(Renderer* renderer,
     bool useBundles,
     bool bindGbufOrScene)
 {
-    if (objects.empty()) return;
+    if (objects.empty()) {
+        return;
+    }
 
     auto& tasks = TaskSystem::Get();
     const size_t N = objects.size();
@@ -388,7 +394,9 @@ void Scene::RenderObjectBatch(Renderer* renderer,
             if (useBundles) {
                 auto b = renderer->BeginThreadCommandBundle(nullptr);
                 for (size_t i = begin; i < end; ++i) {
-                    if (auto* obj = objects[i]) obj->Render(renderer, b.cl, view, proj);
+                    if (auto* obj = objects[i]) {
+                        obj->Render(renderer, b.cl, view, proj);
+                    }
                 }
                 renderer->EndThreadCommandBundle(b, batchIndex);
             }
@@ -406,7 +414,9 @@ void Scene::RenderObjectBatch(Renderer* renderer,
                     }
 
                     for (size_t i = begin; i < end; ++i) {
-                        if (auto* obj = objects[i]) obj->Render(renderer, t.cl, view, proj);
+                        if (auto* obj = objects[i]) {
+                            obj->Render(renderer, t.cl, view, proj);
+                        }
                     }
                 }
                 renderer->EndThreadCommandList(t, batchIndex);

--- a/TextureCube.cpp
+++ b/TextureCube.cpp
@@ -272,9 +272,13 @@ bool TextureCube::ParseDDS_(const uint8_t* bytes, size_t size,
 
     if (hasDX10) {
         // DX10 header path (modern formats)
-        if (size < 4 + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10)) return false;
+        if (size < 4 + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10)) {
+            return false;
+        }
         const auto* hx = reinterpret_cast<const DDS_HEADER_DXT10*>(bytes + 4 + sizeof(DDS_HEADER));
-        if (hx->resourceDimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D) return false;
+        if (hx->resourceDimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D) {
+            return false;
+        }
 
         outIsCube = (hx->miscFlag & 0x4) != 0; // D3D11_RESOURCE_MISC_TEXTURECUBE
         outW = hdr->width;

--- a/shaders/instance_anim.hlsl
+++ b/shaders/instance_anim.hlsl
@@ -23,12 +23,16 @@ void main(uint3 DTid : SV_DispatchThreadID)
 {
     uint idx = DTid.x;
     if (idx >= instanceCount)
+    {
         return;
+    }
 
     // --- вращение вокруг Y (в радианах)
     gInstances[idx].rotationY += (angularSpeed + (idx % 7) * 0.1f) * deltaTime;
     if (gInstances[idx].rotationY > 6.283185f)
+    {
         gInstances[idx].rotationY -= 6.283185f;
+    }
     float a = gInstances[idx].rotationY + idx;
     //a = 0;
     // row-vector совместимая матрица R_y

--- a/shaders/lighting_ps.hlsl
+++ b/shaders/lighting_ps.hlsl
@@ -76,12 +76,14 @@ float ShadowPCF3x3(float2 uv, float zRef, float2 texel, float radiusPx)
     float s = 0.0;
     [unroll]
     for (int y = -1; y <= 1; ++y)
-    [unroll]
+    {
+        [unroll]
         for (int x = -1; x <= 1; ++x)
         {
             float2 off = float2(x, y) * texel * radiusPx;
             s += ShadowAtlas.SampleCmp(gSmpLinear, uv + off, zRef).r;
         }
+    }
     return s / 9.0;
 }
 


### PR DESCRIPTION
## Summary
- wrap single-line `if` statements across material management, scene logic, resource helpers, and shader utilities in braces to ensure consistent scoping
- add braces to single-line `for` loops in renderer utilities, helper textures, and shader sampling code to avoid accidental fall-through changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd80756cf4832980a1db01033daca0