### PR TITLE
Add task pooling to TaskSystem

### DIFF
--- a/TaskSystem.cpp
+++ b/TaskSystem.cpp
@@ -1,5 +1,8 @@
 #include "TaskSystem.h"
 
+#include <new>
+#include <utility>
+
 TaskSystem& TaskSystem::Get() {
     static TaskSystem g;
     return g;
@@ -7,6 +10,7 @@ TaskSystem& TaskSystem::Get() {
 
 TaskSystem::~TaskSystem() {
     Stop();
+    ClearPools();
 }
 
 void TaskSystem::Start(unsigned threadCount) {
@@ -21,16 +25,15 @@ void TaskSystem::Stop() {
     scheduler_.WaitforAllAndShutdown();
 }
 
-namespace {
-struct TaskWithDeps : enki::ITaskSet {
+struct TaskSystem::TaskWithDeps : enki::ITaskSet {
     std::vector<enki::Dependency> deps;
     TaskWithDeps(uint32_t range, size_t depCount)
         : enki::ITaskSet(range), deps(depCount) {}
 };
 
-struct LambdaTaskSet : TaskWithDeps {
-    TaskSystem::Task fn;
-    LambdaTaskSet(TaskSystem::Task&& f, size_t depCount)
+struct TaskSystem::LambdaTaskSet : TaskWithDeps {
+    Task fn;
+    LambdaTaskSet(Task&& f, size_t depCount)
         : TaskWithDeps(1, depCount), fn(std::move(f)) {}
     void ExecuteRange(enki::TaskSetPartition, uint32_t) override {
         if (fn) {
@@ -39,7 +42,7 @@ struct LambdaTaskSet : TaskWithDeps {
     }
 };
 
-struct RangeTaskSet : TaskWithDeps {
+struct TaskSystem::RangeTaskSet : TaskWithDeps {
     std::function<void(std::size_t)> fn;
     RangeTaskSet(std::size_t count, std::function<void(std::size_t)> f, size_t depCount)
         : TaskWithDeps(static_cast<uint32_t>(count), depCount), fn(std::move(f)) {}
@@ -50,31 +53,43 @@ struct RangeTaskSet : TaskWithDeps {
     }
 };
 
-// Helper which deletes the associated task once it completes.
-struct AutoDelete : enki::ICompletable {
+struct TaskSystem::AutoDelete : enki::ICompletable {
+    enum class Kind { Lambda, Range };
+
+    TaskSystem& owner;
     enki::ITaskSet* task;
+    Kind kind;
     enki::Dependency dep;
-    explicit AutoDelete(enki::ITaskSet* t) : task(t) {
+
+    AutoDelete(TaskSystem& sys, enki::ITaskSet* t, Kind k)
+        : owner(sys), task(t), kind(k) {
         SetDependency(dep, task);
     }
+
     void OnDependenciesComplete(enki::TaskScheduler* pTS, uint32_t thread) override {
         ICompletable::OnDependenciesComplete(pTS, thread);
-        delete task;
-        delete this;
+        switch (kind) {
+        case Kind::Lambda:
+            owner.RecycleLambdaTask(static_cast<LambdaTaskSet*>(task));
+            break;
+        case Kind::Range:
+            owner.RecycleRangeTask(static_cast<RangeTaskSet*>(task));
+            break;
+        }
+        owner.RecycleAutoDelete(this);
     }
 };
-}
 
 TaskSystem::TaskHandle TaskSystem::Submit(Task t) {
     if (!t) { return nullptr; }
-    auto* taskPtr = new LambdaTaskSet(std::move(t), 0);
+    auto* taskPtr = AcquireLambdaTask(std::move(t), 0);
     scheduler_.AddTaskSetToPipe(taskPtr);
     return taskPtr;
 }
 
 TaskSystem::TaskHandle TaskSystem::CreateTask(Task t, std::size_t depCount) {
     if (!t) { return nullptr; }
-    auto* taskPtr = new LambdaTaskSet(std::move(t), depCount);
+    auto* taskPtr = AcquireLambdaTask(std::move(t), depCount);
     return taskPtr;
 }
 
@@ -83,9 +98,7 @@ TaskSystem::TaskHandle TaskSystem::CreateRangeTask(std::size_t jobCount,
                          std::size_t batchSize,
                          std::size_t depCount) {
     if (jobCount == 0 || !fn) { return nullptr; }
-    if (batchSize == 0) { batchSize = 1; }
-    auto* taskPtr = new RangeTaskSet(jobCount, std::move(fn), depCount);
-    taskPtr->m_MinRange = static_cast<uint32_t>(batchSize);
+    auto* taskPtr = AcquireRangeTask(jobCount, std::move(fn), batchSize, depCount);
     return taskPtr;
 }
 
@@ -110,8 +123,8 @@ void TaskSystem::Submit(TaskHandle handle) {
 
 void TaskSystem::SubmitDetach(Task t) {
     if (!t) { return; }
-    auto* taskPtr = new LambdaTaskSet(std::move(t), 0);
-    new AutoDelete(taskPtr);
+    auto* taskPtr = AcquireLambdaTask(std::move(t), 0);
+    AcquireAutoDelete(taskPtr, AutoDelete::Kind::Lambda);
     scheduler_.AddTaskSetToPipe(taskPtr);
 }
 
@@ -141,9 +154,10 @@ void TaskSystem::DispatchWait(std::size_t jobCount,
 void TaskSystem::DispatchDetach(std::size_t jobCount,
                           std::function<void(std::size_t)> fn,
                           std::size_t batchSize) {
-    auto* taskPtr = static_cast<enki::ITaskSet*>(CreateRangeTask(jobCount, std::move(fn), batchSize));
+    TaskHandle taskHandle = CreateRangeTask(jobCount, std::move(fn), batchSize);
+    auto* taskPtr = static_cast<RangeTaskSet*>(taskHandle);
     if (!taskPtr) { return; }
-    new AutoDelete(taskPtr);
+    AcquireAutoDelete(taskPtr, AutoDelete::Kind::Range);
     scheduler_.AddTaskSetToPipe(taskPtr);
 }
 
@@ -155,7 +169,13 @@ void TaskSystem::Wait(TaskHandle handle) {
 
 void TaskSystem::Release(TaskHandle& handle) {
     if (handle) {
-        delete handle;
+        if (auto* lambda = dynamic_cast<LambdaTaskSet*>(handle)) {
+            RecycleLambdaTask(lambda);
+        } else if (auto* range = dynamic_cast<RangeTaskSet*>(handle)) {
+            RecycleRangeTask(range);
+        } else {
+            delete handle;
+        }
         handle = nullptr;
     }
 }
@@ -190,5 +210,117 @@ void TaskSystem::WaitForAll() {
 
 std::size_t TaskSystem::ThreadIndex() const {
     return scheduler_.GetThreadNum();
+}
+
+TaskSystem::LambdaTaskSet* TaskSystem::AcquireLambdaTask(Task&& f, std::size_t depCount) {
+    LambdaTaskSet* task = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(lambdaPoolMutex_);
+        if (!lambdaTaskPool_.empty()) {
+            task = lambdaTaskPool_.back();
+            lambdaTaskPool_.pop_back();
+        }
+    }
+
+    if (!task) {
+        return new LambdaTaskSet(std::move(f), depCount);
+    }
+
+    return new (task) LambdaTaskSet(std::move(f), depCount);
+}
+
+TaskSystem::RangeTaskSet* TaskSystem::AcquireRangeTask(std::size_t jobCount,
+                                                       std::function<void(std::size_t)> fn,
+                                                       std::size_t batchSize,
+                                                       std::size_t depCount) {
+    if (batchSize == 0) {
+        batchSize = 1;
+    }
+
+    RangeTaskSet* task = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(rangePoolMutex_);
+        if (!rangeTaskPool_.empty()) {
+            task = rangeTaskPool_.back();
+            rangeTaskPool_.pop_back();
+        }
+    }
+
+    if (!task) {
+        task = new RangeTaskSet(jobCount, std::move(fn), depCount);
+    } else {
+        task = new (task) RangeTaskSet(jobCount, std::move(fn), depCount);
+    }
+
+    task->m_MinRange = static_cast<uint32_t>(batchSize);
+    return task;
+}
+
+void TaskSystem::RecycleLambdaTask(LambdaTaskSet* task) {
+    if (!task) { return; }
+
+    task->~LambdaTaskSet();
+    std::lock_guard<std::mutex> lock(lambdaPoolMutex_);
+    lambdaTaskPool_.push_back(task);
+}
+
+void TaskSystem::RecycleRangeTask(RangeTaskSet* task) {
+    if (!task) { return; }
+
+    task->m_MinRange = 1;
+    task->~RangeTaskSet();
+    std::lock_guard<std::mutex> lock(rangePoolMutex_);
+    rangeTaskPool_.push_back(task);
+}
+
+TaskSystem::AutoDelete* TaskSystem::AcquireAutoDelete(enki::ITaskSet* task, AutoDelete::Kind kind) {
+    AutoDelete* autoDelete = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(autoDeletePoolMutex_);
+        if (!autoDeletePool_.empty()) {
+            autoDelete = autoDeletePool_.back();
+            autoDeletePool_.pop_back();
+        }
+    }
+
+    if (!autoDelete) {
+        return new AutoDelete(*this, task, kind);
+    }
+
+    return new (autoDelete) AutoDelete(*this, task, kind);
+}
+
+void TaskSystem::RecycleAutoDelete(AutoDelete* autoDelete) {
+    if (!autoDelete) { return; }
+
+    autoDelete->~AutoDelete();
+    std::lock_guard<std::mutex> lock(autoDeletePoolMutex_);
+    autoDeletePool_.push_back(autoDelete);
+}
+
+void TaskSystem::ClearPools() {
+    {
+        std::lock_guard<std::mutex> lock(lambdaPoolMutex_);
+        for (auto* task : lambdaTaskPool_) {
+            ::operator delete(task);
+        }
+        lambdaTaskPool_.clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(rangePoolMutex_);
+        for (auto* task : rangeTaskPool_) {
+            ::operator delete(task);
+        }
+        rangeTaskPool_.clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(autoDeletePoolMutex_);
+        for (auto* autoDelete : autoDeletePool_) {
+            ::operator delete(autoDelete);
+        }
+        autoDeletePool_.clear();
+    }
 }
 

--- a/TaskSystem.h
+++ b/TaskSystem.h
@@ -68,6 +68,12 @@ public:
     std::size_t ThreadIndex() const;
 
 private:
+    struct TaskWithDeps;
+    struct LambdaTaskSet;
+    struct RangeTaskSet;
+    struct AutoDelete;
+    friend struct AutoDelete;
+
     TaskSystem() = default;
     ~TaskSystem();
 
@@ -75,8 +81,25 @@ private:
     TaskSystem& operator=(const TaskSystem&) = delete;
 
 private:
+    LambdaTaskSet* AcquireLambdaTask(Task&& f, std::size_t depCount);
+    RangeTaskSet* AcquireRangeTask(std::size_t jobCount,
+                                   std::function<void(std::size_t)> fn,
+                                   std::size_t batchSize,
+                                   std::size_t depCount);
+    void RecycleLambdaTask(LambdaTaskSet* task);
+    void RecycleRangeTask(RangeTaskSet* task);
+    AutoDelete* AcquireAutoDelete(enki::ITaskSet* task, AutoDelete::Kind kind);
+    void RecycleAutoDelete(AutoDelete* autoDelete);
+    void ClearPools();
+
     enki::TaskScheduler scheduler_;
     std::vector<TaskHandle> trackedFrameTasks_;
     std::mutex trackedFrameMutex_;
+    std::vector<LambdaTaskSet*> lambdaTaskPool_;
+    std::vector<RangeTaskSet*> rangeTaskPool_;
+    std::mutex lambdaPoolMutex_;
+    std::mutex rangePoolMutex_;
+    std::vector<AutoDelete*> autoDeletePool_;
+    std::mutex autoDeletePoolMutex_;
 };
 


### PR DESCRIPTION
## Summary
- add pooled allocation for lambda and range tasks owned by TaskSystem
- recycle finished tasks back into the pools for reuse across submit paths
- clear pooled storage on shutdown while guarding access with mutexes
- pool AutoDelete wrappers so detach paths no longer use raw new/delete

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d13f918bcc8329be79b4e84dbb25ee