### PR TITLE
Refine text glyph run storage and pooling

### DIFF
--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -150,22 +150,26 @@ void TextManager::AddText(RegionId id, float px, const float4& color, std::wstri
     Region& rg = regions_[id];
 
     const size_t charCount = text.size();
-    RegionLine ln = AcquireRegionLine(charCount);
-    ln.color = color;
-    ln.px = px;
-    BuildGlyphRun(text, ln.px, ln.run, ln.widthPx);
-    const size_t glyphReserve = (ln.run.ready ? ln.run.glyphs.size() : charCount);
-    ln.glyphCount = (uint32_t)std::min<size_t>(glyphReserve, std::numeric_limits<uint32_t>::max());
+    RegionLine* ln = AcquireRegionLine(charCount);
+    if (!ln) {
+        return;
+    }
+
+    ln->color = color;
+    ln->px = px;
+    BuildGlyphRun(text, ln->px, ln->run, ln->widthPx);
+    const size_t glyphReserve = (ln->run.ready ? ln->run.size() : charCount);
+    ln->glyphCount = (uint32_t)std::min<size_t>(glyphReserve, std::numeric_limits<uint32_t>::max());
 
     if (rg.autoMeasure || (rg.align != Align::Left)) {
-        rg.maxLineWidth = std::max(rg.maxLineWidth, ln.widthPx);
+        rg.maxLineWidth = std::max(rg.maxLineWidth, ln->widthPx);
     }
     else {
         // для Align::Left + fixedWidth измерение не обязательно (ширина уже в ln.widthPx)
     }
 
     rg.glyphCount += glyphReserve;
-    rg.lines.push_back(std::move(ln));
+    rg.lines.push_back(ln);
     rg.totalLines = (int)rg.lines.size();
     rg.lineStepPx = (int)std::round(px + 2.0f);
 }
@@ -218,14 +222,15 @@ void TextManager::Build(Renderer* r, ID3D12GraphicsCommandList* /*cl*/) {
         // строки
         const float regionW = (rg.fixedWidthPx.has_value() ? rg.fixedWidthPx.value() : rg.maxLineWidth);
         int y = rg.y;
-        for (const RegionLine& ln : rg.lines) {
+        for (const RegionLine* ln : rg.lines) {
+            if (!ln) { continue; }
             float xOff = 0.0f;
             switch (rg.align) {
             case Align::Left: { xOff = 0.0f; break; }
-            case Align::Center: { xOff = std::max(0.0f, 0.5f * (regionW - ln.widthPx)); break; }
-            case Align::Right: { xOff = std::max(0.0f, (regionW - ln.widthPx)); break; }
+            case Align::Center: { xOff = std::max(0.0f, 0.5f * (regionW - ln->widthPx)); break; }
+            case Align::Right: { xOff = std::max(0.0f, (regionW - ln->widthPx)); break; }
             }
-            EmitGlyphRun(rg.x, y, xOff, ln.color, ln.run);
+            EmitGlyphRun(rg.x, y, xOff, ln->color, ln->run);
             y += rg.lineStepPx;
         }
     }
@@ -325,44 +330,45 @@ void TextManager::Clear() {
     regionPool_.clear();
 }
 
-TextManager::RegionLine TextManager::AcquireRegionLine(size_t glyphReserveHint) {
-    RegionLine ln;
-    if (!regionLinePool_.empty()) {
-        ln = std::move(regionLinePool_.back());
-        regionLinePool_.pop_back();
-    }
-
-    ln.color = {};
-    ln.px = 16.0f;
-    ln.widthPx = 0.0f;
-    ln.glyphCount = 0;
-
-    ln.run.glyphs.clear();
-    ln.run.xOffsets.clear();
-    ln.run.scale = 1.0f;
-    ln.run.ready = false;
-
-    if (glyphReserveHint > 0) {
-        if (ln.run.glyphs.capacity() < glyphReserveHint) {
-            ln.run.glyphs.reserve(glyphReserveHint);
-        }
-        if (ln.run.xOffsets.capacity() < glyphReserveHint) {
-            ln.run.xOffsets.reserve(glyphReserveHint);
+TextManager::RegionLine* TextManager::AcquireRegionLine(size_t glyphReserveHint) {
+    RegionLine* ln = nullptr;
+    for (RegionLine& candidate : regionLinePool_) {
+        if (!candidate.inUse) {
+            ln = &candidate;
+            break;
         }
     }
+
+    if (!ln) {
+        regionLinePool_.emplace_back();
+        ln = &regionLinePool_.back();
+    }
+
+    if (!ln) {
+        return nullptr;
+    }
+
+    ln->inUse = true;
+    ln->color = {};
+    ln->px = 16.0f;
+    ln->widthPx = 0.0f;
+    ln->glyphCount = 0;
+    ln->run.Reset();
+
+    assert(glyphReserveHint <= GlyphRun::kDefaultCapacity);
+    (void)glyphReserveHint;
 
     return ln;
 }
 
 void TextManager::RecycleRegionLines() {
     for (Region& rg : regions_) {
-        for (RegionLine& ln : rg.lines) {
-            ln.run.glyphs.clear();
-            ln.run.xOffsets.clear();
-            ln.run.ready = false;
-            ln.widthPx = 0.0f;
-            ln.glyphCount = 0;
-            regionLinePool_.push_back(std::move(ln));
+        for (RegionLine* ln : rg.lines) {
+            if (!ln) { continue; }
+            ln->run.Reset();
+            ln->widthPx = 0.0f;
+            ln->glyphCount = 0;
+            ln->inUse = false;
         }
         rg.lines.clear();
         rg.maxLineWidth = 0.0f;
@@ -376,8 +382,7 @@ void TextManager::RecycleRegionLines() {
 
 // Общий хелпер построения глиф-рана + ширины (один проход)
 void TextManager::BuildGlyphRun(std::wstring_view text, float px, GlyphRun& outRun, float& outWidthPx) const {
-    outRun.glyphs.clear();
-    outRun.xOffsets.clear();
+    outRun.Reset();
     outRun.scale = px / float(font_->PxSize());
     outRun.ready = false;
     outWidthPx = 0.0f;
@@ -387,8 +392,10 @@ void TextManager::BuildGlyphRun(std::wstring_view text, float px, GlyphRun& outR
     const FontAtlas* font = font_;
     const float scale = outRun.scale;
 
-    outRun.glyphs.reserve(text.size());
-    outRun.xOffsets.reserve(text.size());
+    if (text.size() > GlyphRun::kDefaultCapacity) {
+        assert(text.size() <= GlyphRun::kDefaultCapacity);
+    }
+    outRun.Reserve(text.size());
 
     const FontGlyph* glyphSpace = font->Find((uint32_t)L' ');
     const FontGlyph* glyphTab   = font->Find((uint32_t)L'\t');
@@ -445,8 +452,12 @@ void TextManager::BuildGlyphRun(std::wstring_view text, float px, GlyphRun& outR
             }
         }
 
-        outRun.xOffsets.push_back(penX);
-        outRun.glyphs.push_back(gph);
+        if (outRun.size() >= GlyphRun::kDefaultCapacity) {
+            assert(outRun.size() < GlyphRun::kDefaultCapacity);
+            break;
+        }
+
+        outRun.Append(gph, penX);
 
         penX += float(gph->xadv) * scale;
         prev = cp;
@@ -458,17 +469,17 @@ void TextManager::BuildGlyphRun(std::wstring_view text, float px, GlyphRun& outR
 
 // Быстрый эмит с подготовленного глиф-рана
 void TextManager::EmitGlyphRun(int x, int y, float xOffset, const float4& color, const GlyphRun& run) {
-    if (!run.ready || run.glyphs.empty()) { return; }
+    if (!run.ready || run.empty()) { return; }
 
     const float scale = run.scale;
     const float penY = (float)y + float(font_->Ascent()) * scale;
 
-    const size_t n = run.glyphs.size();
+    const size_t n = run.size();
     if (n == 0) { return; }
 
     size_t drawable = 0;
     for (size_t i = 0; i < n; ++i) {
-        const FontGlyph* gph = run.glyphs[i];
+        const FontGlyph* gph = run.GlyphAt(i);
         if (gph && gph->w != 0 && gph->h != 0) { ++drawable; }
     }
     if (drawable == 0) { return; }
@@ -485,9 +496,9 @@ void TextManager::EmitGlyphRun(int x, int y, float xOffset, const float4& color,
     size_t idxOffset = baseIdx;
 
     for (size_t i = 0; i < n; ++i) {
-        const FontGlyph* gph = run.glyphs[i];
+        const FontGlyph* gph = run.GlyphAt(i);
         if (!gph || gph->w == 0 || gph->h == 0) { continue; }
-        const float penX = (float)x + xOffset + run.xOffsets[i];
+        const float penX = (float)x + xOffset + run.XOffsetAt(i);
 
         const float gx = penX + float(gph->xoff) * scale;
         const float gy = penY + float(gph->yoff) * scale;

--- a/TextManager.h
+++ b/TextManager.h
@@ -1,10 +1,14 @@
 #pragma once
 #include <vector>
+#include <list>
+#include <array>
+#include <cassert>
 #include <string>
 #include <string_view>
 #include <cstdint>
 #include <optional>
 #include <memory>
+#include <utility>
 #include <algorithm>
 #include <wrl/client.h>
 #include "Material.h"
@@ -55,10 +59,48 @@ private:
 
     // Предподсчитанный «глиф-ран» одной строки
     struct GlyphRun {
-        std::vector<const struct FontGlyph*> glyphs; // ptr на глифы в атласе
-        std::vector<float> xOffsets;                 // кумулятивные X до каждого глифа (с кернингом)
-        float scale = 1.0f;                          // px / fontPx
+        static constexpr size_t kDefaultCapacity = 256;
+
+        std::array<const struct FontGlyph*, kDefaultCapacity> glyphs{}; // ptr на глифы в атласе
+        std::array<float, kDefaultCapacity> xOffsets{};                  // кумулятивные X до каждого глифа (с кернингом)
+        size_t glyphCount = 0;
+        float scale = 1.0f;   // px / fontPx
         bool  ready = false;
+
+        void Reset() {
+            glyphCount = 0;
+            scale = 1.0f;
+            ready = false;
+        }
+
+        void Reserve(size_t desired) {
+            if (desired > kDefaultCapacity) {
+                assert(desired <= kDefaultCapacity);
+            }
+            (void)desired;
+        }
+
+        void Append(const struct FontGlyph* glyph, float xOffset) {
+            if (glyphCount >= kDefaultCapacity) {
+                assert(glyphCount < kDefaultCapacity);
+                return;
+            }
+            glyphs[glyphCount] = glyph;
+            xOffsets[glyphCount] = xOffset;
+            ++glyphCount;
+        }
+
+        [[nodiscard]] size_t size() const noexcept { return glyphCount; }
+        [[nodiscard]] bool empty() const noexcept { return glyphCount == 0; }
+        [[nodiscard]] size_t capacity() const noexcept { return kDefaultCapacity; }
+        [[nodiscard]] const struct FontGlyph* GlyphAt(size_t index) const noexcept {
+            assert(index < glyphCount);
+            return glyphs[index];
+        }
+        [[nodiscard]] float XOffsetAt(size_t index) const noexcept {
+            assert(index < glyphCount);
+            return xOffsets[index];
+        }
     };
 
     struct RegionLine {
@@ -67,6 +109,7 @@ private:
         float    widthPx = 0;   // ширина строки (для Center/Right)
         GlyphRun run;           // кэш глифов/офсетов
         uint32_t glyphCount = 0; // запас по глифам для резерва
+        bool     inUse = false;
     };
 
     struct Region {
@@ -78,7 +121,7 @@ private:
         std::optional<float> fixedWidthPx; // если есть — используем для фона/выравнивания
         bool  autoMeasure = true;          // если false и Align::Left — измерение строк не требуется
 
-        std::vector<RegionLine> lines;
+        std::vector<RegionLine*> lines;
         float maxLineWidth = 0;
         int   totalLines = 0;
         int   lineStepPx = 18;
@@ -153,7 +196,7 @@ private:
     // Рисунок прямоугольника (фон)
     void  EmitRect(int x, int y, float w, float h, const float4& color);
 
-    RegionLine AcquireRegionLine(size_t glyphReserveHint);
+    RegionLine* AcquireRegionLine(size_t glyphReserveHint);
     void       RecycleRegionLines();
 
 private:
@@ -174,7 +217,7 @@ private:
 
     std::vector<Region> regions_;
     std::vector<Region> regionPool_;
-    std::vector<RegionLine> regionLinePool_;
+    std::list<RegionLine> regionLinePool_;
 
     UINT  vpW_ = 1, vpH_ = 1;
     float dpi_ = 1.0f;


### PR DESCRIPTION
## Summary
- store glyph run data in fixed 256-entry std::arrays and guard overflow with assertions during build and append
- update region line pooling to reuse entries from a single list using an in-use flag instead of maintaining active/pool lists
- adjust glyph run builders to stop emitting once the fixed capacity is hit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d000714e448329adcf26514e966351