### PR TITLE
Refactor renderable architecture for flexible uniform binders

### DIFF
--- a/DebugGrid.cpp
+++ b/DebugGrid.cpp
@@ -8,6 +8,75 @@
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;
 
+namespace
+{
+class GridMVPBinder final : public RenderableObject::UniformBinder
+{
+public:
+    void RebuildHandles(RenderableObject& owner) override
+    {
+        if (Material* material = owner.GetGraphicsMaterial())
+        {
+            mvpHandle_ = material->ComputeCBFieldHandle(0, "modelViewProj");
+        }
+        else
+        {
+            mvpHandle_ = {};
+        }
+    }
+
+    void UpdateMainCB(RenderableObject& owner, Renderer* /*renderer*/, const mat4& view, const mat4& proj, uint8_t* cbData) override
+    {
+        Material* material = owner.GetGraphicsMaterial();
+        if (!material) { return; }
+
+        mat4 mvp = owner.GetModelMatrix() * view * proj;
+        UpdateUniform(owner, mvpHandle_, material, mvp, cbData);
+    }
+
+private:
+    Material::CBFieldHandle mvpHandle_{};
+};
+
+class AxesUniformBinder final : public RenderableObject::UniformBinder
+{
+public:
+    explicit AxesUniformBinder(DebugGrid::AxesRO& owner) : owner_(owner) {}
+
+    void RebuildHandles(RenderableObject& owner) override
+    {
+        if (Material* material = owner.GetGraphicsMaterial())
+        {
+            mvpHandle_ = material->ComputeCBFieldHandle(0, "modelViewProj");
+            viewportThicknessHandle_ = material->ComputeCBFieldHandle(0, "viewportThickness");
+        }
+        else
+        {
+            mvpHandle_ = {};
+            viewportThicknessHandle_ = {};
+        }
+    }
+
+    void UpdateMainCB(RenderableObject& owner, Renderer* renderer, const mat4& view, const mat4& proj, uint8_t* cbData) override
+    {
+        Material* material = owner.GetGraphicsMaterial();
+        if (!material || !renderer) { return; }
+
+        mat4 mvp = owner.GetModelMatrix() * view * proj;
+        UpdateUniform(owner, mvpHandle_, material, mvp, cbData);
+
+        const UINT w = renderer->GetWidth();
+        const UINT h = renderer->GetHeight();
+        UpdateUniform(owner, viewportThicknessHandle_, material, float4(float(w), float(h), owner_.GetThicknessPx(), 0.0f), cbData);
+    }
+
+private:
+    DebugGrid::AxesRO& owner_;
+    Material::CBFieldHandle mvpHandle_{};
+    Material::CBFieldHandle viewportThicknessHandle_{};
+};
+} // namespace
+
 // ──────────────────────────────────────────────────────────────
 // ВЕРШИННЫЕ ТИПЫ (локально, чтобы не плодить инклуды)
 // ──────────────────────────────────────────────────────────────
@@ -29,7 +98,7 @@ struct AxisVertex {
 class DebugGrid::GridRO final : public RenderableObject {
 public:
     GridRO(float halfSize, float step, float yPlane, float alpha)
-        : RenderableObject(/*matPreset*/"", /*inputLayout*/"PosColor", /*shader*/L"shaders/lines.hlsl")
+        : RenderableObject(/*inputLayout*/"PosColor", /*shader*/L"shaders/lines.hlsl")
         , halfSize_(halfSize), step_(step), yPlane_(yPlane), alpha_(alpha)
     {
     }
@@ -52,12 +121,12 @@ public:
         gd.blend.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
         gd.blend.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
 
-        RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
-
-        if (auto* material = GetGraphicsMaterial())
+        if (!GetUniformBinder())
         {
-            mvpHandle_ = material->ComputeCBFieldHandle(0, "modelViewProj");
+            SetUniformBinder(std::make_unique<GridMVPBinder>());
         }
+
+        RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
 
         std::vector<LineVertex> verts;
         BuildGridCPU(verts);
@@ -76,21 +145,6 @@ public:
         vertexCount_ = static_cast<UINT>(verts.size());
 
         um.StealKeepAlive(uploadKeepAlive);
-    }
-
-    void UpdateUniforms(Renderer* /*renderer*/, const mat4& view, const mat4& proj, uint8_t* cbData) override
-    {
-        mat4 mvp = (GetModelMatrix() * view * proj);
-        UpdateUniform(mvpHandle_, graphicsMaterial_.get(), mvp, cbData);
-    }
-
-    void OnMaterialHotReload(Renderer* renderer) override
-    {
-        RenderableObject::OnMaterialHotReload(renderer);
-        if (auto* material = GetGraphicsMaterial())
-        {
-            mvpHandle_ = material->ComputeCBFieldHandle(0, "modelViewProj");
-        }
     }
 
     void IssueDraw(Renderer* /*renderer*/, ID3D12GraphicsCommandList* cl) override
@@ -142,7 +196,6 @@ private:
     ComPtr<ID3D12Resource> vb_;
     D3D12_VERTEX_BUFFER_VIEW vbv_{};
     UINT vertexCount_ = 0;
-    Material::CBFieldHandle mvpHandle_{};
 };
 
 // ──────────────────────────────────────────────────────────────
@@ -151,7 +204,7 @@ private:
 class DebugGrid::AxesRO final : public RenderableObject {
 public:
     AxesRO(float axisLen, float yPlane, float alpha, float thicknessPx)
-        : RenderableObject(/*matPreset*/"", /*inputLayout*/"AxisLine", /*shader*/L"shaders/axes.hlsl")
+        : RenderableObject(/*inputLayout*/"AxisLine", /*shader*/L"shaders/axes.hlsl")
         , axisLen_(axisLen), yPlane_(yPlane), alpha_(alpha), thicknessPx_(thicknessPx)
     {
     }
@@ -175,13 +228,12 @@ public:
         gd.blend.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
         gd.blend.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
 
-        RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
-
-        if (auto* material = GetGraphicsMaterial())
+        if (!GetUniformBinder())
         {
-            mvpHandle_ = material->ComputeCBFieldHandle(0, "modelViewProj");
-            viewportThicknessHandle_ = material->ComputeCBFieldHandle(0, "viewportThickness");
+            SetUniformBinder(std::make_unique<AxesUniformBinder>(*this));
         }
+
+        RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
 
         std::vector<AxisVertex> verts;
         BuildAxesCPU(verts);
@@ -202,25 +254,7 @@ public:
         um.StealKeepAlive(uploadKeepAlive);
     }
 
-    void UpdateUniforms(Renderer* r, const mat4& view, const mat4& proj, uint8_t* cbData) override
-    {
-        mat4 mvp = (GetModelMatrix() * view * proj);
-        UpdateUniform(mvpHandle_, graphicsMaterial_.get(), mvp, cbData);
-
-        const UINT w = r->GetWidth();
-        const UINT h = r->GetHeight();
-        UpdateUniform(viewportThicknessHandle_, graphicsMaterial_.get(), float4(float(w), float(h), thicknessPx_, 0.0f), cbData);
-    }
-
-    void OnMaterialHotReload(Renderer* renderer) override
-    {
-        RenderableObject::OnMaterialHotReload(renderer);
-        if (auto* material = GetGraphicsMaterial())
-        {
-            mvpHandle_ = material->ComputeCBFieldHandle(0, "modelViewProj");
-            viewportThicknessHandle_ = material->ComputeCBFieldHandle(0, "viewportThickness");
-        }
-    }
+    float GetThicknessPx() const { return thicknessPx_; }
 
     void IssueDraw(Renderer* /*renderer*/, ID3D12GraphicsCommandList* cl) override
     {
@@ -274,8 +308,6 @@ private:
     ComPtr<ID3D12Resource> vb_;
     D3D12_VERTEX_BUFFER_VIEW vbv_{};
     UINT vertexCount_ = 0;
-    Material::CBFieldHandle mvpHandle_{};
-    Material::CBFieldHandle viewportThicknessHandle_{};
 };
 
 // ──────────────────────────────────────────────────────────────

--- a/GBufferRenderable.cpp
+++ b/GBufferRenderable.cpp
@@ -1,0 +1,134 @@
+#include "GBufferRenderable.h"
+
+#include "Renderer.h"
+#include "MaterialDataManager.h"
+
+namespace
+{
+class GBufferUniformBinder final : public RenderableObject::UniformBinder
+{
+public:
+    explicit GBufferUniformBinder(MaterialParams& params) : params_(params) {}
+
+    void RebuildHandles(RenderableObject& owner) override
+    {
+        cbHandles_ = {};
+        shadowHandles_ = {};
+
+        if (Material* material = owner.GetGraphicsMaterial())
+        {
+            cbHandles_.world = material->ComputeCBFieldHandle(0, "world");
+            cbHandles_.view = material->ComputeCBFieldHandle(0, "view");
+            cbHandles_.proj = material->ComputeCBFieldHandle(0, "proj");
+            cbHandles_.baseColor = material->ComputeCBFieldHandle(0, "baseColor");
+            cbHandles_.metalRough = material->ComputeCBFieldHandle(0, "metalRough");
+            cbHandles_.texOffsScale = material->ComputeCBFieldHandle(0, "texOffsScale");
+            cbHandles_.texFlags = material->ComputeCBFieldHandle(0, "texFlags");
+        }
+
+        if (Material* shadowMaterial = owner.GetShadowMaterial())
+        {
+            shadowHandles_.world = shadowMaterial->ComputeCBFieldHandle(0, "world");
+            shadowHandles_.view = shadowMaterial->ComputeCBFieldHandle(0, "view");
+            shadowHandles_.proj = shadowMaterial->ComputeCBFieldHandle(0, "proj");
+        }
+    }
+
+    void UpdateMainCB(RenderableObject& owner, Renderer* /*renderer*/, const mat4& view, const mat4& proj, uint8_t* cbData) override
+    {
+        Material* material = owner.GetGraphicsMaterial();
+        if (!material) { return; }
+
+        UpdateUniform(owner, cbHandles_.world, material, owner.GetModelMatrix(), cbData);
+        UpdateUniform(owner, cbHandles_.view, material, view, cbData);
+        UpdateUniform(owner, cbHandles_.proj, material, proj, cbData);
+
+        const auto& p = params_;
+        UpdateUniform(owner, cbHandles_.baseColor, material, p.baseColor, cbData);
+        UpdateUniform(owner, cbHandles_.metalRough, material, p.metalRough, cbData);
+        UpdateUniform(owner, cbHandles_.texOffsScale, material, p.texOffsScale, cbData);
+        UpdateUniform(owner, cbHandles_.texFlags, material, p.texFlags, cbData);
+    }
+
+    void UpdateShadowCB(RenderableObject& owner, Renderer* /*renderer*/, const mat4& lightView, const mat4& lightProj, uint8_t* cbData) override
+    {
+        Material* material = owner.GetShadowMaterial();
+        if (!material) { return; }
+
+        UpdateUniform(owner, shadowHandles_.world, material, owner.GetModelMatrix(), cbData);
+        UpdateUniform(owner, shadowHandles_.view, material, lightView, cbData);
+        UpdateUniform(owner, shadowHandles_.proj, material, lightProj, cbData);
+    }
+
+private:
+    struct CBHandles
+    {
+        Material::CBFieldHandle world;
+        Material::CBFieldHandle view;
+        Material::CBFieldHandle proj;
+        Material::CBFieldHandle baseColor;
+        Material::CBFieldHandle metalRough;
+        Material::CBFieldHandle texOffsScale;
+        Material::CBFieldHandle texFlags;
+    } cbHandles_{};
+
+    struct ShadowCBHandles
+    {
+        Material::CBFieldHandle world;
+        Material::CBFieldHandle view;
+        Material::CBFieldHandle proj;
+    } shadowHandles_{};
+
+    MaterialParams& params_;
+};
+} // namespace
+
+GBufferRenderable::GBufferRenderable(const std::string& matPreset,
+    const std::string& inputLayout,
+    const std::wstring& graphicsShader)
+    : RenderableObject(inputLayout, graphicsShader)
+    , matPreset_(matPreset)
+{
+    auto& gd = GetGraphicsDesc();
+    gd.numRT = 3;
+    gd.rtvFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+    gd.rtvFormats[1] = DXGI_FORMAT_R10G10B10A2_UNORM;
+    gd.rtvFormats[2] = DXGI_FORMAT_R11G11B10_FLOAT;
+    gd.dsvFormat = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+
+    SetUniformBinder(std::make_unique<GBufferUniformBinder>(matParams_));
+}
+
+void GBufferRenderable::Init(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    if (!renderer)
+    {
+        return;
+    }
+
+    if (!matData_)
+    {
+        matData_ = renderer->GetMaterialDataManager()->GetOrCreate(renderer, uploadCmdList, uploadKeepAlive, matPreset_);
+        if (matData_)
+        {
+            matData_->ConfigureDefinesForGBuffer(GetGraphicsDesc());
+        }
+    }
+
+    RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
+}
+
+void GBufferRenderable::PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* /*cl*/, RenderContext& ctx)
+{
+    if (!renderer)
+    {
+        return;
+    }
+
+    if (matData_)
+    {
+        matData_->StageGBufferBindings(renderer, ctx, 0, 0);
+    }
+}

--- a/GBufferRenderable.h
+++ b/GBufferRenderable.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "RenderableObject.h"
+#include "MaterialData.h"
+
+class GBufferRenderable : public RenderableObject
+{
+public:
+    GBufferRenderable(const std::string& matPreset,
+        const std::string& inputLayout,
+        const std::wstring& graphicsShader);
+
+    void Init(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive) override;
+
+    MaterialParams& MaterialParamsRef() { return matParams_; }
+    const MaterialParams& MaterialParamsRef() const { return matParams_; }
+
+    MaterialData* GetMaterialData() const { return matData_.get(); }
+
+protected:
+    void PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx) override;
+
+private:
+    std::shared_ptr<MaterialData> matData_;
+    MaterialParams matParams_;
+    std::string matPreset_;
+};

--- a/GpuInstancedModels.cpp
+++ b/GpuInstancedModels.cpp
@@ -18,7 +18,7 @@ GpuInstancedModels::GpuInstancedModels(
     const std::string& inputLayout,
     const std::wstring& graphicsShader,
     const std::wstring& computeShader)
-    : RenderableObject(matPreset, inputLayout, graphicsShader)
+    : GBufferRenderable(matPreset, inputLayout, graphicsShader)
     , computeShader_(computeShader)
     , modelName_(std::move(modelName))
     , instanceCount_(numInstances)
@@ -30,7 +30,7 @@ void GpuInstancedModels::Init(Renderer* renderer,
     std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
 {
     // Инициализация RenderableObject (создаёт GraphicsMaterial, ставит b0)
-    RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
+    GBufferRenderable::Init(renderer, uploadCmdList, uploadKeepAlive);
 
     // Compute-материал
     computeMaterial_ = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, computeShader_);
@@ -86,7 +86,7 @@ void GpuInstancedModels::PopulateContext(Renderer* renderer, ID3D12GraphicsComma
     std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> srvs;
     srvs.reserve(4);
     srvs.push_back(instanceBuffer_.GetSRVCPU()); // t0: инстансы
-    if (matData_) { matData_->AppendGBufferSRVs(srvs); } // t1..t3: albedo/mr/normal
+    if (auto* data = GetMaterialData()) { data->AppendGBufferSRVs(srvs); } // t1..t3: albedo/mr/normal
 
     auto tbl = renderer->StageSrvUavTable(srvs);
     ctx.table[0] = tbl.gpu;
@@ -101,24 +101,24 @@ void GpuInstancedModels::RecordGraphics(Renderer* renderer, ID3D12GraphicsComman
         D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
     renderer->Transition(cl, instanceBuffer_.GetResource(), kSRV);
 
-	RenderableObject::RecordGraphics(renderer, cl, ctx);
+    RenderableObject::RecordGraphics(renderer, cl, ctx);
 }
 
 void GpuInstancedModels::IssueDraw(Renderer* renderer, ID3D12GraphicsCommandList* cl)
 {
     if (!renderer) { return; }
-	if (!cl) { return; }
+    if (!cl) { return; }
     mesh_->DrawInstanced(cl, instanceCount_);
 }
 
-void GpuInstancedModels::RecordShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& lightView, const mat4& lightProj, RenderContext& ctx, uint8_t* cbData)
+void GpuInstancedModels::RecordShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& lightView, const mat4& lightProj, RenderContext& ctx)
 {
     const D3D12_RESOURCE_STATES kSRV =
         D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
     renderer->Transition(cl, instanceBuffer_.GetResource(), kSRV);
     ctx.table[0] = instanceBuffer_.GetSRVForFrame(renderer);
 
-    RenderableObject::RecordShadow(renderer, cl, lightView, lightProj, ctx, cbData);
+    RenderableObject::RecordShadow(renderer, cl, lightView, lightProj, ctx);
 }
 
 void GpuInstancedModels::Tick(float deltaTime)

--- a/GpuInstancedModels.h
+++ b/GpuInstancedModels.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
-#include "RenderableObject.h"
+#include "GBufferRenderable.h"
 #include "InstanceBuffer.h"
 #include "Material.h"
 #include "Texture2D.h"
@@ -8,7 +8,7 @@
 #include <string>
 #include <memory>
 
-class GpuInstancedModels : public RenderableObject {
+class GpuInstancedModels : public GBufferRenderable {
 public:
     GpuInstancedModels(
         std::string modelName,
@@ -31,7 +31,7 @@ protected:
     void RecordGraphics(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx) override;
     void PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx) override;
     void IssueDraw(Renderer* renderer, ID3D12GraphicsCommandList* cl) override;
-    void RecordShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& lightView, const mat4& lightProj, RenderContext& ctx, uint8_t* cbData) override;
+    void RecordShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& lightView, const mat4& lightProj, RenderContext& ctx) override;
 
 private:
     // данные инстансинга

--- a/RenderableObject.cpp
+++ b/RenderableObject.cpp
@@ -1,4 +1,4 @@
-﻿#include "RenderableObject.h"
+#include "RenderableObject.h"
 
 #include <stdexcept>
 #include <cstring>
@@ -11,43 +11,36 @@ using namespace DirectX;
 using Microsoft::WRL::ComPtr;
 
 RenderableObject::RenderableObject(
-    const std::string& matPreset,
     const std::string& inputLayout,
-    const std::wstring& graphicsShader):
-    matPreset_(matPreset)
+    const std::wstring& graphicsShader)
 {
-    // Дефолтный GraphicsDesc (треугольники, depth on, без бленда)
     graphicsDesc_.shaderFile = graphicsShader;
     graphicsDesc_.inputLayoutKey = inputLayout;
     graphicsDesc_.topologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-    graphicsDesc_.numRT = 3;
-    graphicsDesc_.rtvFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;      // GB0: Albedo+Metal
-    graphicsDesc_.rtvFormats[1] = DXGI_FORMAT_R10G10B10A2_UNORM;   // GB1: NormalOcta+Rough
-    graphicsDesc_.rtvFormats[2] = DXGI_FORMAT_R11G11B10_FLOAT;     // GB2: Emissive
+    graphicsDesc_.numRT = 0;
     graphicsDesc_.dsvFormat = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
     graphicsDesc_.FillDefaultsTriangle();
 
-	mesh_.reset(new Mesh());
+    mesh_.reset(new Mesh());
+    modelMatrix_ = mat4::Identity();
 }
 
-RenderableObject::~RenderableObject()
-{
-}
+RenderableObject::~RenderableObject() = default;
 
 void RenderableObject::Init(Renderer* renderer,
     ID3D12GraphicsCommandList* uploadCmdList,
     std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
 {
-    if (!matData_)
+    (void)uploadCmdList;
+    (void)uploadKeepAlive;
+
+    if (!renderer)
     {
-        matData_ = renderer->GetMaterialDataManager()->GetOrCreate(renderer, uploadCmdList, uploadKeepAlive, matPreset_);
-        if (matData_)
-        {
-	        matData_->ConfigureDefinesForGBuffer(graphicsDesc_);
-        }
+        return;
     }
 
     graphicsMaterial_ = renderer->GetMaterialManager()->GetOrCreateGraphics(renderer, graphicsDesc_);
+
     if (CastsShadow())
     {
         shadowDesc_ = graphicsDesc_;
@@ -61,8 +54,15 @@ void RenderableObject::Init(Renderer* renderer,
 
         shadowMaterial_ = renderer->GetMaterialManager()->GetOrCreateGraphics(renderer, shadowDesc_);
     }
+    else
+    {
+        shadowMaterial_.reset();
+    }
 
-    RebuildHandleCaches();
+    if (uniformBinder_)
+    {
+        uniformBinder_->RebuildHandles(*this);
+    }
 }
 
 void RenderableObject::IssueDraw(Renderer* renderer, ID3D12GraphicsCommandList* cl)
@@ -73,30 +73,15 @@ void RenderableObject::IssueDraw(Renderer* renderer, ID3D12GraphicsCommandList* 
     GetMesh()->Draw(cl);
 }
 
-void RenderableObject::UpdateUniforms(Renderer* renderer, const mat4& view, const mat4& proj, uint8_t* cbData)
+void RenderableObject::PopulateContext(Renderer* /*renderer*/, ID3D12GraphicsCommandList* /*cl*/, RenderContext& /*ctx*/)
 {
-    if (!cbData) { return; }
-    //CPU_SCOPE(L"RenderableObject::UpdateUniforms");
-    UpdateUniform(cb0Handles_.world, graphicsMaterial_.get(), GetModelMatrix(), cbData);
-    UpdateUniform(cb0Handles_.view, graphicsMaterial_.get(), view, cbData);
-    UpdateUniform(cb0Handles_.proj, graphicsMaterial_.get(), proj, cbData);
-
-    ApplyMaterialParamsToCB(cbData);
-}
-
-void RenderableObject::PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx)
-{
-	if (matData_)
-	{
-        matData_->StageGBufferBindings(renderer, ctx, 0, 0);
-	}
 }
 
 void RenderableObject::RecordGraphics(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx)
 {
     if (!renderer) { return; }
     if (cl == nullptr) { return; }
-    // Установить графический материал
+    if (!graphicsMaterial_) { return; }
     graphicsMaterial_->Bind(cl, ctx, renderer->GetWireframeMode() && allowWireframe_);
 }
 
@@ -104,33 +89,26 @@ void RenderableObject::Render(Renderer* renderer, ID3D12GraphicsCommandList* cl,
 {
     if (!renderer) { return; }
     if (cl == nullptr) { return; }
-    //CPU_SCOPE(L"RenderableObject::Render");
+    if (!graphicsMaterial_) { return; }
 
     constexpr UINT kAlign = 256;
     const UINT cbSizeBytes = graphicsMaterial_->GetCBSizeBytesAligned(0, kAlign);
-    
-    // 2) выделить слайс в ринг-буфере кадра и прописать CBV
-    auto alloc = renderer->GetFrameResource()->AllocDynamic(cbSizeBytes, kAlign); // <- как просили
+
+    auto alloc = renderer->GetFrameResource()->AllocDynamic(cbSizeBytes, kAlign);
     uint8_t* cbData = static_cast<uint8_t*>(alloc.cpu);
     auto h = renderer->GetRenderContextPool()->Acquire();
     auto& ctx = h.ref();
     ctx.cbv[0] = alloc.gpu;
 
     RecordCompute(renderer, cl);
-    UpdateUniforms(renderer, view, proj, cbData);
+    if (uniformBinder_)
+    {
+        uniformBinder_->UpdateMainCB(*this, renderer, view, proj, cbData);
+    }
     PopulateContext(renderer, cl, ctx);
     RecordGraphics(renderer, cl, ctx);
-    
-    IssueDraw(renderer, cl);
-}
 
-void RenderableObject::ApplyMaterialParamsToCB(uint8_t* cbData)
-{
-    const auto& p = matParams_;
-    UpdateUniform(cb0Handles_.baseColor, graphicsMaterial_.get(), p.baseColor, cbData);
-    UpdateUniform(cb0Handles_.metalRough, graphicsMaterial_.get(), p.metalRough, cbData);
-    UpdateUniform(cb0Handles_.texOffsScale, graphicsMaterial_.get(), p.texOffsScale, cbData);
-    UpdateUniform(cb0Handles_.texFlags, graphicsMaterial_.get(), p.texFlags, cbData);
+    IssueDraw(renderer, cl);
 }
 
 std::wstring RenderableObject::AppendSuffixBeforeExt(const std::wstring& file,
@@ -144,49 +122,31 @@ std::wstring RenderableObject::AppendSuffixBeforeExt(const std::wstring& file,
 }
 
 void RenderableObject::RecordShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl,
-    const mat4& lightView, const mat4& lightProj, RenderContext& ctx, uint8_t* cbData)
+    const mat4& lightView, const mat4& lightProj, RenderContext& ctx)
 {
-    if (!renderer || !cl || !GetMesh() || !shadowMaterial_) { return; }
-    UpdateUniform(shadowHandles_.world, shadowMaterial_.get(), GetModelMatrix(), cbData);
-    UpdateUniform(shadowHandles_.view, shadowMaterial_.get(), lightView, cbData);
-    UpdateUniform(shadowHandles_.proj, shadowMaterial_.get(), lightProj, cbData);
+    (void)lightView;
+    (void)lightProj;
 
+    if (!renderer || !cl || !GetMesh() || !shadowMaterial_) { return; }
     shadowMaterial_->Bind(cl, ctx, false);
 }
 
 void RenderableObject::OnMaterialHotReload(Renderer* /*renderer*/)
 {
-    RebuildHandleCaches();
-}
-
-void RenderableObject::RebuildHandleCaches()
-{
-    cb0Handles_ = {};
-    shadowHandles_ = {};
-
-    if (graphicsMaterial_)
+    if (uniformBinder_)
     {
-        cb0Handles_.world = graphicsMaterial_->ComputeCBFieldHandle(0, "world");
-        cb0Handles_.view = graphicsMaterial_->ComputeCBFieldHandle(0, "view");
-        cb0Handles_.proj = graphicsMaterial_->ComputeCBFieldHandle(0, "proj");
-        cb0Handles_.baseColor = graphicsMaterial_->ComputeCBFieldHandle(0, "baseColor");
-        cb0Handles_.metalRough = graphicsMaterial_->ComputeCBFieldHandle(0, "metalRough");
-        cb0Handles_.texOffsScale = graphicsMaterial_->ComputeCBFieldHandle(0, "texOffsScale");
-        cb0Handles_.texFlags = graphicsMaterial_->ComputeCBFieldHandle(0, "texFlags");
-    }
-
-    if (shadowMaterial_)
-    {
-        shadowHandles_.world = shadowMaterial_->ComputeCBFieldHandle(0, "world");
-        shadowHandles_.view = shadowMaterial_->ComputeCBFieldHandle(0, "view");
-        shadowHandles_.proj = shadowMaterial_->ComputeCBFieldHandle(0, "proj");
+        uniformBinder_->RebuildHandles(*this);
     }
 }
 
 void RenderableObject::RenderShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl,
     const mat4& lightView, const mat4& lightProj)
 {
-    //CPU_SCOPE(L"RenderableObject::RenderShadow");
+    if (!renderer || !cl || !shadowMaterial_)
+    {
+        return;
+    }
+
     if (!CastsShadow())
     {
         return;
@@ -200,6 +160,29 @@ void RenderableObject::RenderShadow(Renderer* renderer, ID3D12GraphicsCommandLis
 
     ctx.cbv[0] = alloc.gpu;
 
-    RecordShadow(renderer, cl, lightView, lightProj, ctx, cbData);
+    if (uniformBinder_)
+    {
+        uniformBinder_->UpdateShadowCB(*this, renderer, lightView, lightProj, cbData);
+    }
+
+    RecordShadow(renderer, cl, lightView, lightProj, ctx);
     IssueDraw(renderer, cl);
+}
+
+void RenderableObject::SetGraphicsMaterial(Material* m)
+{
+    graphicsMaterial_.reset(m);
+    if (uniformBinder_)
+    {
+        uniformBinder_->RebuildHandles(*this);
+    }
+}
+
+void RenderableObject::SetUniformBinder(std::unique_ptr<UniformBinder> binder)
+{
+    uniformBinder_ = std::move(binder);
+    if (uniformBinder_ && graphicsMaterial_)
+    {
+        uniformBinder_->RebuildHandles(*this);
+    }
 }

--- a/RenderableObject.h
+++ b/RenderableObject.h
@@ -6,7 +6,6 @@
 #include <memory>
 
 #include "Material.h"
-#include "MaterialData.h"
 #include "Mesh.h"
 #include "RenderContext.h"
 #include "Math.h"
@@ -16,8 +15,24 @@ class Renderer;
 
 class RenderableObject: public RenderableObjectBase {
 public:
+    class UniformBinder
+    {
+    public:
+        virtual ~UniformBinder() = default;
+
+        virtual void RebuildHandles(RenderableObject& /*owner*/) {}
+        virtual void UpdateMainCB(RenderableObject& /*owner*/, Renderer* /*renderer*/, const mat4& /*view*/, const mat4& /*proj*/, uint8_t* /*cbData*/) {}
+        virtual void UpdateShadowCB(RenderableObject& /*owner*/, Renderer* /*renderer*/, const mat4& /*lightView*/, const mat4& /*lightProj*/, uint8_t* /*cbData*/) {}
+
+    protected:
+        template<typename T>
+        bool UpdateUniform(RenderableObject& owner, const Material::CBFieldHandle& handle, Material* material, const T& value, uint8_t* cbData) const
+        {
+            return owner.UpdateUniform(handle, material, value, cbData);
+        }
+    };
+
     RenderableObject(
-        const std::string& matPreset,
         const std::string& inputLayout,
         const std::wstring& graphicsShader);
     virtual ~RenderableObject();
@@ -40,11 +55,8 @@ public:
     const Mesh* GetMesh() const { return mesh_.get(); }
 
     Material* GetGraphicsMaterial() const { return graphicsMaterial_.get(); }
-    void SetGraphicsMaterial(Material* m) { graphicsMaterial_.reset(m); RebuildHandleCaches(); } // если хочешь вручную
-
-    // пер-объектные параметры (b0)
-    MaterialParams& MaterialParamsRef() { return matParams_; }
-    const MaterialParams& MaterialParamsRef() const { return matParams_; }
+    void SetGraphicsMaterial(Material* m);
+    Material* GetShadowMaterial() const { return shadowMaterial_.get(); }
 
     // GraphicsDesc — правим пайплайн (топология/блендинг/растр/DS)
     Material::GraphicsDesc& GetGraphicsDesc() { return graphicsDesc_; }
@@ -58,13 +70,10 @@ public:
 
 protected:
     virtual void RecordCompute(Renderer* renderer, ID3D12GraphicsCommandList* cl) {}
-    virtual void UpdateUniforms(Renderer* renderer, const mat4& view, const mat4& proj, uint8_t* cbData);
     virtual void PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx);
     virtual void RecordGraphics(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx);
     virtual void IssueDraw(Renderer* renderer, ID3D12GraphicsCommandList* cl);
-    virtual void RecordShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& lightView, const mat4& lightProj, RenderContext& ctx, uint8_t* cbData);
-
-    void ApplyMaterialParamsToCB(uint8_t* cbData);
+    virtual void RecordShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& lightView, const mat4& lightProj, RenderContext& ctx);
 
     template<typename T>
     bool UpdateUniform(const Material::CBFieldHandle& handle, Material* material, const T& value, uint8_t* cbData)
@@ -76,12 +85,8 @@ protected:
     }
 
 protected:
-    // Данные рендера
-    std::shared_ptr<MaterialData> matData_;          // ассет: текстуры+фичи (shared)
-    MaterialParams                matParams_;        // пер-объект в b0
     std::shared_ptr<Material>     graphicsMaterial_; // вариант шейдера (PSO/RS)
     Material::GraphicsDesc        graphicsDesc_;
-    std::string                   matPreset_;
     std::shared_ptr<Material>     shadowMaterial_;
     Material::GraphicsDesc        shadowDesc_;
 
@@ -91,29 +96,16 @@ protected:
     // CB (upload, пер-объектный)
     bool allowWireframe_ = true;
 
+    void SetUniformBinder(std::unique_ptr<UniformBinder> binder);
+    UniformBinder* GetUniformBinder() const { return uniformBinder_.get(); }
+
 private:
     static std::wstring AppendSuffixBeforeExt(const std::wstring& file, const std::wstring& suffix);
 
-    void RebuildHandleCaches();
-
-    struct CBHandles
-    {
-        Material::CBFieldHandle world;
-        Material::CBFieldHandle view;
-        Material::CBFieldHandle proj;
-        Material::CBFieldHandle baseColor;
-        Material::CBFieldHandle metalRough;
-        Material::CBFieldHandle texOffsScale;
-        Material::CBFieldHandle texFlags;
-    } cb0Handles_{};
-
-    struct ShadowCBHandles
-    {
-        Material::CBFieldHandle world;
-        Material::CBFieldHandle view;
-        Material::CBFieldHandle proj;
-    } shadowHandles_{};
-
     RenderableObject(const RenderableObject&) = delete;
     RenderableObject& operator=(const RenderableObject&) = delete;
+
+    friend class UniformBinder;
+
+    std::unique_ptr<UniformBinder> uniformBinder_;
 };

--- a/Skybox.cpp
+++ b/Skybox.cpp
@@ -3,7 +3,48 @@
 #include "UploadManager.h"
 #include "FrameResource.h"
 
+#include <memory>
+
 using Microsoft::WRL::ComPtr;
+
+namespace
+{
+class SkyboxUniformBinder final : public RenderableObject::UniformBinder
+{
+public:
+    explicit SkyboxUniformBinder(Skybox& owner) : owner_(owner) {}
+
+    void RebuildHandles(RenderableObject& owner) override
+    {
+        viewHandle_ = {};
+        projHandle_ = {};
+        exposureHandle_ = {};
+
+        if (Material* material = owner.GetGraphicsMaterial())
+        {
+            viewHandle_ = material->ComputeCBFieldHandle(0, "view");
+            projHandle_ = material->ComputeCBFieldHandle(0, "proj");
+            exposureHandle_ = material->ComputeCBFieldHandle(0, "exposure");
+        }
+    }
+
+    void UpdateMainCB(RenderableObject& owner, Renderer* /*renderer*/, const mat4& view, const mat4& proj, uint8_t* cbData) override
+    {
+        Material* material = owner.GetGraphicsMaterial();
+        if (!material) { return; }
+
+        UpdateUniform(owner, viewHandle_, material, view, cbData);
+        UpdateUniform(owner, projHandle_, material, proj, cbData);
+        UpdateUniform(owner, exposureHandle_, material, owner_.GetExposure(), cbData);
+    }
+
+private:
+    Skybox& owner_;
+    Material::CBFieldHandle viewHandle_{};
+    Material::CBFieldHandle projHandle_{};
+    Material::CBFieldHandle exposureHandle_{};
+};
+} // namespace
 
 void Skybox::Init(Renderer* renderer,
     ID3D12GraphicsCommandList* uploadCmdList,
@@ -29,33 +70,12 @@ void Skybox::Init(Renderer* renderer,
     // Сборка геометрии (куб)
     BuildCubeMesh_(renderer, uploadCmdList, uploadKeepAlive);
 
+    if (!GetUniformBinder())
+    {
+        SetUniformBinder(std::make_unique<SkyboxUniformBinder>(*this));
+    }
+
     RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
-
-    if (auto* material = GetGraphicsMaterial())
-    {
-        viewHandle_ = material->ComputeCBFieldHandle(0, "view");
-        projHandle_ = material->ComputeCBFieldHandle(0, "proj");
-        exposureHandle_ = material->ComputeCBFieldHandle(0, "exposure");
-    }
-}
-
-void Skybox::OnMaterialHotReload(Renderer* renderer)
-{
-    RenderableObject::OnMaterialHotReload(renderer);
-    if (auto* material = GetGraphicsMaterial())
-    {
-        viewHandle_ = material->ComputeCBFieldHandle(0, "view");
-        projHandle_ = material->ComputeCBFieldHandle(0, "proj");
-        exposureHandle_ = material->ComputeCBFieldHandle(0, "exposure");
-    }
-}
-
-void Skybox::UpdateUniforms(Renderer* /*renderer*/, const mat4& view, const mat4& proj, uint8_t* cbData)
-{
-    // CB0: ожидаем идентификаторы "view" и "proj" в cbuffer'е (см. skybox.hlsl)
-    UpdateUniform(viewHandle_, graphicsMaterial_.get(), view, cbData);
-    UpdateUniform(projHandle_, graphicsMaterial_.get(), proj, cbData);
-    UpdateUniform(exposureHandle_, graphicsMaterial_.get(), exposure_, cbData);
 }
 
 void Skybox::PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx)

--- a/Skybox.h
+++ b/Skybox.h
@@ -8,7 +8,7 @@
 
 class Skybox : public RenderableObject {
 public:
-    Skybox(const std::wstring& filePath): RenderableObject(/*matPreset*/"", /*inputLayout*/"PosOnly", /*graphicsShader*/L"shaders/skybox.hlsl"),
+    Skybox(const std::wstring& filePath): RenderableObject(/*inputLayout*/"PosOnly", /*graphicsShader*/L"shaders/skybox.hlsl"),
         path_(filePath)
     {
         allowWireframe_ = false;
@@ -28,10 +28,7 @@ public:
     bool IsSimpleRender() const { return true; }
     bool CastsShadow() const { return false; }
 
-    void OnMaterialHotReload(Renderer* renderer) override;
-
 protected:
-    void UpdateUniforms(Renderer* renderer, const mat4& view, const mat4& proj, uint8_t* cbData) override;
     void PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx) override;
     
 private:
@@ -43,7 +40,4 @@ private:
     TextureCube cube_;
     std::wstring path_;
     float exposure_ = 1.0f;
-    Material::CBFieldHandle viewHandle_{};
-    Material::CBFieldHandle projHandle_{};
-    Material::CBFieldHandle exposureHandle_{};
 };

--- a/StaticMesh.cpp
+++ b/StaticMesh.cpp
@@ -6,7 +6,7 @@ StaticMesh::StaticMesh(const std::string& modelName,
     const std::string& matPreset,
     const std::string& inputLayout,
     const std::wstring& graphicsShader)
-    : RenderableObject(matPreset, inputLayout, graphicsShader),
+    : GBufferRenderable(matPreset, inputLayout, graphicsShader),
     modelName_(modelName)
 {
     pos_ = float3(0.0f, 0.0f, 0.0f);
@@ -17,7 +17,7 @@ StaticMesh::StaticMesh(const std::string& modelName,
 
 void StaticMesh::Init(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList, std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive)
 {
-    RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
+    GBufferRenderable::Init(renderer, uploadCmdList, uploadKeepAlive);
     if (!modelName_.empty())
     {
         mesh_ = renderer->GetMeshManager()->Load(modelName_, renderer, uploadCmdList, uploadKeepAlive, { true, false, 0 });

--- a/StaticMesh.h
+++ b/StaticMesh.h
@@ -1,8 +1,8 @@
 #pragma once
-#include "RenderableObject.h"
+#include "GBufferRenderable.h"
 #include "Math.h"
 
-class StaticMesh : public RenderableObject
+class StaticMesh : public GBufferRenderable
 {
 public:
     StaticMesh(const std::string& modelName,

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="FontAtlas.cpp" />
     <ClCompile Include="FontManager.cpp" />
     <ClCompile Include="FrameResource.cpp" />
+    <ClCompile Include="GBufferRenderable.cpp" />
     <ClCompile Include="GpuInstancedModels.cpp" />
     <ClCompile Include="InputLayoutManager.cpp" />
     <ClCompile Include="InputManager.cpp" />
@@ -184,6 +185,7 @@
     <ClInclude Include="FontAtlas.h" />
     <ClInclude Include="FontManager.h" />
     <ClInclude Include="FrameResource.h" />
+    <ClInclude Include="GBufferRenderable.h" />
     <ClInclude Include="GpuInstancedModels.h" />
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="InputLayoutManager.h" />

--- a/test_cube.vcxproj.filters
+++ b/test_cube.vcxproj.filters
@@ -84,6 +84,9 @@
     <ClCompile Include="FrameResource.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="GBufferRenderable.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="FontManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -156,6 +159,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="FrameResource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GBufferRenderable.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="DescriptorAllocator.h">


### PR DESCRIPTION
## Summary
- Add a pluggable UniformBinder interface to `RenderableObject` and move g-buffer bindings into dedicated binder classes for g-buffer meshes, the skybox, and the debug grid.
- Create a `GBufferRenderable` subclass that owns g-buffer material data/params and update mesh renderables to inherit from it and use binder-driven constant updates.
- Register the new g-buffer renderable sources in the Visual Studio project files.

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d16112c32c8329a9b61e69d730908a