### PR TITLE
Refresh constant buffer handles after shader reloads

### DIFF
--- a/DebugGrid.cpp
+++ b/DebugGrid.cpp
@@ -84,6 +84,15 @@ public:
         UpdateGraphicsUniform(mvpHandle_, mvp, cbData);
     }
 
+    void OnMaterialHotReload(Renderer* renderer) override
+    {
+        RenderableObject::OnMaterialHotReload(renderer);
+        if (auto* material = GetGraphicsMaterial())
+        {
+            mvpHandle_ = material->ComputeCBFieldHandle(0, "modelViewProj");
+        }
+    }
+
     void IssueDraw(Renderer* /*renderer*/, ID3D12GraphicsCommandList* cl) override
     {
         cl->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_LINELIST);
@@ -201,6 +210,16 @@ public:
         const UINT w = r->GetWidth();
         const UINT h = r->GetHeight();
         UpdateGraphicsUniform(viewportThicknessHandle_, float4(float(w), float(h), thicknessPx_, 0.0f), cbData);
+    }
+
+    void OnMaterialHotReload(Renderer* renderer) override
+    {
+        RenderableObject::OnMaterialHotReload(renderer);
+        if (auto* material = GetGraphicsMaterial())
+        {
+            mvpHandle_ = material->ComputeCBFieldHandle(0, "modelViewProj");
+            viewportThicknessHandle_ = material->ComputeCBFieldHandle(0, "viewportThickness");
+        }
     }
 
     void IssueDraw(Renderer* /*renderer*/, ID3D12GraphicsCommandList* cl) override

--- a/Material.cpp
+++ b/Material.cpp
@@ -877,17 +877,20 @@ bool MaterialManager::RequestFSProbeAsync()
     return true;
 }
 
-void MaterialManager::ApplyPendingHotReloads(Renderer* r, uint64_t frameNumber, uint64_t keepAliveFrames)
+bool MaterialManager::ApplyPendingHotReloads(Renderer* r, uint64_t frameNumber, uint64_t keepAliveFrames)
 {
+    bool anyReloaded = false;
     for (auto& kv : materials_) {
         auto& mat = kv.second;
         if (mat) {
             if (mat->HotReloadIfPending(r, frameNumber, keepAliveFrames)) {
+                anyReloaded = true;
                 // лог: пересобрали
             }
             mat->CollectRetired(frameNumber, keepAliveFrames);
         }
     }
+    return anyReloaded;
 }
 
 const Material::CBufferInfo* Material::GetCBInfo(UINT bRegister) const {

--- a/Material.h
+++ b/Material.h
@@ -245,7 +245,7 @@ public:
     }
 
     bool RequestFSProbeAsync();
-    void ApplyPendingHotReloads(Renderer* r, uint64_t frameIndex, uint64_t keepAliveFrames);
+    bool ApplyPendingHotReloads(Renderer* r, uint64_t frameIndex, uint64_t keepAliveFrames);
     bool IsProbeInFlight() const { return fsProbeInFlight_.load(std::memory_order_acquire); }
 
     void Clear() { materials_.clear(); }

--- a/PointLight.cpp
+++ b/PointLight.cpp
@@ -184,3 +184,8 @@ void PointLight::RenderColor(Renderer* r, ID3D12GraphicsCommandList* cl,
     cl->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
     cl->DrawInstanced(3, 1, 0, 0);
 }
+
+void PointLight::OnMaterialHotReload()
+{
+    RebuildHandleCache();
+}

--- a/PointLight.h
+++ b/PointLight.h
@@ -31,6 +31,8 @@ public:
                      const Math::mat4& invView, const Math::mat4& invProj,
                      const Math::float3& camPos);
 
+    void OnMaterialHotReload();
+
 private:
     Math::mat4 BuildModel() const;
 

--- a/RenderableObject.cpp
+++ b/RenderableObject.cpp
@@ -161,6 +161,11 @@ void RenderableObject::RecordShadow(Renderer* renderer, ID3D12GraphicsCommandLis
     shadowMaterial_->Bind(cl, ctx, false);
 }
 
+void RenderableObject::OnMaterialHotReload(Renderer* /*renderer*/)
+{
+    RebuildHandleCaches();
+}
+
 void RenderableObject::RebuildHandleCaches()
 {
     cb0Handles_ = {};

--- a/RenderableObject.h
+++ b/RenderableObject.h
@@ -29,6 +29,7 @@ public:
     // Базовый отрисовщик: Compute -> Graphics (Bind/IssueDraw)
     virtual void Render(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& view, const mat4& proj);
     virtual void RenderShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& lightView, const mat4& lightProj);
+    virtual void OnMaterialHotReload(Renderer* renderer);
 
     // Трансформ
     const Math::mat4& GetModelMatrix() const { return modelMatrix_; }

--- a/RenderableObjectBase.h
+++ b/RenderableObjectBase.h
@@ -17,4 +17,5 @@ public:
     virtual bool IsTransparent() const = 0;
     virtual bool IsSimpleRender() const = 0;
     virtual bool CastsShadow() const = 0;
+    virtual void OnMaterialHotReload(Renderer* renderer) {}
 };

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -432,8 +432,17 @@ void Renderer::Tick(float dt)
         }
 
         // 2) применим pending-пересборки (если скан что-то нашёл и флаг выставлен)
-        materialManager_.ApplyPendingHotReloads(this, totalFrameNumber_, /*keepAliveFrames=*/kFrameCount + 1);
+        if (materialManager_.ApplyPendingHotReloads(this, totalFrameNumber_, /*keepAliveFrames=*/kFrameCount + 1)) {
+            materialsHotReloaded_ = true;
+        }
     }
+}
+
+bool Renderer::ConsumeMaterialHotReloadFlag()
+{
+    bool wasReloaded = materialsHotReloaded_;
+    materialsHotReloaded_ = false;
+    return wasReloaded;
 }
 
 Renderer::ThreadCL Renderer::BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE type, ID3D12PipelineState* pso)

--- a/Renderer.h
+++ b/Renderer.h
@@ -65,6 +65,7 @@ public:
     void EndFrame();                   // барьер RT->Present, Execute, Present, сигнал фэнса
 
     void Tick(float dt);
+    bool ConsumeMaterialHotReloadFlag();
 
     void CreateDeferredTargets(UINT width, UINT height);
     void DestroyDeferredTargets();
@@ -249,6 +250,7 @@ private:
     bool     shaderHotReloadEnabled_ = true;
     float    shaderWatchIntervalSec_ = 1.0f; // раз в секунду
     float    shaderWatchAccumSec_ = 0.0f;
+    bool     materialsHotReloaded_ = false;
 
     // D3D12 core
     ComPtr<ID3D12Device>              device_;

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -75,6 +75,46 @@ void Scene::CBHandleCache::ComposeHandles::Populate(Material* material)
     skyboxIntensity = material->ComputeCB0FieldHandle("skyboxIntensity");
 }
 
+void Scene::RefreshCachedHandles(Renderer* renderer)
+{
+    cbHandles_ = {};
+
+    if (matLighting_)
+    {
+        cbHandles_.lighting.Populate(matLighting_.get());
+    }
+    if (matCompose_)
+    {
+        cbHandles_.compose.Populate(matCompose_.get());
+    }
+    if (matSSR_)
+    {
+        cbHandles_.ssr.Populate(matSSR_.get());
+    }
+    if (matBlur_)
+    {
+        cbHandles_.blur.Populate(matBlur_.get());
+    }
+
+    for (auto& light : pointLights_)
+    {
+        light.OnMaterialHotReload();
+    }
+
+    for (auto& obj : objects_)
+    {
+        if (obj)
+        {
+            obj->OnMaterialHotReload(renderer);
+        }
+    }
+
+    if (skyBox_)
+    {
+        skyBox_->OnMaterialHotReload(renderer);
+    }
+}
+
 static void BuildFrustumSliceCornersWS(const mat4& invView, const mat4& invProj,
     float zNearVS, float zFarVS, std::array<float3, 8>& outCornersWS)
 {
@@ -147,7 +187,6 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
         gd.depth.DepthEnable = FALSE;
         matLighting_ = renderer->GetMaterialManager()->GetOrCreateGraphics(renderer, gd);
     }
-    cbHandles_.lighting.Populate(matLighting_.get());
 
     if (!matCompose_) {
         Material::GraphicsDesc gd{};
@@ -159,7 +198,6 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
         gd.depth.DepthEnable = FALSE;
         matCompose_ = renderer->GetMaterialManager()->GetOrCreateGraphics(renderer, gd);
     }
-    cbHandles_.compose.Populate(matCompose_.get());
 
     if (!matTonemap_) {
         Material::GraphicsDesc gd{};
@@ -180,7 +218,6 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
         gd.depth.DepthEnable = FALSE;
         matSSR_ = renderer->GetMaterialManager()->GetOrCreateGraphics(renderer, gd);
     }
-    cbHandles_.ssr.Populate(matSSR_.get());
 
     if (!matBlur_) {
         Material::GraphicsDesc gd{};
@@ -190,7 +227,6 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
         gd.depth.DepthEnable = FALSE;
         matBlur_ = renderer->GetMaterialManager()->GetOrCreateGraphics(renderer, gd);
     }
-    cbHandles_.blur.Populate(matBlur_.get());
 
     if (!matDebug_) {
         Material::GraphicsDesc gd{};
@@ -274,6 +310,8 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
     {
         obj->Init(renderer, uploadCmdList, uploadKeepAlive);
     }
+
+    RefreshCachedHandles(renderer);
 }
 
 void Scene::AddObject(std::unique_ptr<RenderableObjectBase> obj) {
@@ -316,6 +354,11 @@ void Scene::Render(Renderer* renderer) {
 
     if (actions_->WasActionPressed("Wireframe", *input_)) {
         renderer->SetWireframeMode(!renderer->GetWireframeMode());
+    }
+
+    if (renderer->ConsumeMaterialHotReloadFlag())
+    {
+        RefreshCachedHandles(renderer);
     }
 
     auto* tb = renderer->GetTextManager();

--- a/Scene.h
+++ b/Scene.h
@@ -28,6 +28,8 @@ public:
     void Clear();
 
 private:
+    void RefreshCachedHandles(Renderer* renderer);
+
     enum class ObjectRenderType { OpaqueSimple, OpaqueComplex, TransparentSimple, TransparentComplex };
     static constexpr size_t kRenderTypeCount = 4;
     using ObjectBucket = std::vector<RenderableObjectBase*>;

--- a/Skybox.cpp
+++ b/Skybox.cpp
@@ -39,6 +39,17 @@ void Skybox::Init(Renderer* renderer,
     }
 }
 
+void Skybox::OnMaterialHotReload(Renderer* renderer)
+{
+    RenderableObject::OnMaterialHotReload(renderer);
+    if (auto* material = GetGraphicsMaterial())
+    {
+        viewHandle_ = material->ComputeCBFieldHandle(0, "view");
+        projHandle_ = material->ComputeCBFieldHandle(0, "proj");
+        exposureHandle_ = material->ComputeCBFieldHandle(0, "exposure");
+    }
+}
+
 void Skybox::UpdateUniforms(Renderer* /*renderer*/, const mat4& view, const mat4& proj, uint8_t* cbData)
 {
     // CB0: ожидаем идентификаторы "view" и "proj" в cbuffer'е (см. skybox.hlsl)

--- a/Skybox.h
+++ b/Skybox.h
@@ -32,6 +32,7 @@ protected:
     // пер-кадровые константы и дескрипторы
     void UpdateUniforms(Renderer* renderer, const mat4& view, const mat4& proj, uint8_t* cbData) override;
     void PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx) override;
+    void OnMaterialHotReload(Renderer* renderer) override;
 
     // рисуем обычным путём базового класса:
     // RecordGraphics/IssueDraw наследуем без изменений.


### PR DESCRIPTION
## Summary
- have MaterialManager report when a hot reload succeeds so the renderer can track pending material updates
- refresh scene constant-buffer handle caches after hot reloads and when initializing the scene
- let renderables, debug helpers, the skybox, and point lights rebuild their cached constant-buffer handles when notified

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d04bd7bf608329bbf530d4a349ae2b