### PR TITLE
Optimize thread command list setup

### DIFF
--- a/FrameResource.h
+++ b/FrameResource.h
@@ -71,13 +71,13 @@ private:
                         a->Reset();
                     }
                 }
-                used[qi] = 0;
+                used[qi].store(0u, std::memory_order_relaxed);
             }
         }
 
         ID3D12CommandAllocator* Acquire(ID3D12Device* dev, D3D12_COMMAND_LIST_TYPE type) {
             const int qi = QueueIndex_(type);
-            const UINT index = used[qi].fetch_add(1, std::memory_order_acq_rel);
+            const UINT index = used[qi].fetch_add(1u, std::memory_order_relaxed);
             auto& queuePool = pools[qi];
 
             // Быстрый путь: уже есть аллокатор с таким индексом.
@@ -107,7 +107,7 @@ private:
 
         void ResetUsage() {
             for (int qi = 0; qi < kQueueCount_; ++qi) {
-                used[qi].store(0u, std::memory_order_release);
+                used[qi].store(0u, std::memory_order_relaxed);
             }
         }
 
@@ -116,7 +116,7 @@ private:
             ID3D12CommandAllocator* alloc,
             ID3D12PipelineState* initialPSO = nullptr) {
             const int qi = QueueIndex_(type);
-            const UINT index = used[qi].fetch_add(1u, std::memory_order_acq_rel);
+            const UINT index = used[qi].fetch_add(1u, std::memory_order_relaxed);
             auto& vec = pools[qi];
 
             if (index >= vec.size()) {

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -186,6 +186,8 @@ void Renderer::InitD3D12(HWND window) {
         frameResources_[i]->InitUpload(device_.Get(), /*bytes*/ 4 * 1024 * 1024);
     }
 
+    RefreshCurrentFrameCaches();
+
     samplerManager_.Init(device_.Get(), 512);
 
     InitFence();
@@ -333,22 +335,47 @@ void Renderer::SignalFrame(UINT frameIndex) {
     frameFenceValues_[frameIndex] = v;
 }
 
+void Renderer::RefreshCurrentFrameCaches() {
+    currentFrameResource_ = nullptr;
+    currentFrameDescriptorHeapCount_ = 0;
+    currentFrameDescriptorHeaps_.fill(nullptr);
+
+    if (currentFrameIndex_ >= kFrameCount) {
+        return;
+    }
+
+    FrameResource* fr = frameResources_[currentFrameIndex_].get();
+    currentFrameResource_ = fr;
+    if (!fr) {
+        return;
+    }
+
+    if (auto* heap = fr->GetDescAlloc().GetShaderVisibleHeap()) {
+        currentFrameDescriptorHeaps_[currentFrameDescriptorHeapCount_++] = heap;
+    }
+    if (auto* heap = fr->GetSamplerAlloc().GetShaderVisibleHeap()) {
+        currentFrameDescriptorHeaps_[currentFrameDescriptorHeapCount_++] = heap;
+    }
+}
+
 void Renderer::BeginFrame() {
-	CPU_SCOPE("Renderer::BeginFrame");
+    CPU_SCOPE("Renderer::BeginFrame");
     // Ждём GPU по своему backbuffer'у
     WaitForFrame(currentFrameIndex_);
+
+    RefreshCurrentFrameCaches();
+    FrameResource* fr = currentFrameResource_;
 
     ++totalFrameNumber_;
 
     // Сброс кадровых пулов
-    auto& fr = frameResources_[currentFrameIndex_];
-    fr->ResetCommandAllocators(device_.Get());
-    fr->ResetCommandListsUsage();
-
-    frameResources_[currentFrameIndex_]->GetDescAlloc().ResetPerFrame();
-    frameResources_[currentFrameIndex_]->GetSamplerAlloc().ResetPerFrame();
-    frameResources_[currentFrameIndex_]->ResetCommandListsUsage();
-    frameResources_[currentFrameIndex_]->ResetUpload();
+    if (fr) {
+        fr->ResetCommandAllocators(device_.Get());
+        fr->ResetCommandListsUsage();
+        fr->GetDescAlloc().ResetPerFrame();
+        fr->GetSamplerAlloc().ResetPerFrame();
+        fr->ResetUpload();
+    }
 
     ctxPool_.ResetForFrame();
 }
@@ -414,32 +441,31 @@ Renderer::ThreadCL Renderer::BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE type
     CPU_SCOPE("Renderer::BeginThreadCommandList");
     ID3D12GraphicsCommandList* cl = 0;
     ID3D12CommandAllocator* alloc = 0;
-    {
-        auto& fr = frameResources_[currentFrameIndex_];
-        {
-            //CPU_SCOPE("Renderer::BeginThreadCommandList.1");
-            alloc = fr->AcquireCommandAllocator(device_.Get(), type);
-        }
-        {
-            CPU_SCOPE("Renderer::BeginThreadCommandList.2");
-            cl = fr->AcquireCommandList(device_.Get(), type, alloc, pso);
-        }
+    FrameResource* fr = currentFrameResource_;
+    if (!fr) {
+        fr = frameResources_[currentFrameIndex_].get();
+    }
+    if (!fr) {
+        return {};
     }
 
-    ID3D12DescriptorHeap* heaps[] = {
-        frameResources_[currentFrameIndex_]->GetDescAlloc().GetShaderVisibleHeap(),
-        frameResources_[currentFrameIndex_]->GetSamplerAlloc().GetShaderVisibleHeap()
-    };
-    cl->SetDescriptorHeaps(_countof(heaps), heaps);
+    //CPU_SCOPE("Renderer::BeginThreadCommandList.1");
+    alloc = fr->AcquireCommandAllocator(device_.Get(), type);
+    {
+        CPU_SCOPE("Renderer::BeginThreadCommandList.2");
+        cl = fr->AcquireCommandList(device_.Get(), type, alloc, pso);
+    }
+
+    if ((type == D3D12_COMMAND_LIST_TYPE_DIRECT || type == D3D12_COMMAND_LIST_TYPE_COMPUTE) &&
+        currentFrameDescriptorHeapCount_ > 0)
+    {
+        cl->SetDescriptorHeaps(currentFrameDescriptorHeapCount_, currentFrameDescriptorHeaps_.data());
+    }
 
     // регистрируем CL в lock-free трекере состояний
     //RegisterCurrentThreadCL(cl);
 
-    ThreadCL t{};
-    t.alloc = alloc;
-    t.cl = cl;
-    t.type = type;
-    return t;
+    return ThreadCL{ alloc, cl, type };
 }
 
 Renderer::ThreadCL Renderer::BeginThreadCommandBundle(ID3D12PipelineState* initialPSO)
@@ -677,6 +703,7 @@ void Renderer::ExecuteTimelineAndPresent() {
     //ThrowIfFailed(swapChain_->Present(1, 0));
     SignalFrame(currentFrameIndex_);
     currentFrameIndex_ = swapChain_->GetCurrentBackBufferIndex();
+    RefreshCurrentFrameCaches();
 }
 
 void Renderer::WaitForPreviousFrame() {

--- a/Renderer.h
+++ b/Renderer.h
@@ -2,6 +2,7 @@
 #include <d3d12.h>
 #include <dxgi1_4.h>
 #include <wrl/client.h>
+#include <array>
 
 #include "DescriptorAllocator.h"
 #include "FrameResource.h"
@@ -190,6 +191,7 @@ private:
     void CreateDepthResources(UINT width, UINT height);
     void WaitForFrame(UINT frameIndex);   // ожидание конкретного кадра (по fence value кадра)
     void SignalFrame(UINT frameIndex);    // сигнал на фэнсе для кадра
+    void RefreshCurrentFrameCaches();
 
     D3D12_CPU_DESCRIPTOR_HANDLE DeferredRtvAt(UINT idx) const;
     D3D12_CPU_DESCRIPTOR_HANDLE DeferredDsvAt(UINT idx) const;
@@ -271,8 +273,12 @@ private:
     UINT64                            frameFenceValues_[kFrameCount] = {};  // последний сигнал для каждого кадра
 
     // Кадровые ресурсы (аллокатор + upload и т.п.)
-	std::unique_ptr<FrameResource>    frameResources_[kFrameCount];
+        std::unique_ptr<FrameResource>    frameResources_[kFrameCount];
     UINT                              currentFrameIndex_ = 0;                   // 0..kFrameCount-1
+    FrameResource*                    currentFrameResource_ = nullptr;
+    static constexpr UINT             kFrameShaderVisibleHeapCount_ = 2;
+    std::array<ID3D12DescriptorHeap*, kFrameShaderVisibleHeapCount_> currentFrameDescriptorHeaps_{};
+    UINT                              currentFrameDescriptorHeapCount_ = 0;
 
     std::mutex knownStatesMtx_;
     robin_hood::unordered_map<ID3D12Resource*, D3D12_RESOURCE_STATES> knownStates_;


### PR DESCRIPTION
## Summary
- cache the current frame resource and descriptor heaps so BeginThreadCommandList avoids repeated lookups and skips heap binding for non-direct/compute lists
- relax the atomic memory ordering in command allocator/list pools to reduce CPU fences during hot path usage

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfc95301308329b05a8a4ce5b5ecb2