### PR TITLE
Implement grow-only text buffers

### DIFF
--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -193,8 +193,8 @@ void TextManager::Build(Renderer* r, ID3D12GraphicsCommandList* /*cl*/) {
         totalGlyphs += rg.glyphCount;
     }
     if (totalGlyphs) {
-        verts_.reserve(verts_.size() + totalGlyphs * 4);
-        idx_.reserve(idx_.size() + totalGlyphs * 6);
+        verts_.ensureAdditional(totalGlyphs * 4);
+        idx_.ensureAdditional(totalGlyphs * 6);
     }
 
     // 1) Резерв под потенциальные фоновые прямоугольники
@@ -473,17 +473,16 @@ void TextManager::EmitGlyphRun(int x, int y, float xOffset, const float4& color,
     }
     if (drawable == 0) { return; }
 
-    verts_.reserve(verts_.size() + drawable * 4);
-    idx_.reserve(idx_.size() + drawable * 6);
+    const size_t vertsToAppend = drawable * 4;
+    const size_t idxToAppend = drawable * 6;
 
-    const size_t baseVert = verts_.size();
-    const size_t baseIdx = idx_.size();
-    verts_.resize(baseVert + drawable * 4);
-    idx_.resize(baseIdx + drawable * 6);
+    const size_t baseVert = verts_.appendUninitialized(vertsToAppend);
+    const size_t baseIdx = idx_.appendUninitialized(idxToAppend);
 
-    Vertex* vPtr = verts_.data() + baseVert;
-    uint32_t* iPtr = idx_.data() + baseIdx;
-    size_t emitted = 0;
+    Vertex* const vData = verts_.data();
+    uint32_t* const iData = idx_.data();
+    size_t vertOffset = baseVert;
+    size_t idxOffset = baseIdx;
 
     for (size_t i = 0; i < n; ++i) {
         const FontGlyph* gph = run.glyphs[i];
@@ -495,18 +494,19 @@ void TextManager::EmitGlyphRun(int x, int y, float xOffset, const float4& color,
         const float gw = float(gph->w) * scale;
         const float gh = float(gph->h) * scale;
 
-        Vertex* curV = vPtr + emitted * 4;
+        const size_t glyphVertBase = vertOffset;
+        Vertex* curV = vData + glyphVertBase;
         curV[0] = { {gx,      gy,      0}, color, {gph->u0, gph->v0} };
         curV[1] = { {gx + gw, gy,      0}, color, {gph->u1, gph->v0} };
         curV[2] = { {gx + gw, gy + gh, 0}, color, {gph->u1, gph->v1} };
         curV[3] = { {gx,      gy + gh, 0}, color, {gph->u0, gph->v1} };
+        vertOffset += 4;
 
-        const uint32_t base = (uint32_t)(baseVert + emitted * 4);
-        uint32_t* curI = iPtr + emitted * 6;
+        const uint32_t base = static_cast<uint32_t>(glyphVertBase);
+        uint32_t* curI = iData + idxOffset;
         curI[0] = base + 0u; curI[1] = base + 1u; curI[2] = base + 2u;
         curI[3] = base + 0u; curI[4] = base + 2u; curI[5] = base + 3u;
-
-        ++emitted;
+        idxOffset += 6;
     }
 }
 

--- a/TextManager.h
+++ b/TextManager.h
@@ -4,6 +4,8 @@
 #include <string_view>
 #include <cstdint>
 #include <optional>
+#include <memory>
+#include <algorithm>
 #include <wrl/client.h>
 #include "Material.h"
 #include "RenderContext.h"
@@ -84,6 +86,59 @@ private:
     };
 
 private:
+    template<typename T>
+    class GrowOnlyArray {
+    public:
+        void clear() noexcept { size_ = 0; }
+        [[nodiscard]] bool empty() const noexcept { return size_ == 0; }
+        [[nodiscard]] size_t size() const noexcept { return size_; }
+        [[nodiscard]] size_t capacity() const noexcept { return capacity_; }
+        [[nodiscard]] T* data() noexcept { return storage_.get(); }
+        [[nodiscard]] const T* data() const noexcept { return storage_.get(); }
+
+        void ensureAdditional(size_t additional) {
+            if (additional == 0) { return; }
+            ensureCapacity(size_ + additional);
+        }
+
+        size_t appendUninitialized(size_t count) {
+            if (count == 0) { return size_; }
+            ensureCapacity(size_ + count);
+            const size_t base = size_;
+            size_ += count;
+            return base;
+        }
+
+    private:
+        void ensureCapacity(size_t required) {
+            if (required <= capacity_) { return; }
+
+            size_t newCapacity = (capacity_ != 0) ? capacity_ : kInitialCapacity;
+            if (newCapacity == 0) { newCapacity = 1; }
+            while (newCapacity < required) {
+                const size_t next = newCapacity * 2;
+                if (next <= newCapacity) { // overflow guard
+                    newCapacity = required;
+                    break;
+                }
+                newCapacity = next;
+            }
+
+            std::unique_ptr<T[]> newStorage = std::make_unique<T[]>(newCapacity);
+            if (storage_) {
+                std::copy_n(storage_.get(), size_, newStorage.get());
+            }
+            storage_.swap(newStorage);
+            capacity_ = newCapacity;
+        }
+
+        static constexpr size_t kInitialCapacity = 256;
+
+        std::unique_ptr<T[]> storage_;
+        size_t size_ = 0;
+        size_t capacity_ = 0;
+    };
+
     static std::wstring UTF8toW(std::string_view s);
 
     // === Общий хелпер построения глиф-рана и ширины ===
@@ -107,8 +162,8 @@ private:
     std::shared_ptr<Material> matText_;
     std::shared_ptr<Material> matRect_;
 
-    std::vector<Vertex>      verts_;
-    std::vector<uint32_t>    idx_;
+    GrowOnlyArray<Vertex>    verts_;
+    GrowOnlyArray<uint32_t>  idx_;
     D3D12_VERTEX_BUFFER_VIEW vbv_{};
     D3D12_INDEX_BUFFER_VIEW  ibv_{};
 


### PR DESCRIPTION
## Summary
- add a grow-only dynamic array helper to TextManager for glyph vertices and indices so allocations only happen when capacity is exhausted
- rewrite glyph run emission and preallocation to append through the grow-only buffers using explicit offsets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0012440fc8329bd8e7bcd77619cb0