### PR TITLE
Convert profiler scopes to wide strings

### DIFF
--- a/App.cpp
+++ b/App.cpp
@@ -134,11 +134,11 @@ void App::Run(HINSTANCE hInstance, int nCmdShow) {
 #endif
 
         {
-            CPU_SCOPE("Whole Cycle");
+            CPU_SCOPE(L"Whole Cycle");
             input_.NewFrame();
 
             {
-                CPU_SCOPE("Win Messages");
+                CPU_SCOPE(L"Win Messages");
                 while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE)) {
                     TranslateMessage(&msg);
                     DispatchMessage(&msg);

--- a/Material.cpp
+++ b/Material.cpp
@@ -368,7 +368,7 @@ void Material::RefreshWatchTimes_()
 
 bool Material::FSProbeAndFlagPending()
 {
-    CPU_SCOPE("Material::FSProbeAndFlagPending");
+    CPU_SCOPE(L"Material::FSProbeAndFlagPending");
     std::lock_guard<std::mutex> lk(watchMtx_);
     if (watchedFiles_.empty()) { return false; }
 

--- a/Profiler.cpp
+++ b/Profiler.cpp
@@ -5,7 +5,6 @@
 #include <sstream>
 #include <cstdio>
 #include <ctime>
-#include <codecvt>
 #include <filesystem>
 #include "third_party/robin_hood.h"
 #include "TextManager.h"
@@ -44,29 +43,14 @@ std::string EscapeJson(const std::string& input) {
 struct TraceDumpData {
     std::vector<Profiler::TraceEvent> events;
     std::vector<std::string> threadNames;
+    std::vector<Profiler::TraceNameEntry> names;
 };
 
 std::wstring BuildWideName(const Profiler::ScopeNameKey& key) {
-    if (!key.namePtr) {
+    if (!key.namePtr || !*key.namePtr) {
         return L"unknown";
     }
-    if (key.isWide) {
-        const wchar_t* ws = static_cast<const wchar_t*>(key.namePtr);
-        return ws ? std::wstring(ws) : std::wstring(L"unknown");
-    }
-    const char* cs = static_cast<const char*>(key.namePtr);
-    if (!cs) {
-        return L"unknown";
-    }
-    std::wstring result;
-    while (*cs) {
-        result.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*cs)));
-        ++cs;
-    }
-    if (result.empty()) {
-        result = L"unknown";
-    }
-    return result;
+    return std::wstring(key.namePtr);
 }
 
 std::string WideToUtf8(const std::wstring& input) {
@@ -111,12 +95,6 @@ Profiler& Profiler::Get() {
 }
 
 #if PROF_GPU_ENABLED
-Profiler::ScopedGpu::ScopedGpu(ID3D12GraphicsCommandList* cl, const char* name, uint64_t id)
-    : cl_(cl)
-{
-    idx_ = Profiler::Get().BeginGpuSample(cl, ScopeNameKey::FromNarrow(name, id));
-}
-
 Profiler::ScopedGpu::ScopedGpu(ID3D12GraphicsCommandList* cl, const wchar_t* name, uint64_t id)
     : cl_(cl)
 {
@@ -145,6 +123,8 @@ void Profiler::BeginFrame(uint64_t frameNo) {
         traceCapturing_ = true;
         traceFramesRemaining_ = traceRequestFrameCount_;
         traceEvents_.clear();
+        traceNames_.clear();
+        traceNameLookup_.clear();
         traceStartUs_ = 0;
         traceStartSet_ = false;
         traceStopRequested_ = false;
@@ -193,7 +173,8 @@ void Profiler::EndFrame() {
             const uint64_t durUs = (endUs > startUs) ? (endUs - startUs) : 0;
             const uint32_t threadIdx = GetThreadIndex_Locked(std::this_thread::get_id());
             TraceEvent fev;
-            fev.narrowName = "Frame " + std::to_string(frameNo_);
+            fev.inlineName = L"Frame ";
+            fev.inlineName += std::to_wstring(frameNo_);
             fev.tsUs = (startUs >= traceStartUs_) ? (startUs - traceStartUs_) : 0;
             fev.durUs = durUs;
             fev.threadIndex = threadIdx;
@@ -219,6 +200,8 @@ void Profiler::EndFrame() {
                 traceStartUs_ = 0;
                 traceStartSet_ = false;
                 traceDump.events = std::move(traceEvents_);
+                traceDump.names = std::move(traceNames_);
+                traceNameLookup_.clear();
                 traceDump.threadNames = threadIndexToName_;
                 haveTraceDump = true;
                 traceRequestFrameCount_ = 0;
@@ -458,41 +441,51 @@ void Profiler::EndFrame() {
 #endif
 
         if (haveTraceDump && !traceDump.events.empty()) {
-            WriteTraceJson(traceDump.events, traceDump.threadNames);
+            WriteTraceJson(traceDump.events, traceDump.threadNames, traceDump.names);
         }
     });
 }
 
 void Profiler::PushSample(const ScopeNameKey& key, CpuClock::time_point start, CpuClock::time_point end) {
     if (!GetEnabled()) { return; }
-    std::lock_guard<std::mutex> lk(mtx_);
-    if (!frameOpen_) { return; }
     const uint64_t startUs = ToMicroseconds(start);
     const uint64_t endUs = ToMicroseconds(end);
     const uint64_t durUs = (endUs > startUs) ? (endUs - startUs) : 0;
-    const uint32_t threadIdx = GetThreadIndex_Locked(std::this_thread::get_id());
     const double ms = std::chrono::duration<double, std::milli>(end - start).count();
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (!frameOpen_) { return; }
     frameSamples_.push_back({ key, ms });
     if (traceCapturing_) {
         if (!traceStartSet_) {
             traceStartUs_ = startUs;
             traceStartSet_ = true;
         }
-        TraceEvent ev;
-        ev.isWide = key.isWide;
-        if (key.isWide) {
-            const wchar_t* ws = static_cast<const wchar_t*>(key.namePtr);
-            if (ws) {
-                ev.wideName.assign(ws);
-            }
-            else {
-                ev.wideName = L"unknown";
-            }
-            //ev.narrowName = WideToUtf8(ev.wideName);
+        const uint32_t threadIdx = GetThreadIndex_Locked(std::this_thread::get_id());
+        uint32_t nameIndex = std::numeric_limits<uint32_t>::max();
+        bool haveNameIndex = false;
+        std::wstring displayName;
+        auto nameIt = traceNameLookup_.find(key);
+        if (nameIt != traceNameLookup_.end()) {
+            nameIndex = nameIt->second;
+            haveNameIndex = true;
         }
         else {
-            const char* cs = static_cast<const char*>(key.namePtr);
-            ev.narrowName = cs ? std::string(cs) : std::string("unknown");
+            displayName = BuildWideName(key);
+            if (traceNames_.size() < static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
+                TraceNameEntry entry{};
+                entry.displayName = std::move(displayName);
+                nameIndex = static_cast<uint32_t>(traceNames_.size());
+                traceNames_.push_back(std::move(entry));
+                traceNameLookup_.emplace(key, nameIndex);
+                haveNameIndex = true;
+            }
+        }
+        TraceEvent ev;
+        if (haveNameIndex) {
+            ev.nameIndex = nameIndex;
+        }
+        else {
+            ev.inlineName = std::move(displayName);
         }
         ev.tsUs = (startUs >= traceStartUs_) ? (startUs - traceStartUs_) : 0;
         ev.durUs = durUs;
@@ -577,7 +570,7 @@ void Profiler::BeginGpuFrame(ID3D12GraphicsCommandList* cl) {
         gpuFrameSampleIdx_.store(SIZE_MAX, std::memory_order_relaxed);
         return;
     }
-    const size_t idx = BeginGpuSample(cl, ScopeNameKey::FromNarrow("GPU.Frame", 0));
+    const size_t idx = BeginGpuSample(cl, ScopeNameKey::FromWide(L"GPU.Frame", 0));
     gpuFrameSampleIdx_.store(idx, std::memory_order_relaxed);
 #else
     (void)cl;
@@ -643,7 +636,7 @@ void Profiler::EndGpuSample(ID3D12GraphicsCommandList* cl, size_t idx) {
 
 void Profiler::EmitOverlay(TextManager* tm, int x, int y, int maxLines) {
     if (!tm || !GetEnabled()) { return; }
-    CPU_SCOPE("Profiler::EmitOverlay");
+    CPU_SCOPE(L"Profiler::EmitOverlay");
 
     // читаем актуальные read-буферы БЕЗ локов
     const int readIdx = overlayReadBuf_.load(std::memory_order_acquire);
@@ -825,7 +818,9 @@ uint32_t Profiler::GetThreadIndex_Locked(std::thread::id id) {
     return idx;
 }
 
-void Profiler::WriteTraceJson(const std::vector<TraceEvent>& events, const std::vector<std::string>& threadNames) {
+void Profiler::WriteTraceJson(const std::vector<TraceEvent>& events,
+                              const std::vector<std::string>& threadNames,
+                              const std::vector<TraceNameEntry>& names) {
     if (events.empty()) { return; }
     const uint32_t fileIdx = traceFileCounter_.fetch_add(1u, std::memory_order_relaxed);
     auto now = std::chrono::system_clock::now();
@@ -864,10 +859,12 @@ void Profiler::WriteTraceJson(const std::vector<TraceEvent>& events, const std::
     }
 
     for (const auto& ev : events) {
-        std::string name = ev.narrowName;
-        if (name.empty() && !ev.wideName.empty()) {
-            name = WideToUtf8(ev.wideName);
+        std::wstring nameWide = ev.inlineName;
+        if (nameWide.empty() && ev.nameIndex < names.size()) {
+            nameWide = names[ev.nameIndex].displayName;
         }
+        if (nameWide.empty()) { nameWide = L"unknown"; }
+        std::string name = WideToUtf8(nameWide);
         if (name.empty()) { name = "unknown"; }
         std::ostringstream line;
         line << "  {\"name\":\"" << EscapeJson(name) << "\",\"cat\":\"CPU\",\"ph\":\"X\",\"ts\":"

--- a/Profiler.h
+++ b/Profiler.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string_view>
 #include <cstring>
+#include <limits>
 
 #include "TaskSystem.h"
 
@@ -36,15 +37,11 @@ public:
     using CpuClock = std::chrono::steady_clock;
 
     struct ScopeNameKey {
-        const void* namePtr = nullptr;
-        uint64_t    nameId = 0;
-        bool        isWide = false;
+        const wchar_t* namePtr = nullptr;
+        uint64_t       nameId = 0;
 
-        static ScopeNameKey FromNarrow(const char* ptr, uint64_t id) {
-            return ScopeNameKey{ ptr, id, false };
-        }
         static ScopeNameKey FromWide(const wchar_t* ptr, uint64_t id) {
-            return ScopeNameKey{ ptr, id, true };
+            return ScopeNameKey{ ptr, id };
         }
     };
 
@@ -91,8 +88,7 @@ public:
             if (key.nameId != 0) {
                 return robin_hood::hash_bytes(&key.nameId, sizeof(key.nameId));
             }
-            const size_t ptrHash = robin_hood::hash_bytes(&key.namePtr, sizeof(key.namePtr));
-            return ptrHash ^ (key.isWide ? 0x9E3779B97F4A7C15ull : 0ull);
+            return robin_hood::hash_bytes(&key.namePtr, sizeof(key.namePtr));
         }
     };
 
@@ -101,17 +97,20 @@ public:
             if (a.nameId != 0 || b.nameId != 0) {
                 return a.nameId == b.nameId;
             }
-            return a.namePtr == b.namePtr && a.isWide == b.isWide;
+            return a.namePtr == b.namePtr;
         }
     };
 
     struct TraceEvent {
-        std::string  narrowName;
-        std::wstring wideName;
-        bool isWide = false;
-        uint64_t tsUs = 0;
-        uint64_t durUs = 0;
-        uint32_t threadIndex = 0;
+        uint32_t    nameIndex = std::numeric_limits<uint32_t>::max();
+        std::wstring inlineName;
+        uint64_t    tsUs = 0;
+        uint64_t    durUs = 0;
+        uint32_t    threadIndex = 0;
+    };
+
+    struct TraceNameEntry {
+        std::wstring displayName;
     };
 
     // --- данные оверлея (снэпшот) ---
@@ -142,12 +141,6 @@ public:
     // Скоповая отметка (CPU)
     class ScopedCpu {
     public:
-        ScopedCpu(const char* name, uint64_t nameId = 0) {
-#if PROF_ENABLED
-            key_ = ScopeNameKey::FromNarrow(name, nameId);
-            start_ = Clock::now();
-#endif
-        }
         ScopedCpu(const wchar_t* name, uint64_t nameId = 0) {
 #if PROF_ENABLED
             key_ = ScopeNameKey::FromWide(name, nameId);
@@ -180,7 +173,6 @@ public:
     // Скоповая отметка (GPU)
     class ScopedGpu {
     public:
-        ScopedGpu(ID3D12GraphicsCommandList* cl, const char* name, uint64_t nameId = 0);
         ScopedGpu(ID3D12GraphicsCommandList* cl, const wchar_t* name, uint64_t nameId = 0);
         ~ScopedGpu();
     private:
@@ -254,7 +246,9 @@ private:
 #if PROF_ENABLED
     void ResetMax_Unsafe(); // вызывать под mtx_
     uint32_t GetThreadIndex_Locked(std::thread::id id);
-    void WriteTraceJson(const std::vector<TraceEvent>& events, const std::vector<std::string>& threadNames);
+    void WriteTraceJson(const std::vector<TraceEvent>& events,
+                        const std::vector<std::string>& threadNames,
+                        const std::vector<TraceNameEntry>& names);
 #endif
 
 private:
@@ -338,6 +332,8 @@ private:
     uint64_t traceStartUs_ = 0;
     bool traceStartSet_ = false;
     std::vector<TraceEvent> traceEvents_;
+    std::vector<TraceNameEntry> traceNames_;
+    robin_hood::unordered_flat_map<ScopeNameKey, uint32_t, ScopeNameKeyHash, ScopeNameKeyEqual> traceNameLookup_;
     std::atomic<uint32_t> traceFileCounter_{ 0 };
 
 #if PROF_GPU_ENABLED

--- a/RenderGraph.h
+++ b/RenderGraph.h
@@ -55,7 +55,7 @@ public:
     // Старое: последовательное исполнение (на место)
     void Execute(Renderer* renderer)
     {
-        CPU_SCOPE("RenderGraph::Execute");
+        CPU_SCOPE(L"RenderGraph::Execute");
         if (renderer == nullptr) { return; }
         Unroll(renderer, /*executeInplace=*/true, nullptr);
     }
@@ -73,7 +73,7 @@ public:
     // сабмитим РЕАЛЬНЫЕ таски пассов с ожиданием их mt-deps.
     void ExecuteParallel(Renderer* renderer, TaskSystem& tasks)
     {
-        CPU_SCOPE("RenderGraph::ExecuteParallel");
+        CPU_SCOPE(L"RenderGraph::ExecuteParallel");
         const auto& flat = BuildSchedule(renderer);
         if (flat.empty()) { return; }
 

--- a/RenderableObject.cpp
+++ b/RenderableObject.cpp
@@ -84,7 +84,7 @@ void RenderableObject::IssueDraw(Renderer* renderer, ID3D12GraphicsCommandList* 
 void RenderableObject::UpdateUniforms(Renderer* renderer, const mat4& view, const mat4& proj, uint8_t* cbData)
 {
     if (!cbData) { return; }
-    CPU_SCOPE("RenderableObject::UpdateUniforms");
+    CPU_SCOPE(L"RenderableObject::UpdateUniforms");
     UpdateUniform(kWorldID, GetModelMatrix(), cbData);
     UpdateUniform(kViewID, view, cbData);
     UpdateUniform(kProjID, proj, cbData);
@@ -112,7 +112,7 @@ void RenderableObject::Render(Renderer* renderer, ID3D12GraphicsCommandList* cl,
 {
     if (!renderer) { return; }
     if (cl == nullptr) { return; }
-    CPU_SCOPE("RenderableObject::Render");
+    CPU_SCOPE(L"RenderableObject::Render");
 
     UINT cbSizeBytes = 0;
 
@@ -163,11 +163,11 @@ void RenderableObject::RecordShadow(Renderer* renderer, ID3D12GraphicsCommandLis
     const mat4& lightView, const mat4& lightProj, RenderContext& ctx, uint8_t* cbData)
 {
     if (!renderer || !cl || !GetMesh() || !shadowMaterial_) { return; }
-    //CPU_SCOPE("RenderableObject::RecordShadow");
+    //CPU_SCOPE(L"RenderableObject::RecordShadow");
 
     //TaskSystem::Get().Submit([this, &lightProj, &lightView, cbData]()
     {
-        //CPU_SCOPE("RenderableObject::RecordShadow.Unis");
+        //CPU_SCOPE(L"RenderableObject::RecordShadow.Unis");
         shadowMaterial_->UpdateCB0Field(kWorldID, GetModelMatrix(), cbData);
         shadowMaterial_->UpdateCB0Field(kViewID, lightView, cbData);
         shadowMaterial_->UpdateCB0Field(kProjID, lightProj, cbData);
@@ -180,7 +180,7 @@ void RenderableObject::RecordShadow(Renderer* renderer, ID3D12GraphicsCommandLis
 void RenderableObject::RenderShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl,
     const mat4& lightView, const mat4& lightProj)
 {
-    //CPU_SCOPE("RenderableObject::RenderShadow");
+    //CPU_SCOPE(L"RenderableObject::RenderShadow");
     if (!CastsShadow())
     {
         return;

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -318,7 +318,7 @@ void Renderer::CreateDepthResources(UINT width, UINT height) {
 }
 
 void Renderer::WaitForFrame(UINT frameIndex) {
-    CPU_SCOPE("Renderer::WaitForFrame");
+    CPU_SCOPE(L"Renderer::WaitForFrame");
     const UINT64 value = frameFenceValues_[frameIndex];
     if (value == 0) {
         return; // ещё не сигналили этот кадр — ждать нечего
@@ -359,7 +359,7 @@ void Renderer::RefreshCurrentFrameCaches() {
 }
 
 void Renderer::BeginFrame() {
-    CPU_SCOPE("Renderer::BeginFrame");
+    CPU_SCOPE(L"Renderer::BeginFrame");
     // Ждём GPU по своему backbuffer'у
     WaitForFrame(currentFrameIndex_);
 
@@ -438,7 +438,7 @@ void Renderer::Tick(float dt)
 
 Renderer::ThreadCL Renderer::BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE type, ID3D12PipelineState* pso)
 {
-    CPU_SCOPE("Renderer::BeginThreadCommandList");
+    CPU_SCOPE(L"Renderer::BeginThreadCommandList");
     ID3D12GraphicsCommandList* cl = 0;
     ID3D12CommandAllocator* alloc = 0;
     FrameResource* fr = currentFrameResource_;
@@ -449,7 +449,7 @@ Renderer::ThreadCL Renderer::BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE type
         return {};
     }
 
-    //CPU_SCOPE("Renderer::BeginThreadCommandList.1");
+    //CPU_SCOPE(L"Renderer::BeginThreadCommandList.1");
     alloc = fr->AcquireCommandAllocator(device_.Get(), type);
     cl = fr->AcquireCommandList(device_.Get(), type, alloc, pso);
 
@@ -471,7 +471,7 @@ Renderer::ThreadCL Renderer::BeginThreadCommandBundle(ID3D12PipelineState* initi
 }
 
 void Renderer::EndThreadCommandList(ThreadCL& t, size_t batchIndex) {
-    CPU_SCOPE("Renderer::EndThreadCommandList");
+    CPU_SCOPE(L"Renderer::EndThreadCommandList");
     if (!t.cl) { return; }
     ThrowIfFailed(t.cl->Close());
 
@@ -513,7 +513,7 @@ void Renderer::RegisterPassDriver(ID3D12GraphicsCommandList* cl, size_t batchInd
 
 void Renderer::EndThreadCommandBundle(ThreadCL& b, size_t batchIndex)
 {
-    CPU_SCOPE("Renderer::EndThreadCommandBundle");
+    CPU_SCOPE(L"Renderer::EndThreadCommandBundle");
     if (b.cl != nullptr) {
         ThrowIfFailed(b.cl->Close());
         std::lock_guard<std::mutex> lk(submitMtx_);
@@ -526,7 +526,7 @@ void Renderer::EndThreadCommandBundle(ThreadCL& b, size_t batchIndex)
 }
 
 void Renderer::ExecuteTimelineAndPresent() {
-    CPU_SCOPE("Renderer::ExecuteTimelineAndPresent");
+    CPU_SCOPE(L"Renderer::ExecuteTimelineAndPresent");
 
     submitListsScratch_.clear();
 
@@ -762,7 +762,7 @@ D3D12_RESOURCE_STATES Renderer::GetGlobalKnownState(ID3D12Resource* res)
 
 void Renderer::Transition(ID3D12GraphicsCommandList* cl, ID3D12Resource* res, D3D12_RESOURCE_STATES after) {
     if (!cl || !res) { return; }
-    CPU_SCOPE("Renderer::Transition");
+    CPU_SCOPE(L"Renderer::Transition");
     ID3D12CommandList* base = static_cast<ID3D12CommandList*>(cl);
 
     // быстрый путь — активный CL лежит в TLS

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -216,7 +216,7 @@ void Scene::AddObject(std::unique_ptr<RenderableObjectBase> obj) {
 }
 
 void Scene::Tick(float deltaTime) {
-    CPU_SCOPE("Scene::Tick");
+    CPU_SCOPE(L"Scene::Tick");
 
     if (input_ != nullptr && actions_ != nullptr)
     {
@@ -247,7 +247,7 @@ void Scene::Render(Renderer* renderer) {
     if (!renderer) {
         return;
     }
-    CPU_SCOPE("Scene::Render");
+    CPU_SCOPE(L"Scene::Render");
 
     if (actions_->WasActionPressed("Wireframe", *input_)) {
         renderer->SetWireframeMode(!renderer->GetWireframeMode());
@@ -290,81 +290,81 @@ void Scene::Render(Renderer* renderer) {
 
     RenderGraph rg;
     auto pClear = rg.AddPass("PrologueClear", {},
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE("Pass_PrologueClear"); Pass_PrologueClear(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_PrologueClear"); Pass_PrologueClear(renderer, ctx); });
 
     auto pShadow = rg.AddPass("CSM", { pClear },
         [this, renderer, &view, &proj, &invView, &invProj, zNear, zFar, camDir, &buckets]
         (RenderGraph::PassContext ctx) {
-            CPU_SCOPE("Pass_CSM");
+            CPU_SCOPE(L"Pass_CSM");
             Pass_CSM(renderer, ctx, view, proj, invView, invProj, zNear, zFar, camDir, buckets);
         });
 
     auto pGbuf = rg.AddPass("GBuffer", { pShadow },
         [this, renderer, &view, &proj, &buckets](RenderGraph::PassContext ctx) {
-            CPU_SCOPE("Pass_GBuffer");
+            CPU_SCOPE(L"Pass_GBuffer");
             Pass_GBuffer(renderer, ctx, view, proj, buckets);
         });
 
     auto pLight = rg.AddPassMT("Lighting", { pGbuf }, { pShadow },
         [this, renderer, &view, &proj, &invView, &invProj, camDir](RenderGraph::PassContext ctx) {
-            CPU_SCOPE("Pass_Lighting");
+            CPU_SCOPE(L"Pass_Lighting");
             Pass_Lighting(renderer, ctx, view, proj, invView, invProj, camDir);
         });
 
     auto pPointLights = rg.AddPass("PointLights", { pLight },
         [this, renderer, &view, &proj, &invView, &invProj](RenderGraph::PassContext ctx) {
-            CPU_SCOPE("Pass_PointLights");
+            CPU_SCOPE(L"Pass_PointLights");
             Pass_PointLights(renderer, ctx, view, proj, invView, invProj);
         });
 
     auto pSky = rg.AddPass("Skybox", { pPointLights },
         [this, renderer, &view, &proj](RenderGraph::PassContext ctx) {
-            CPU_SCOPE("Pass_Skybox");
+            CPU_SCOPE(L"Pass_Skybox");
             Pass_Skybox(renderer, ctx, view, proj);
         });
 
     auto pSSR = rg.AddPass("SSR", { pSky },
         [this, renderer, &view, &proj, &invView, &invProj, zNear, zFar](RenderGraph::PassContext ctx) {
-            CPU_SCOPE("Pass_SSR");
+            CPU_SCOPE(L"Pass_SSR");
             Pass_SSR(renderer, ctx, view, proj, invView, invProj, zNear, zFar);
         });
 
     auto pBlur = rg.AddPass("SSR.Blur", { pSSR },
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE("Pass_SSR.Blur"); Pass_SSR_Blur(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_SSR.Blur"); Pass_SSR_Blur(renderer, ctx); });
 
     auto pCompose = rg.AddPass("Compose", { pBlur },
         [this, renderer, &view, &proj, &invView, &invProj, zNear, zFar](RenderGraph::PassContext ctx) {
-            CPU_SCOPE("Pass_Compose");
+            CPU_SCOPE(L"Pass_Compose");
             Pass_Compose(renderer, ctx, view, proj, invView, invProj, zNear, zFar);
         });
 
     auto pTransp = rg.AddPass("Transparent", { pCompose },
         [this, renderer, &view, &proj, &buckets](RenderGraph::PassContext ctx) {
-            CPU_SCOPE("Pass_Transparent");
+            CPU_SCOPE(L"Pass_Transparent");
             Pass_Transparent(renderer, ctx, view, proj, buckets);
         });
 
     auto pTone = rg.AddPass("Tonemap", { pTransp },
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE("Pass_Tonemap"); Pass_Tonemap(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_Tonemap"); Pass_Tonemap(renderer, ctx); });
 
     rg.AddPass("Debug", { pTone },
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE("Pass_Debug"); Pass_Debug(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_Debug"); Pass_Debug(renderer, ctx); });
 
     rg.ExecuteParallel(renderer, TaskSystem::Get());
     //rg.Execute(renderer);
     
     {
-        CPU_SCOPE("Main Wait");
+        CPU_SCOPE(L"Main Wait");
         TaskSystem::Get().WaitForAll();
     }
 
     RenderGraph epilogueRG;
     epilogueRG.AddPass("Overlay", {},
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE("Pass_Overlay"); Pass_Overlay(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_Overlay"); Pass_Overlay(renderer, ctx); });
     epilogueRG.Execute(renderer);
     
     {
-        CPU_SCOPE("Last Wait");
+        CPU_SCOPE(L"Last Wait");
         TaskSystem::Get().WaitForAll();
     }
     renderer->EndFrame();
@@ -403,7 +403,7 @@ void Scene::RenderObjectBatch(Renderer* renderer,
             else {
                 auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
                 {
-                    GPU_SCOPE(t.cl, "RenderObjectBatch");
+                    GPU_SCOPE(t.cl, L"RenderObjectBatch");
                     if (bindGbufOrScene)
                     {
                         renderer->BindGBuffer(t.cl, Renderer::ClearMode::None); // без очистки!
@@ -445,7 +445,7 @@ void Scene::RenderShadowBatch(Renderer* renderer,
     tasks.DispatchDetach((N + chunkSize - 1) / chunkSize,
         [renderer, &objects, &lightView, &lightProj, cascadeIndex, chunkSize, batchIndex](std::size_t jobIndex)
         {
-            CPU_SCOPE("RenderShadowBatch.Async");
+            CPU_SCOPE(L"RenderShadowBatch.Async");
             const size_t begin = jobIndex * chunkSize;
             const size_t end = std::min(begin + chunkSize, objects.size());
 
@@ -453,7 +453,7 @@ void Scene::RenderShadowBatch(Renderer* renderer,
               auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
               t.cl->SetName(L"RenderShadowBatch");
               {
-                  GPU_SCOPE(t.cl, "RenderShadowBatch");
+                  GPU_SCOPE(t.cl, L"RenderShadowBatch");
 
                   // важное: привязываем нужный тайл атласа каскада, без очистки
                   renderer->BindShadowTarget(t.cl, cascadeIndex, /*clear=*/false);
@@ -473,7 +473,7 @@ void Scene::Pass_PrologueClear(Renderer* r, RenderGraph::PassContext ctx)
     auto t = r->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_PrologueClear");
+        GPU_SCOPE(t.cl, L"Pass_PrologueClear");
         r->RecordBindAndClear(t.cl);
     }
     r->EndThreadCommandList(t, ctx.batchIndex);
@@ -487,7 +487,7 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
     auto d = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     d.cl->SetName(L"CSM");
     {
-        GPU_SCOPE(d.cl, "Pass_CSM");
+        GPU_SCOPE(d.cl, L"Pass_CSM");
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(d.cl, D.shadow.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE);
         renderer->BindShadowTarget(d.cl, 0, /*clear=*/true);
@@ -507,7 +507,7 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
 
     auto cascades = TaskSystem::Get().Dispatch(kCascades, [this, renderer, &buckets, &invView, &invProj, &proj, camDir, sunDirWS = dirLight_.dir, batchIndex](std::size_t idx)
     {
-        CPU_SCOPE("CSM.PerCascade");
+        CPU_SCOPE(L"CSM.PerCascade");
         const auto& D = renderer->GetDeferredForFrame();
 
         float sliceNear = cachedSplitsVS_[idx], sliceFar = cachedSplitsVS_[idx + 1];
@@ -599,7 +599,7 @@ void Scene::Pass_GBuffer(Renderer* renderer, RenderGraph::PassContext ctx,
     rgGB.AddPass("GBuffer.Driver", {}, [renderer](RenderGraph::PassContext sub) {
         auto driver = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         {
-            GPU_SCOPE(driver.cl, "GBuffer.Driver");
+            GPU_SCOPE(driver.cl, L"GBuffer.Driver");
 
             const auto& D = renderer->GetDeferredForFrame();
             renderer->Transition(driver.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
@@ -641,7 +641,7 @@ void Scene::Pass_Lighting(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_Lighting");
+        GPU_SCOPE(t.cl, L"Pass_Lighting");
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(t.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
         renderer->Transition(t.cl, D.gb1.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -712,7 +712,7 @@ void Scene::Pass_PointLights(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_PointLights");
+        GPU_SCOPE(t.cl, L"Pass_PointLights");
 
         const auto& D = renderer->GetDeferredForFrame();
 
@@ -750,7 +750,7 @@ void Scene::Pass_Skybox(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_Skybox");
+        GPU_SCOPE(t.cl, L"Pass_Skybox");
 
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(t.cl, D.light.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
@@ -773,7 +773,7 @@ void Scene::Pass_SSR(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_SSR");
+        GPU_SCOPE(t.cl, L"Pass_SSR");
         const auto& D = renderer->GetDeferredForFrame();
 
         renderer->Transition(t.cl, D.depth.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -813,7 +813,7 @@ void Scene::Pass_SSR_Blur(Renderer* renderer, RenderGraph::PassContext ctx)
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_SSR.Blur");
+        GPU_SCOPE(t.cl, L"Pass_SSR.Blur");
         const auto& D = renderer->GetDeferredForFrame();
         // X Pass---
         renderer->Transition(t.cl, D.ssr.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -870,7 +870,7 @@ void Scene::Pass_Compose(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_Compose");
+        GPU_SCOPE(t.cl, L"Pass_Compose");
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(t.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
         renderer->Transition(t.cl, D.gb1.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -926,7 +926,7 @@ void Scene::Pass_Transparent(Renderer* renderer, RenderGraph::PassContext ctx,
     rgTr.AddPass("Transparent.Driver", {}, [renderer](RenderGraph::PassContext sub) {
         auto driver = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         {
-            GPU_SCOPE(driver.cl, "Transparent.Driver");
+            GPU_SCOPE(driver.cl, L"Transparent.Driver");
             const auto& D = renderer->GetDeferredForFrame();
             renderer->Transition(driver.cl, D.scene.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
             renderer->Transition(driver.cl, D.depth.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE);
@@ -959,7 +959,7 @@ void Scene::Pass_Tonemap(Renderer* renderer, RenderGraph::PassContext ctx)
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_Tonemap");
+        GPU_SCOPE(t.cl, L"Pass_Tonemap");
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(t.cl, D.scene.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
         renderer->RecordBindDefaultsNoClear(t.cl);
@@ -989,7 +989,7 @@ void Scene::Pass_Debug(Renderer* renderer, RenderGraph::PassContext ctx)
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, "Pass_Debug");
+        GPU_SCOPE(t.cl, L"Pass_Debug");
         renderer->RecordBindDefaultsNoClear(t.cl);
 
         auto h = renderer->GetRenderContextPool()->Acquire();
@@ -1013,7 +1013,7 @@ void Scene::Pass_Overlay(Renderer* renderer, RenderGraph::PassContext ctx)
         auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
         {
-            GPU_SCOPE(t.cl, "Pass_Overlay");
+            GPU_SCOPE(t.cl, L"Pass_Overlay");
             renderer->RecordBindDefaultsNoClear(t.cl);
             if (showProfiler_)
             {

--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -164,7 +164,7 @@ void TextManager::AddTextf(RegionId id, float px, const float4& color, const wch
 // ======== СБОРКА / ОТРИСОВКА ========
 void TextManager::Build(Renderer* r, ID3D12GraphicsCommandList* /*cl*/) {
     if (font_ == nullptr) { return; }
-    CPU_SCOPE("TextManager::Build");
+    CPU_SCOPE(L"TextManager::Build");
 
     // 0) Предподсчёт глифов для единого reserve
     size_t totalGlyphs = 0;
@@ -247,7 +247,7 @@ void TextManager::Build(Renderer* r, ID3D12GraphicsCommandList* /*cl*/) {
 }
 
 void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
-    CPU_SCOPE("TextManager::Draw");
+    CPU_SCOPE(L"TextManager::Draw");
     // 1) фон
     if (!rectVerts_.empty() && !rectIdx_.empty() && matRect_) {
         auto h = r->GetRenderContextPool()->Acquire();
@@ -488,7 +488,7 @@ void TextManager::EmitGlyphRun(int x, int y, float xOffset, const float4& color,
 // Позиционная отрисовка теперь тоже через BuildGlyphRun + EmitGlyphRun
 void TextManager::EmitTextImmediate(int x, int y, const float4& color, float px, std::wstring_view text) {
     if (font_ == nullptr) { return; }
-    CPU_SCOPE("TextManager::EmitTextImmediate");
+    CPU_SCOPE(L"TextManager::EmitTextImmediate");
     GlyphRun run;
     float width = 0.0f;
     BuildGlyphRun(text, px, run, width);


### PR DESCRIPTION
## Summary
- remove narrow-string handling from the profiler so scope keys and trace metadata are tracked as wide strings
- delay UTF-8 conversion until `WriteTraceJson` when emitting trace files
- update all CPU and GPU scope usages to pass wide string literals

## Testing
- not run (Windows/DirectX build environment is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cfd9098da88329a47556dd756187e8