### PR TITLE
Refine task system waits and isolate async frame jobs

### DIFF
--- a/App.cpp
+++ b/App.cpp
@@ -170,7 +170,8 @@ void App::Run(HINSTANCE hInstance, int nCmdShow) {
         Profiler::Get().EndFrame();
     }
 
-    scene_.Clear();
-
     TaskSystem::Get().Stop();
+
+    scene_.Clear();
+    renderer_.Shutdown();
 }

--- a/Material.cpp
+++ b/Material.cpp
@@ -872,9 +872,14 @@ bool MaterialManager::RequestFSProbeAsync()
             }
         }
         fsProbeInFlight_.store(false, std::memory_order_release);
-        });
+    });
 
     return true;
+}
+
+void MaterialManager::Clear()
+{
+    materials_.clear();
 }
 
 bool MaterialManager::ApplyPendingHotReloads(Renderer* r, uint64_t frameNumber, uint64_t keepAliveFrames)

--- a/Material.h
+++ b/Material.h
@@ -248,7 +248,7 @@ public:
     bool ApplyPendingHotReloads(Renderer* r, uint64_t frameIndex, uint64_t keepAliveFrames);
     bool IsProbeInFlight() const { return fsProbeInFlight_.load(std::memory_order_acquire); }
 
-    void Clear() { materials_.clear(); }
+    void Clear();
 
 private:
     // key → material

--- a/Profiler.cpp
+++ b/Profiler.cpp
@@ -147,8 +147,9 @@ void Profiler::EndFrame() {
     if (!GetEnabled()) { return; }
 
     // 0) ждём прошлую асинхронную сборку (минимум работы в главном потоке)
-    TaskSystem::Get().Wait(overlayTask_);
-    overlayTask_ = nullptr;
+    TaskSystem& tasks = TaskSystem::Get();
+    tasks.Wait(overlayTask_);
+    tasks.Release(overlayTask_);
 
     // 1) заберём сэмплы текущего кадра и закроем кадр (быстро)
     std::vector<ScopeSample> samples;

--- a/RenderGraph.h
+++ b/RenderGraph.h
@@ -120,7 +120,12 @@ public:
         }
 
         for (size_t i = 0; i < N; ++i) {
-            tasks.Wait(passDoneScratch_[i]);
+            if (passDoneScratch_[i]) {
+                tasks.Wait(passDoneScratch_[i]);
+            }
+        }
+        for (size_t i = N; i-- > 0;) {
+            tasks.Release(passDoneScratch_[i]);
         }
     }
 

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -16,13 +16,10 @@ Renderer::Renderer()
 }
 
 Renderer::~Renderer() {
-    // 1) Полный аккуратный teardown
-    Shutdown();
-
-    // 2) Теперь отчёт — уже после того, как мы всё обнулили
+    // Отчёт — уже после того, как мы всё обнулили
     ReportLiveObjects(); // если у тебя есть эта функция в сборке дебага
 
-    // 3) Закрываем событие в самом конце
+    // Закрываем событие в самом конце
     if (fenceEvent_ != nullptr) {
         CloseHandle(fenceEvent_);
         fenceEvent_ = nullptr;

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -368,6 +368,8 @@ void Scene::Render(Renderer* renderer) {
 
     renderer->BeginSubmitTimeline();
 
+    TaskSystem::Get().WaitForTrackedAsyncTasks();
+
     // матрицы кадра и параметры камеры/света (как у тебя)
     const float aspect = float(renderer->GetWidth()) / float(renderer->GetHeight());
     const mat4 view = camera_.GetViewMatrix();
@@ -460,10 +462,10 @@ void Scene::Render(Renderer* renderer) {
 
     rg.ExecuteParallel(renderer, TaskSystem::Get());
     //rg.Execute(renderer);
-    
+
     {
-        CPU_SCOPE(L"Main Wait");
-        TaskSystem::Get().WaitForAll();
+        CPU_SCOPE(L"Frame Async Wait");
+        TaskSystem::Get().WaitForTrackedAsyncTasks();
     }
 
     RenderGraph epilogueRG;
@@ -472,8 +474,8 @@ void Scene::Render(Renderer* renderer) {
     epilogueRG.Execute(renderer);
     
     {
-        CPU_SCOPE(L"Last Wait");
-        TaskSystem::Get().WaitForAll();
+        CPU_SCOPE(L"Overlay Async Wait");
+        TaskSystem::Get().WaitForTrackedAsyncTasks();
     }
     renderer->EndFrame();
 }
@@ -493,7 +495,7 @@ void Scene::RenderObjectBatch(Renderer* renderer,
     const size_t N = objects.size();
     const size_t chunkSize = 16;
 
-    tasks.DispatchDetach((N + chunkSize - 1) / chunkSize,
+    tasks.DispatchTrack((N + chunkSize - 1) / chunkSize,
         [renderer, view, proj, &objects, useBundles, chunkSize, batchIndex, bindGbufOrScene](std::size_t jobIndex)
         {
             CPU_SCOPE(L"RenderObjectBatch.Async");
@@ -551,7 +553,7 @@ void Scene::RenderShadowBatch(Renderer* renderer,
         chunkSize = 32;
     }
 
-    tasks.DispatchDetach((N + chunkSize - 1) / chunkSize,
+    tasks.DispatchTrack((N + chunkSize - 1) / chunkSize,
         [renderer, &objects, &lightView, &lightProj, cascadeIndex, chunkSize, batchIndex](std::size_t jobIndex)
         {
             CPU_SCOPE(L"RenderShadowBatch.Async");
@@ -559,21 +561,21 @@ void Scene::RenderShadowBatch(Renderer* renderer,
             const size_t end = std::min(begin + chunkSize, objects.size());
 
             // каждый чанк — отдельный direct CL
-              auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
-              t.cl->SetName(L"RenderShadowBatch");
-              {
-                  GPU_SCOPE(t.cl, L"RenderShadowBatch");
+            auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
+            t.cl->SetName(L"RenderShadowBatch");
+            {
+                GPU_SCOPE(t.cl, L"RenderShadowBatch");
 
-                  // важное: привязываем нужный тайл атласа каскада, без очистки
-                  renderer->BindShadowTarget(t.cl, cascadeIndex, /*clear=*/false);
+                // важное: привязываем нужный тайл атласа каскада, без очистки
+                renderer->BindShadowTarget(t.cl, cascadeIndex, /*clear=*/false);
 
-                  for (size_t i = begin; i < end; ++i) {
-                      if (auto* obj = objects[i]) {
-                          obj->RenderShadow(renderer, t.cl, lightView, lightProj);
-                      }
-                  }
-              }
-              renderer->EndThreadCommandList(t, batchIndex);
+                for (size_t i = begin; i < end; ++i) {
+                    if (auto* obj = objects[i]) {
+                        obj->RenderShadow(renderer, t.cl, lightView, lightProj);
+                    }
+                }
+            }
+            renderer->EndThreadCommandList(t, batchIndex);
         }, 1);
 }
 
@@ -614,7 +616,8 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
     cachedSplitsVS_[3] = 100.0f;
     cachedSplitsVS_[4] = zFarShadow;
 
-    auto cascades = TaskSystem::Get().Dispatch(kCascades, [this, renderer, &buckets, &invView, &invProj, &proj, camDir, sunDirWS = dirLight_.dir, batchIndex](std::size_t idx)
+    TaskSystem& tasks = TaskSystem::Get();
+    tasks.DispatchWait(kCascades, [this, renderer, &buckets, &invView, &invProj, &proj, camDir, sunDirWS = dirLight_.dir, batchIndex](std::size_t idx)
     {
         CPU_SCOPE(L"CSM.PerCascade");
         const auto& D = renderer->GetDeferredForFrame();
@@ -697,7 +700,6 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
             RenderShadowBatch(renderer, opaqueComplex, batchIndex, cachedLightView_[idx], cachedLightProj_[idx], (UINT)idx, /*chunk*/32);
         }
     }, 1);
-    TaskSystem::Get().Wait(cascades);
 }
 
 void Scene::Pass_GBuffer(Renderer* renderer, RenderGraph::PassContext ctx,
@@ -1143,6 +1145,8 @@ void Scene::Pass_Overlay(Renderer* renderer, RenderGraph::PassContext ctx)
 
 void Scene::Clear()
 {
+    TaskSystem::Get().WaitForTrackedAsyncTasks();
+
     matLighting_.reset();
     matCompose_.reset();
     matTonemap_.reset();

--- a/Scene.h
+++ b/Scene.h
@@ -164,4 +164,5 @@ private:
     DirectionalLight dirLight_;
 
     std::unique_ptr<Skybox> skyBox_;
+
 };

--- a/TaskSystem.cpp
+++ b/TaskSystem.cpp
@@ -123,6 +123,21 @@ TaskSystem::TaskHandle TaskSystem::Dispatch(std::size_t jobCount,
     return handle;
 }
 
+void TaskSystem::DispatchTrack(std::size_t jobCount,
+                         std::function<void(std::size_t)> fn,
+                         std::size_t batchSize) {
+    TaskHandle handle = Dispatch(jobCount, std::move(fn), batchSize);
+    TrackFrameTask(handle);
+}
+
+void TaskSystem::DispatchWait(std::size_t jobCount,
+                        std::function<void(std::size_t)> fn,
+                        std::size_t batchSize) {
+    TaskHandle handle = Dispatch(jobCount, std::move(fn), batchSize);
+    Wait(handle);
+    Release(handle);
+}
+
 void TaskSystem::DispatchDetach(std::size_t jobCount,
                           std::function<void(std::size_t)> fn,
                           std::size_t batchSize) {
@@ -135,7 +150,37 @@ void TaskSystem::DispatchDetach(std::size_t jobCount,
 void TaskSystem::Wait(TaskHandle handle) {
     if (handle) {
         scheduler_.WaitforTask(handle);
+    }
+}
+
+void TaskSystem::Release(TaskHandle& handle) {
+    if (handle) {
         delete handle;
+        handle = nullptr;
+    }
+}
+
+void TaskSystem::TrackFrameTask(TaskHandle handle) {
+    if (!handle) { return; }
+    std::lock_guard<std::mutex> lk(trackedFrameMutex_);
+    trackedFrameTasks_.push_back(handle);
+}
+
+void TaskSystem::WaitForTrackedAsyncTasks() {
+    std::vector<TaskHandle> handles;
+    {
+        std::lock_guard<std::mutex> lk(trackedFrameMutex_);
+        if (trackedFrameTasks_.empty()) {
+            return;
+        }
+        handles.swap(trackedFrameTasks_);
+    }
+
+    for (auto& h : handles) {
+        Wait(h);
+    }
+    for (auto& h : handles) {
+        Release(h);
     }
 }
 

--- a/TaskSystem.h
+++ b/TaskSystem.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <memory>
 #include <initializer_list>
+#include <mutex>
 
 #include "third_party/enkiTS/src/TaskScheduler.h"
 
@@ -31,6 +32,12 @@ public:
     TaskHandle Dispatch(std::size_t jobCount,
                         std::function<void(std::size_t)> fn,
                         std::size_t batchSize = 1);
+    void DispatchTrack(std::size_t jobCount,
+                       std::function<void(std::size_t)> fn,
+                       std::size_t batchSize = 1);
+    void DispatchWait(std::size_t jobCount,
+                      std::function<void(std::size_t)> fn,
+                      std::size_t batchSize = 1);
 
     // fire-and-forget versions (auto delete)
     void SubmitDetach(Task t);
@@ -39,19 +46,21 @@ public:
                         std::size_t batchSize = 1);
 
     void Wait(TaskHandle handle);
+    void Release(TaskHandle& handle);
+
+    void TrackFrameTask(TaskHandle handle);
+    void WaitForTrackedAsyncTasks();
 
     template<class F>
     static void ParallelFor(std::size_t jobCount, F&& fn, std::size_t batchSize)
     {
-        auto h = Get().Dispatch(jobCount, std::forward<F>(fn), batchSize);
-        Get().Wait(h);
+        Get().DispatchWait(jobCount, std::forward<F>(fn), batchSize);
     }
 
     template<class F>
     static void ParallelForNoHelp(std::size_t jobCount, F&& fn, std::size_t batchSize)
     {
-        auto h = Get().Dispatch(jobCount, std::forward<F>(fn), batchSize);
-        Get().Wait(h);
+        Get().DispatchWait(jobCount, std::forward<F>(fn), batchSize);
     }
 
     void WaitForAll();
@@ -67,5 +76,7 @@ private:
 
 private:
     enki::TaskScheduler scheduler_;
+    std::vector<TaskHandle> trackedFrameTasks_;
+    std::mutex trackedFrameMutex_;
 };
 


### PR DESCRIPTION
## Summary
- add explicit TaskSystem::Release to separate waiting from destruction and clean up render graph pass handles
- add TaskSystem helpers (DispatchTrack/DispatchWait) for tracking frame-local async work so Scene can drop global WaitForAll barriers while safely waiting on recorded command list jobs
- keep the shader hot-reload probe on a detached task now that teardown waits for the scheduler to stop
- stop the task system before tearing down the scene, invoke renderer shutdown explicitly, and leave the destructor to report live objects only

## Testing
- not run (not supported)

------
https://chatgpt.com/codex/tasks/task_e_68cffed4bddc83298732c3cdffc75a32