### PR TITLE
Refactor trace string table and reuse profiler scratch buffers

### DIFF
--- a/App.cpp
+++ b/App.cpp
@@ -1,6 +1,6 @@
 #include "App.h"
 #include "Profiler.h"
-
+#include "ProfilerScopes.h"
 #include <cassert>
 
 LRESULT CALLBACK App::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
@@ -156,11 +156,11 @@ void App::Run(HINSTANCE hInstance, int nCmdShow) {
 #endif
 
             {
-                CPU_SCOPE(L"Whole Cycle");
+                CPU_SCOPE(ProfilerScopes::kWholeCycle);
                 input.NewFrame();
 
                 {
-                    CPU_SCOPE(L"Win Messages");
+                    CPU_SCOPE(ProfilerScopes::kWinMessages);
                     while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE)) {
                         TranslateMessage(&msg);
                         DispatchMessage(&msg);

--- a/Material.cpp
+++ b/Material.cpp
@@ -18,6 +18,8 @@
 #include "RootSignatureLayout.h"
 #include "RootSignatureParser.h"
 #include "TaskSystem.h"
+#include "Profiler.h"
+#include "ProfilerScopes.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -369,7 +371,7 @@ void Material::RefreshWatchTimes_()
 
 bool Material::FSProbeAndFlagPending()
 {
-    CPU_SCOPE(L"Material::FSProbeAndFlagPending");
+    CPU_SCOPE(ProfilerScopes::kMaterialFSProbe);
     std::lock_guard<std::mutex> lk(watchMtx_);
     if (watchedFiles_.empty()) { return false; }
 

--- a/Profiler.cpp
+++ b/Profiler.cpp
@@ -6,6 +6,10 @@
 #include <cstdio>
 #include <ctime>
 #include <filesystem>
+#include <string_view>
+#include <algorithm>
+#include <memory>
+#include <limits>
 #include "third_party/robin_hood.h"
 #include "TextManager.h"
 
@@ -40,17 +44,161 @@ std::string EscapeJson(const std::string& input) {
     return out;
 }
 
-struct TraceDumpData {
-    std::vector<Profiler::TraceEvent> events;
-    std::vector<std::string> threadNames;
-    std::vector<Profiler::TraceNameEntry> names;
-};
+const Profiler::ScopeNameKey kTraceHandlingKey = Profiler::RegisterTraceLiteral(L"TraceHandling");
+const Profiler::ScopeNameKey kProfilerEmitOverlayKey = Profiler::RegisterTraceLiteral(L"Profiler::EmitOverlay");
+const Profiler::ScopeNameKey kGpuFrameKey = Profiler::RegisterTraceLiteral(L"GPU.Frame");
 
 std::wstring BuildWideName(const Profiler::ScopeNameKey& key) {
-    if (!key.namePtr || !*key.namePtr) {
+    if (!key.name || key.name->empty()) {
         return L"unknown";
     }
-    return std::wstring(key.namePtr);
+    return *key.name;
+}
+
+class TraceStringTable {
+public:
+    Profiler::ScopeNameKey RegisterLiteral(const wchar_t* name) {
+#if PROF_ENABLED
+        std::lock_guard<std::mutex> lock(mtx_);
+
+        std::wstring literal = (name && *name) ? std::wstring(name) : std::wstring();
+        if (literal.empty()) {
+            literal = L"unknown";
+        }
+
+        auto valueIt = valueLookup_.find(literal);
+        if (valueIt != valueLookup_.end()) {
+            uint32_t idx = valueIt->second;
+            if (idx < entries_.size() && entries_[idx]) {
+                return entries_[idx]->key;
+            }
+        }
+
+        const uint32_t index = static_cast<uint32_t>(entries_.size());
+        auto entry = std::make_unique<Profiler::TraceNameEntry>();
+        entry->displayName = std::move(literal);
+        entry->key.name = &entry->displayName;
+        entry->isDynamic = false;
+        entry->dynamicInUse = false;
+        auto* stored = entry.get();
+        entries_.push_back(std::move(entry));
+        valueLookup_.emplace(stored->displayName, index);
+        keyLookup_.emplace(stored->key.name, index);
+        return stored->key;
+#else
+        (void)name;
+        return {};
+#endif
+    }
+
+    Profiler::ScopeNameKey RegisterDynamic(std::wstring name, uint32_t* outIndex) {
+#if PROF_ENABLED
+        std::lock_guard<std::mutex> lock(mtx_);
+
+        std::wstring display = std::move(name);
+        if (display.empty()) {
+            display = L"unknown";
+        }
+
+        uint32_t index = std::numeric_limits<uint32_t>::max();
+        Profiler::TraceNameEntry* entry = nullptr;
+
+        if (!dynamicFree_.empty()) {
+            index = dynamicFree_.back();
+            dynamicFree_.pop_back();
+            if (index >= entries_.size()) {
+                entries_.resize(index + 1);
+            }
+            if (!entries_[index]) {
+                entries_[index] = std::make_unique<Profiler::TraceNameEntry>();
+            }
+            entry = entries_[index].get();
+            entry->displayName = std::move(display);
+            entry->isDynamic = true;
+            entry->dynamicInUse = true;
+            if (!entry->key.name) {
+                entry->key.name = &entry->displayName;
+            }
+        }
+        else {
+            index = static_cast<uint32_t>(entries_.size());
+            auto newEntry = std::make_unique<Profiler::TraceNameEntry>();
+            newEntry->displayName = std::move(display);
+            newEntry->key.name = &newEntry->displayName;
+            newEntry->isDynamic = true;
+            newEntry->dynamicInUse = true;
+            entry = newEntry.get();
+            entries_.push_back(std::move(newEntry));
+        }
+
+        keyLookup_[entry->key.name] = index;
+
+        if (outIndex) {
+            *outIndex = index;
+        }
+        captureDynamicKeys_.push_back(entry->key);
+        return entry->key;
+#else
+        (void)name; (void)outIndex;
+        return {};
+#endif
+    }
+
+    void ReleaseDynamicKeys(const std::vector<Profiler::ScopeNameKey>& keys) {
+#if PROF_ENABLED
+        if (keys.empty()) { return; }
+        std::lock_guard<std::mutex> lock(mtx_);
+        for (const Profiler::ScopeNameKey& key : keys) {
+            if (!key.name) { continue; }
+            auto it = keyLookup_.find(key.name);
+            if (it == keyLookup_.end()) { continue; }
+            const uint32_t idx = it->second;
+            if (idx >= entries_.size()) { continue; }
+            auto* entry = entries_[idx].get();
+            if (!entry || !entry->isDynamic || !entry->dynamicInUse) { continue; }
+            entry->dynamicInUse = false;
+            dynamicFree_.push_back(idx);
+        }
+#else
+        (void)keys;
+#endif
+    }
+
+    std::vector<Profiler::ScopeNameKey> TakeCaptureKeys() {
+#if PROF_ENABLED
+        std::lock_guard<std::mutex> lock(mtx_);
+        std::vector<Profiler::ScopeNameKey> out;
+        out.swap(captureDynamicKeys_);
+        return out;
+#else
+        return {};
+#endif
+    }
+
+private:
+    std::mutex mtx_;
+    robin_hood::unordered_flat_map<const std::wstring*, uint32_t> keyLookup_;
+    robin_hood::unordered_flat_map<std::wstring, uint32_t> valueLookup_;
+    std::vector<std::unique_ptr<Profiler::TraceNameEntry>> entries_;
+    std::vector<uint32_t> dynamicFree_;
+    std::vector<Profiler::ScopeNameKey> captureDynamicKeys_;
+};
+
+TraceStringTable& GetTraceStringTable() {
+    static TraceStringTable table;
+    return table;
+}
+
+Profiler::ScopeNameKey Profiler::RegisterTraceLiteral(const wchar_t* name) {
+    return GetTraceStringTable().RegisterLiteral(name);
+}
+
+Profiler::ScopeNameKey Profiler::RegisterTraceDynamic(std::wstring name, uint32_t* outIndex) {
+    return GetTraceStringTable().RegisterDynamic(std::move(name), outIndex);
+}
+
+void Profiler::ReleaseTraceNameKeys(const std::vector<ScopeNameKey>& keys) {
+    GetTraceStringTable().ReleaseDynamicKeys(keys);
 }
 
 std::string WideToUtf8(const std::wstring& input) {
@@ -201,13 +349,19 @@ bool Profiler::PushTraceSampleNode(TraceSampleNode* node) {
     return false;
 }
 
-void Profiler::DrainTraceSampleNodes(std::vector<TraceSample>& out) {
-    const size_t prevSize = out.size();
+void Profiler::DrainTraceSampleNodes(uint64_t traceStartUs) {
     TraceSampleNode* head = traceSampleHead_.exchange(kTraceListClosed, std::memory_order_acq_rel);
     if (head == kTraceListClosed) { return; }
     while (head) {
-        out.push_back(head->sample);
         TraceSampleNode* next = head->next;
+        TraceEvent ev = head->sample;
+        if (ev.tsUs >= traceStartUs) {
+            ev.tsUs -= traceStartUs;
+        }
+        else {
+            ev.tsUs = 0;
+        }
+        traceEvents_.push_back(std::move(ev));
         ReleaseTraceSampleNode(head);
         head = next;
     }
@@ -254,10 +408,10 @@ Profiler& Profiler::Get() {
 }
 
 #if PROF_GPU_ENABLED
-Profiler::ScopedGpu::ScopedGpu(ID3D12GraphicsCommandList* cl, const wchar_t* name, uint64_t id)
+Profiler::ScopedGpu::ScopedGpu(ID3D12GraphicsCommandList* cl, ScopeNameKey key)
     : cl_(cl)
 {
-    idx_ = Profiler::Get().BeginGpuSample(cl, ScopeNameKey::FromWide(name, id));
+    idx_ = Profiler::Get().BeginGpuSample(cl, key);
 }
 
 Profiler::ScopedGpu::~ScopedGpu() {
@@ -294,11 +448,13 @@ void Profiler::BeginFrame(uint64_t frameNo) {
         traceCapturing_ = true;
         traceFramesRemaining_ = traceRequestFrameCount_;
         traceEvents_.clear();
-        traceNames_.clear();
-        traceNameLookup_.clear();
         traceStartUs_ = 0;
         traceStartSet_ = false;
         traceStopRequested_ = false;
+        auto leftoverKeys = GetTraceStringTable().TakeCaptureKeys();
+        if (!leftoverKeys.empty()) {
+            GetTraceStringTable().ReleaseDynamicKeys(leftoverKeys);
+        }
     }
 
     if (traceCapturing_ && !traceStartSet_) {
@@ -327,11 +483,16 @@ void Profiler::EndFrame() {
     tasks.Release(overlayTask_);
 
     // 1) заберём сэмплы текущего кадра и закроем кадр (быстро)
-    std::vector<ScopeSample> samples;
+    auto& samples = asyncCpuSamples_;
+    samples.clear();
 #if PROF_GPU_ENABLED
-    std::vector<ScopeSample> gpuSamples;
+    auto& gpuSamples = asyncGpuSamples_;
+    gpuSamples.clear();
 #endif
-    TraceDumpData traceDump;
+    auto& traceDump = traceDumpData_;
+    traceDump.events.clear();
+    traceDump.threadNames.clear();
+    traceDump.dynamicKeys.clear();
     bool haveTraceDump = false;
     const auto frameEnd = CpuClock::now();
     frameSamples_.clear();
@@ -340,64 +501,33 @@ void Profiler::EndFrame() {
     samples.swap(frameSamples_);
     {
         std::lock_guard<std::mutex> lk(mtx_);
-        if (!frameOpen_) { return; }
+        if (!frameOpen_) {
+            frameSamples_.swap(samples);
+            return;
+        }
 #if PROF_GPU_ENABLED
-        gpuSamples = std::move(gpuFrameSamples_);
-        gpuFrameSamples_.clear();
+        gpuSamples.swap(gpuFrameSamples_);
 #endif
         if (traceCapturing_) {
             std::lock_guard<std::mutex> traceLock(traceMtx_);
-            traceSampleScratch_.clear();
-            DrainTraceSampleNodes(traceSampleScratch_);
             const uint64_t startUs = ToMicroseconds(frameCpuStart_);
             const uint64_t endUs = ToMicroseconds(frameEnd);
             const uint64_t durUs = (endUs > startUs) ? (endUs - startUs) : 0;
             const uint32_t threadIdx = GetThreadIndex_Locked(std::this_thread::get_id());
             TraceEvent fev;
-            fev.inlineName = L"Frame ";
-            fev.inlineName += std::to_wstring(frameNo_);
+            std::wstring frameLabel = L"Frame ";
+            frameLabel += std::to_wstring(frameNo_);
+            Profiler::ScopeNameKey frameKey = RegisterTraceDynamic(std::move(frameLabel));
+            fev.key = frameKey;
             fev.tsUs = (startUs >= traceStartUs_) ? (startUs - traceStartUs_) : 0;
             fev.durUs = durUs;
             fev.threadIndex = threadIdx;
             traceEvents_.push_back(std::move(fev));
 
-            for (const TraceSample& sample : traceSampleScratch_) {
-                uint32_t nameIndex = std::numeric_limits<uint32_t>::max();
-                bool haveNameIndex = false;
-                std::wstring displayName;
-                auto nameIt = traceNameLookup_.find(sample.key);
-                if (nameIt != traceNameLookup_.end()) {
-                    nameIndex = nameIt->second;
-                    haveNameIndex = true;
-                }
-                else {
-                    displayName = BuildWideName(sample.key);
-                    if (traceNames_.size() < static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
-                        TraceNameEntry entry{};
-                        entry.displayName = std::move(displayName);
-                        nameIndex = static_cast<uint32_t>(traceNames_.size());
-                        traceNames_.push_back(std::move(entry));
-                        traceNameLookup_.emplace(sample.key, nameIndex);
-                        haveNameIndex = true;
-                    }
-                }
-
-                TraceEvent ev;
-                if (haveNameIndex) {
-                    ev.nameIndex = nameIndex;
-                }
-                else {
-                    ev.inlineName = std::move(displayName);
-                }
-                ev.tsUs = (sample.startUsAbs >= traceStartUs_) ? (sample.startUsAbs - traceStartUs_) : 0;
-                ev.durUs = sample.durUs;
-                ev.threadIndex = sample.threadIndex;
-                traceEvents_.push_back(std::move(ev));
-            }
-            traceSampleScratch_.clear();
+            DrainTraceSampleNodes(traceStartUs_);
 
             TraceEvent hev;
-            hev.inlineName = L"TraceHandling";
+            hev.key = kTraceHandlingKey;
             hev.tsUs = endUs - traceStartUs_;
             hev.durUs = ToMicroseconds(CoolClock::now()) - endUs;
             hev.threadIndex = threadIdx;
@@ -423,9 +553,8 @@ void Profiler::EndFrame() {
                 traceStartUs_ = 0;
                 traceStartSet_ = false;
                 traceDump.events = std::move(traceEvents_);
-                traceDump.names = std::move(traceNames_);
-                traceNameLookup_.clear();
                 traceDump.threadNames = threadIndexToName_;
+                traceDump.dynamicKeys = GetTraceStringTable().TakeCaptureKeys();
                 haveTraceDump = true;
                 traceRequestFrameCount_ = 0;
             }
@@ -445,13 +574,7 @@ void Profiler::EndFrame() {
     }
 #endif
 
-    auto overlayJob =
-#if PROF_GPU_ENABLED
-        [this, samples = std::move(samples), gpuSamples = std::move(gpuSamples), traceDump = std::move(traceDump), haveTraceDump]() mutable
-#else
-        [this, samples = std::move(samples), traceDump = std::move(traceDump), haveTraceDump]() mutable
-#endif
-    {
+    auto overlayJob = [this, haveTraceDump]() mutable {
         const auto t0 = CoolClock::now();
 
         // A) свёртка сэмплов в stats_ (без локов) + EMA/lastCount
@@ -473,12 +596,12 @@ void Profiler::EndFrame() {
             }
         };
 
-        accumulateSamples(samples, stats_, nextOverlayId_);
-        samples.clear();
+        accumulateSamples(asyncCpuSamples_, stats_, nextOverlayId_);
+        asyncCpuSamples_.clear();
 
 #if PROF_GPU_ENABLED
-        accumulateSamples(gpuSamples, gpuStats_, nextGpuOverlayId_);
-        gpuSamples.clear();
+        accumulateSamples(asyncGpuSamples_, gpuStats_, nextGpuOverlayId_);
+        asyncGpuSamples_.clear();
 #endif
 
         // B) формируем текущий набор строк, переиспользуя выделенные буферы
@@ -666,8 +789,15 @@ void Profiler::EndFrame() {
         overlayReadBuf_.store(writeIdx, std::memory_order_release);
 #endif
 
-        if (haveTraceDump && !traceDump.events.empty()) {
-            WriteTraceJson(traceDump.events, traceDump.threadNames, traceDump.names);
+        if (haveTraceDump) {
+            auto& traceDump = traceDumpData_;
+            if (!traceDump.events.empty()) {
+                WriteTraceJson(traceDump.events, traceDump.threadNames);
+            }
+            ReleaseTraceNameKeys(traceDump.dynamicKeys);
+            traceDump.events.clear();
+            traceDump.threadNames.clear();
+            traceDump.dynamicKeys.clear();
         }
     };
 
@@ -701,7 +831,7 @@ void Profiler::PushSample(const ScopeNameKey& key, CpuClock::time_point start, C
     const uint32_t threadIdx = GetThreadIndexForCurrentThread();
     TraceSampleNode* traceNode = AcquireTraceSampleNode();
     traceNode->sample.key = key;
-    traceNode->sample.startUsAbs = startUs;
+    traceNode->sample.tsUs = startUs;
     traceNode->sample.durUs = durUs;
     traceNode->sample.threadIndex = threadIdx;
     if (!PushTraceSampleNode(traceNode)) {
@@ -785,7 +915,7 @@ void Profiler::BeginGpuFrame(ID3D12GraphicsCommandList* cl) {
         gpuFrameSampleIdx_.store(SIZE_MAX, std::memory_order_relaxed);
         return;
     }
-    const size_t idx = BeginGpuSample(cl, ScopeNameKey::FromWide(L"GPU.Frame", 0));
+    const size_t idx = BeginGpuSample(cl, kGpuFrameKey);
     gpuFrameSampleIdx_.store(idx, std::memory_order_relaxed);
 #else
     (void)cl;
@@ -851,7 +981,7 @@ void Profiler::EndGpuSample(ID3D12GraphicsCommandList* cl, size_t idx) {
 
 void Profiler::EmitOverlay(TextManager* tm, int x, int y, int maxLines) {
     if (!tm || !GetEnabled()) { return; }
-    CPU_SCOPE(L"Profiler::EmitOverlay");
+    CPU_SCOPE(kProfilerEmitOverlayKey);
 
     // читаем актуальные read-буферы БЕЗ локов
     const int readIdx = overlayReadBuf_.load(std::memory_order_acquire);
@@ -1034,8 +1164,7 @@ uint32_t Profiler::GetThreadIndex_Locked(std::thread::id id) {
 }
 
 void Profiler::WriteTraceJson(const std::vector<TraceEvent>& events,
-                              const std::vector<std::string>& threadNames,
-                              const std::vector<TraceNameEntry>& names) {
+                              const std::vector<std::string>& threadNames) {
     if (events.empty()) { return; }
     const uint32_t fileIdx = traceFileCounter_.fetch_add(1u, std::memory_order_relaxed);
     auto now = std::chrono::system_clock::now();
@@ -1065,6 +1194,11 @@ void Profiler::WriteTraceJson(const std::vector<TraceEvent>& events,
         out << line;
     };
 
+    static const std::wstring kUnknownWide = L"unknown";
+    static const std::string  kUnknownNarrow = "unknown";
+    robin_hood::unordered_flat_map<const std::wstring*, std::string> nameLookup;
+    nameLookup.reserve(events.size());
+
     for (size_t tid = 0; tid < threadNames.size(); ++tid) {
         if (threadNames[tid].empty()) { continue; }
         std::ostringstream line;
@@ -1074,13 +1208,19 @@ void Profiler::WriteTraceJson(const std::vector<TraceEvent>& events,
     }
 
     for (const auto& ev : events) {
-        std::wstring nameWide = ev.inlineName;
-        if (nameWide.empty() && ev.nameIndex < names.size()) {
-            nameWide = names[ev.nameIndex].displayName;
+        const std::wstring* nameWidePtr = ev.key.name;
+        if (!nameWidePtr || nameWidePtr->empty()) {
+            nameWidePtr = &kUnknownWide;
         }
-        if (nameWide.empty()) { nameWide = L"unknown"; }
-        std::string name = WideToUtf8(nameWide);
-        if (name.empty()) { name = "unknown"; }
+        auto lookupIt = nameLookup.find(nameWidePtr);
+        if (lookupIt == nameLookup.end()) {
+            std::string narrow = WideToUtf8(*nameWidePtr);
+            if (narrow.empty()) {
+                narrow = kUnknownNarrow;
+            }
+            lookupIt = nameLookup.emplace(nameWidePtr, std::move(narrow)).first;
+        }
+        const std::string& name = lookupIt->second;
         std::ostringstream line;
         line << "  {\"name\":\"" << EscapeJson(name) << "\",\"cat\":\"CPU\",\"ph\":\"X\",\"ts\":"
              << ev.tsUs << ",\"dur\":" << ev.durUs << ",\"pid\":0,\"tid\":" << ev.threadIndex << "}";

--- a/Profiler.h
+++ b/Profiler.h
@@ -11,7 +11,6 @@
 #include <optional>
 #include <string_view>
 #include <cstring>
-#include <limits>
 
 #include "TaskSystem.h"
 
@@ -37,11 +36,10 @@ public:
     using CpuClock = std::chrono::steady_clock;
 
     struct ScopeNameKey {
-        const wchar_t* namePtr = nullptr;
-        uint64_t       nameId = 0;
+        const std::wstring* name = nullptr;
 
-        static ScopeNameKey FromWide(const wchar_t* ptr, uint64_t id) {
-            return ScopeNameKey{ ptr, id };
+        const wchar_t* c_str() const noexcept {
+            return name ? name->c_str() : nullptr;
         }
     };
 
@@ -85,39 +83,34 @@ public:
     struct ScopeNameKeyHash {
         using is_avalanching = void;
         size_t operator()(const ScopeNameKey& key) const noexcept {
-            if (key.nameId != 0) {
-                return robin_hood::hash_bytes(&key.nameId, sizeof(key.nameId));
-            }
-            return robin_hood::hash_bytes(&key.namePtr, sizeof(key.namePtr));
+            return robin_hood::hash_bytes(&key.name, sizeof(key.name));
         }
     };
 
     struct ScopeNameKeyEqual {
         bool operator()(const ScopeNameKey& a, const ScopeNameKey& b) const noexcept {
-            if (a.nameId != 0 || b.nameId != 0) {
-                return a.nameId == b.nameId;
-            }
-            return a.namePtr == b.namePtr;
+            return a.name == b.name;
         }
     };
 
     struct TraceEvent {
-        uint32_t    nameIndex = std::numeric_limits<uint32_t>::max();
-        std::wstring inlineName;
-        uint64_t    tsUs = 0;
-        uint64_t    durUs = 0;
-        uint32_t    threadIndex = 0;
+        ScopeNameKey key{};
+        uint64_t     tsUs = 0;
+        uint64_t     durUs = 0;
+        uint32_t     threadIndex = 0;
     };
 
     struct TraceNameEntry {
         std::wstring displayName;
+        ScopeNameKey key{};
+        bool         isDynamic = false;
+        bool         dynamicInUse = false;
     };
 
-    struct TraceSample {
-        ScopeNameKey key{};
-        uint64_t     startUsAbs = 0;
-        uint64_t     durUs = 0;
-        uint32_t     threadIndex = 0;
+    struct TraceDumpData {
+        std::vector<TraceEvent> events;
+        std::vector<std::string> threadNames;
+        std::vector<ScopeNameKey> dynamicKeys;
     };
 
     // --- данные оверлея (снэпшот) ---
@@ -132,6 +125,9 @@ public:
 
 public:
     static Profiler& Get();
+
+    static ScopeNameKey RegisterTraceLiteral(const wchar_t* name);
+    static ScopeNameKey RegisterTraceDynamic(std::wstring name, uint32_t* outIndex = nullptr);
 
     // Границы кадра
     void BeginFrame(uint64_t frameNo);
@@ -148,9 +144,9 @@ public:
     // Скоповая отметка (CPU)
     class ScopedCpu {
     public:
-        ScopedCpu(const wchar_t* name, uint64_t nameId = 0) {
+        ScopedCpu(ScopeNameKey key) {
 #if PROF_ENABLED
-            key_ = ScopeNameKey::FromWide(name, nameId);
+            key_ = key;
             start_ = Clock::now();
 #endif
         }
@@ -169,18 +165,18 @@ public:
     };
 
 #if PROF_ENABLED
-#define CPU_SCOPE(nameLiteral)       Profiler::ScopedCpu _prof_scope_##__LINE__(nameLiteral, 0)
-#define CPU_SCOPE_N(nameLiteral, id) Profiler::ScopedCpu _prof_scope_##__LINE__(nameLiteral, (id))
+#define CPU_SCOPE(keyExpr)       Profiler::ScopedCpu _prof_scope_##__LINE__(keyExpr)
+#define CPU_SCOPE_N(keyExpr, id) Profiler::ScopedCpu _prof_scope_##__LINE__(keyExpr)
 #else
-#define CPU_SCOPE(nameLiteral)       do { } while (0)
-#define CPU_SCOPE_N(nameLiteral, id) do { } while (0)
+#define CPU_SCOPE(keyExpr)       do { } while (0)
+#define CPU_SCOPE_N(keyExpr, id) do { } while (0)
 #endif
 
 #if PROF_GPU_ENABLED
     // Скоповая отметка (GPU)
     class ScopedGpu {
     public:
-        ScopedGpu(ID3D12GraphicsCommandList* cl, const wchar_t* name, uint64_t nameId = 0);
+        ScopedGpu(ID3D12GraphicsCommandList* cl, ScopeNameKey key);
         ~ScopedGpu();
     private:
 #if PROF_ENABLED
@@ -190,19 +186,19 @@ public:
     };
 
 #if PROF_ENABLED
-#define GPU_SCOPE(cmdList, nameLiteral)       Profiler::ScopedGpu _prof_gpu_scope_##__LINE__(cmdList, nameLiteral, 0)
-#define GPU_SCOPE_N(cmdList, nameLiteral, id) Profiler::ScopedGpu _prof_gpu_scope_##__LINE__(cmdList, nameLiteral, (id))
+#define GPU_SCOPE(cmdList, keyExpr)       Profiler::ScopedGpu _prof_gpu_scope_##__LINE__(cmdList, keyExpr)
+#define GPU_SCOPE_N(cmdList, keyExpr, id) Profiler::ScopedGpu _prof_gpu_scope_##__LINE__(cmdList, keyExpr)
 #else
-#define GPU_SCOPE(cmdList, nameLiteral)       do { } while (0)
-#define GPU_SCOPE_N(cmdList, nameLiteral, id) do { } while (0)
+#define GPU_SCOPE(cmdList, keyExpr)       do { } while (0)
+#define GPU_SCOPE_N(cmdList, keyExpr, id) do { } while (0)
 #endif
 #else
     class ScopedGpu {
     public:
         ScopedGpu(... ) {}
     };
-#define GPU_SCOPE(cmdList, nameLiteral)       do { } while (0)
-#define GPU_SCOPE_N(cmdList, nameLiteral, id) do { } while (0)
+#define GPU_SCOPE(cmdList, keyExpr)       do { } while (0)
+#define GPU_SCOPE_N(cmdList, keyExpr, id) do { } while (0)
 #endif
 
     // Оверлей с табличкой (читает дабл-буфер без локов)
@@ -255,8 +251,8 @@ private:
     void ResetMax_Unsafe(); // вызывать под mtx_
     uint32_t GetThreadIndex_Locked(std::thread::id id);
     void WriteTraceJson(const std::vector<TraceEvent>& events,
-                        const std::vector<std::string>& threadNames,
-                        const std::vector<TraceNameEntry>& names);
+                        const std::vector<std::string>& threadNames);
+    void ReleaseTraceNameKeys(const std::vector<ScopeNameKey>& keys);
 #endif
 
 private:
@@ -287,7 +283,7 @@ private:
     uint32_t    GetThreadIndexForCurrentThread();
 
     struct TraceSampleNode {
-        TraceSample sample;
+        TraceEvent sample;
         TraceSampleNode* next = nullptr;
     };
 
@@ -297,7 +293,7 @@ private:
     void             ReleaseTraceSampleNode(TraceSampleNode* node);
     void             ReleaseTraceSampleList(TraceSampleNode* head);
     bool             PushTraceSampleNode(TraceSampleNode* node);
-    void             DrainTraceSampleNodes(std::vector<TraceSample>& out);
+    void             DrainTraceSampleNodes(uint64_t traceStartUs);
 
     std::atomic<SampleNode*> frameSampleHead_{ nullptr };
     std::atomic<SampleNode*> sampleNodePool_{ nullptr };
@@ -376,10 +372,12 @@ private:
     uint64_t traceStartUs_ = 0;
     bool traceStartSet_ = false;
     std::vector<TraceEvent> traceEvents_;
-    std::vector<TraceNameEntry> traceNames_;
-    robin_hood::unordered_flat_map<ScopeNameKey, uint32_t, ScopeNameKeyHash, ScopeNameKeyEqual> traceNameLookup_;
     std::atomic<uint32_t> traceFileCounter_{ 0 };
-    std::vector<TraceSample> traceSampleScratch_;
+    std::vector<ScopeSample> asyncCpuSamples_;
+#if PROF_GPU_ENABLED
+    std::vector<ScopeSample> asyncGpuSamples_;
+#endif
+    TraceDumpData traceDumpData_;
 
 #if PROF_GPU_ENABLED
     // GPU timestamp queries

--- a/ProfilerScopes.cpp
+++ b/ProfilerScopes.cpp
@@ -1,0 +1,51 @@
+#include "ProfilerScopes.h"
+
+namespace ProfilerScopes {
+
+const Profiler::ScopeNameKey kWholeCycle = Profiler::RegisterTraceLiteral(L"Whole Cycle");
+const Profiler::ScopeNameKey kWinMessages = Profiler::RegisterTraceLiteral(L"Win Messages");
+
+const Profiler::ScopeNameKey kMaterialFSProbe = Profiler::RegisterTraceLiteral(L"Material::FSProbeAndFlagPending");
+
+const Profiler::ScopeNameKey kRendererWaitForFrame = Profiler::RegisterTraceLiteral(L"Renderer::WaitForFrame");
+const Profiler::ScopeNameKey kRendererBeginFrame = Profiler::RegisterTraceLiteral(L"Renderer::BeginFrame");
+const Profiler::ScopeNameKey kRendererBeginThreadCommandList = Profiler::RegisterTraceLiteral(L"Renderer::BeginThreadCommandList");
+const Profiler::ScopeNameKey kRendererEndThreadCommandList = Profiler::RegisterTraceLiteral(L"Renderer::EndThreadCommandList");
+const Profiler::ScopeNameKey kRendererEndThreadCommandBundle = Profiler::RegisterTraceLiteral(L"Renderer::EndThreadCommandBundle");
+const Profiler::ScopeNameKey kRendererExecuteTimelineAndPresent = Profiler::RegisterTraceLiteral(L"Renderer::ExecuteTimelineAndPresent");
+const Profiler::ScopeNameKey kRendererTransition = Profiler::RegisterTraceLiteral(L"Renderer::Transition");
+
+const Profiler::ScopeNameKey kSceneTick = Profiler::RegisterTraceLiteral(L"Scene::Tick");
+const Profiler::ScopeNameKey kSceneRender = Profiler::RegisterTraceLiteral(L"Scene::Render");
+const Profiler::ScopeNameKey kPassPrologueClear = Profiler::RegisterTraceLiteral(L"Pass_PrologueClear");
+const Profiler::ScopeNameKey kPassCSM = Profiler::RegisterTraceLiteral(L"Pass_CSM");
+const Profiler::ScopeNameKey kPassGBuffer = Profiler::RegisterTraceLiteral(L"Pass_GBuffer");
+const Profiler::ScopeNameKey kPassLighting = Profiler::RegisterTraceLiteral(L"Pass_Lighting");
+const Profiler::ScopeNameKey kPassPointLights = Profiler::RegisterTraceLiteral(L"Pass_PointLights");
+const Profiler::ScopeNameKey kPassSkybox = Profiler::RegisterTraceLiteral(L"Pass_Skybox");
+const Profiler::ScopeNameKey kPassSSR = Profiler::RegisterTraceLiteral(L"Pass_SSR");
+const Profiler::ScopeNameKey kPassSSRBlur = Profiler::RegisterTraceLiteral(L"Pass_SSR.Blur");
+const Profiler::ScopeNameKey kPassCompose = Profiler::RegisterTraceLiteral(L"Pass_Compose");
+const Profiler::ScopeNameKey kPassTransparent = Profiler::RegisterTraceLiteral(L"Pass_Transparent");
+const Profiler::ScopeNameKey kPassTonemap = Profiler::RegisterTraceLiteral(L"Pass_Tonemap");
+const Profiler::ScopeNameKey kPassDebug = Profiler::RegisterTraceLiteral(L"Pass_Debug");
+const Profiler::ScopeNameKey kFrameAsyncWait = Profiler::RegisterTraceLiteral(L"Frame Async Wait");
+const Profiler::ScopeNameKey kPassOverlay = Profiler::RegisterTraceLiteral(L"Pass_Overlay");
+const Profiler::ScopeNameKey kOverlayAsyncWait = Profiler::RegisterTraceLiteral(L"Overlay Async Wait");
+const Profiler::ScopeNameKey kRenderObjectBatchAsync = Profiler::RegisterTraceLiteral(L"RenderObjectBatch.Async");
+const Profiler::ScopeNameKey kRenderShadowBatchAsync = Profiler::RegisterTraceLiteral(L"RenderShadowBatch.Async");
+const Profiler::ScopeNameKey kCSMPerCascade = Profiler::RegisterTraceLiteral(L"CSM.PerCascade");
+const Profiler::ScopeNameKey kRenderObjectBatchGpu = Profiler::RegisterTraceLiteral(L"RenderObjectBatch");
+const Profiler::ScopeNameKey kRenderShadowBatchGpu = Profiler::RegisterTraceLiteral(L"RenderShadowBatch");
+const Profiler::ScopeNameKey kGBufferDriver = Profiler::RegisterTraceLiteral(L"GBuffer.Driver");
+const Profiler::ScopeNameKey kTransparentDriver = Profiler::RegisterTraceLiteral(L"Transparent.Driver");
+
+const Profiler::ScopeNameKey kTextManagerBuild = Profiler::RegisterTraceLiteral(L"TextManager::Build");
+const Profiler::ScopeNameKey kTextManagerDraw = Profiler::RegisterTraceLiteral(L"TextManager::Draw");
+const Profiler::ScopeNameKey kTextManagerEmitImmediate = Profiler::RegisterTraceLiteral(L"TextManager::EmitTextImmediate");
+
+const Profiler::ScopeNameKey kRenderGraphExecute = Profiler::RegisterTraceLiteral(L"RenderGraph::Execute");
+const Profiler::ScopeNameKey kRenderGraphExecuteParallel = Profiler::RegisterTraceLiteral(L"RenderGraph::ExecuteParallel");
+
+} // namespace ProfilerScopes
+

--- a/ProfilerScopes.h
+++ b/ProfilerScopes.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "Profiler.h"
+
+namespace ProfilerScopes {
+
+// App
+extern const Profiler::ScopeNameKey kWholeCycle;
+extern const Profiler::ScopeNameKey kWinMessages;
+
+// Material
+extern const Profiler::ScopeNameKey kMaterialFSProbe;
+
+// Renderer
+extern const Profiler::ScopeNameKey kRendererWaitForFrame;
+extern const Profiler::ScopeNameKey kRendererBeginFrame;
+extern const Profiler::ScopeNameKey kRendererBeginThreadCommandList;
+extern const Profiler::ScopeNameKey kRendererEndThreadCommandList;
+extern const Profiler::ScopeNameKey kRendererEndThreadCommandBundle;
+extern const Profiler::ScopeNameKey kRendererExecuteTimelineAndPresent;
+extern const Profiler::ScopeNameKey kRendererTransition;
+
+// Scene
+extern const Profiler::ScopeNameKey kSceneTick;
+extern const Profiler::ScopeNameKey kSceneRender;
+extern const Profiler::ScopeNameKey kPassPrologueClear;
+extern const Profiler::ScopeNameKey kPassCSM;
+extern const Profiler::ScopeNameKey kPassGBuffer;
+extern const Profiler::ScopeNameKey kPassLighting;
+extern const Profiler::ScopeNameKey kPassPointLights;
+extern const Profiler::ScopeNameKey kPassSkybox;
+extern const Profiler::ScopeNameKey kPassSSR;
+extern const Profiler::ScopeNameKey kPassSSRBlur;
+extern const Profiler::ScopeNameKey kPassCompose;
+extern const Profiler::ScopeNameKey kPassTransparent;
+extern const Profiler::ScopeNameKey kPassTonemap;
+extern const Profiler::ScopeNameKey kPassDebug;
+extern const Profiler::ScopeNameKey kFrameAsyncWait;
+extern const Profiler::ScopeNameKey kPassOverlay;
+extern const Profiler::ScopeNameKey kOverlayAsyncWait;
+extern const Profiler::ScopeNameKey kRenderObjectBatchAsync;
+extern const Profiler::ScopeNameKey kRenderShadowBatchAsync;
+extern const Profiler::ScopeNameKey kCSMPerCascade;
+extern const Profiler::ScopeNameKey kRenderObjectBatchGpu;
+extern const Profiler::ScopeNameKey kRenderShadowBatchGpu;
+extern const Profiler::ScopeNameKey kGBufferDriver;
+extern const Profiler::ScopeNameKey kTransparentDriver;
+
+// TextManager
+extern const Profiler::ScopeNameKey kTextManagerBuild;
+extern const Profiler::ScopeNameKey kTextManagerDraw;
+extern const Profiler::ScopeNameKey kTextManagerEmitImmediate;
+
+// RenderGraph
+extern const Profiler::ScopeNameKey kRenderGraphExecute;
+extern const Profiler::ScopeNameKey kRenderGraphExecuteParallel;
+
+} // namespace ProfilerScopes
+

--- a/RenderGraph.h
+++ b/RenderGraph.h
@@ -7,6 +7,7 @@
 #include "Renderer.h"
 #include "TaskSystem.h"
 #include "Profiler.h"
+#include "ProfilerScopes.h"
 
 class RenderGraph {
 public:
@@ -55,7 +56,7 @@ public:
     // Старое: последовательное исполнение (на место)
     void Execute(Renderer* renderer)
     {
-        CPU_SCOPE(L"RenderGraph::Execute");
+        CPU_SCOPE(ProfilerScopes::kRenderGraphExecute);
         if (renderer == nullptr) { return; }
         Unroll(renderer, /*executeInplace=*/true, nullptr);
     }
@@ -73,7 +74,7 @@ public:
     // сабмитим РЕАЛЬНЫЕ таски пассов с ожиданием их mt-deps.
     void ExecuteParallel(Renderer* renderer, TaskSystem& tasks)
     {
-        CPU_SCOPE(L"RenderGraph::ExecuteParallel");
+        CPU_SCOPE(ProfilerScopes::kRenderGraphExecuteParallel);
 #if !TASKSYSTEM_ENABLE_PARALLEL_EXECUTION
         (void)tasks;
         Execute(renderer);

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -6,6 +6,7 @@
 #include <d3d12sdklayers.h> // ID3D12Debug*, ID3D12InfoQueue
 #include <mimalloc.h>
 #include "Profiler.h"
+#include "ProfilerScopes.h"
 
 thread_local uint32_t Renderer::tlLaneIndex_ = UINT32_MAX;
 thread_local Renderer::CLStateEntry* Renderer::tlCurrentEntry_ = nullptr;
@@ -315,7 +316,7 @@ void Renderer::CreateDepthResources(UINT width, UINT height) {
 }
 
 void Renderer::WaitForFrame(UINT frameIndex) {
-    CPU_SCOPE(L"Renderer::WaitForFrame");
+    CPU_SCOPE(ProfilerScopes::kRendererWaitForFrame);
     const UINT64 value = frameFenceValues_[frameIndex];
     if (value == 0) {
         return; // ещё не сигналили этот кадр — ждать нечего
@@ -356,7 +357,7 @@ void Renderer::RefreshCurrentFrameCaches() {
 }
 
 void Renderer::BeginFrame() {
-    CPU_SCOPE(L"Renderer::BeginFrame");
+    CPU_SCOPE(ProfilerScopes::kRendererBeginFrame);
     // Ждём GPU по своему backbuffer'у
     WaitForFrame(currentFrameIndex_);
 
@@ -444,7 +445,7 @@ bool Renderer::ConsumeMaterialHotReloadFlag()
 
 Renderer::ThreadCL Renderer::BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE type, ID3D12PipelineState* pso)
 {
-    CPU_SCOPE(L"Renderer::BeginThreadCommandList");
+    CPU_SCOPE(ProfilerScopes::kRendererBeginThreadCommandList);
     ID3D12GraphicsCommandList* cl = 0;
     ID3D12CommandAllocator* alloc = 0;
     FrameResource* fr = currentFrameResource_;
@@ -477,7 +478,7 @@ Renderer::ThreadCL Renderer::BeginThreadCommandBundle(ID3D12PipelineState* initi
 }
 
 void Renderer::EndThreadCommandList(ThreadCL& t, size_t batchIndex) {
-    CPU_SCOPE(L"Renderer::EndThreadCommandList");
+    CPU_SCOPE(ProfilerScopes::kRendererEndThreadCommandList);
     if (!t.cl) { return; }
     ThrowIfFailed(t.cl->Close());
 
@@ -519,7 +520,7 @@ void Renderer::RegisterPassDriver(ID3D12GraphicsCommandList* cl, size_t batchInd
 
 void Renderer::EndThreadCommandBundle(ThreadCL& b, size_t batchIndex)
 {
-    CPU_SCOPE(L"Renderer::EndThreadCommandBundle");
+    CPU_SCOPE(ProfilerScopes::kRendererEndThreadCommandBundle);
     if (b.cl != nullptr) {
         ThrowIfFailed(b.cl->Close());
         std::lock_guard<std::mutex> lk(submitMtx_);
@@ -532,7 +533,7 @@ void Renderer::EndThreadCommandBundle(ThreadCL& b, size_t batchIndex)
 }
 
 void Renderer::ExecuteTimelineAndPresent() {
-    CPU_SCOPE(L"Renderer::ExecuteTimelineAndPresent");
+    CPU_SCOPE(ProfilerScopes::kRendererExecuteTimelineAndPresent);
 
     submitListsScratch_.clear();
 
@@ -768,7 +769,7 @@ D3D12_RESOURCE_STATES Renderer::GetGlobalKnownState(ID3D12Resource* res)
 
 void Renderer::Transition(ID3D12GraphicsCommandList* cl, ID3D12Resource* res, D3D12_RESOURCE_STATES after) {
     if (!cl || !res) { return; }
-    CPU_SCOPE(L"Renderer::Transition");
+    CPU_SCOPE(ProfilerScopes::kRendererTransition);
     ID3D12CommandList* base = static_cast<ID3D12CommandList*>(cl);
 
     // быстрый путь — активный CL лежит в TLS

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -15,6 +15,7 @@
 #include "TaskSystem.h"
 #include "TextManager.h"
 #include "Profiler.h"
+#include "ProfilerScopes.h"
 
 void Scene::CBHandleCache::LightingHandles::Populate(Material* material)
 {
@@ -319,7 +320,7 @@ void Scene::AddObject(std::unique_ptr<RenderableObjectBase> obj) {
 }
 
 void Scene::Tick(float deltaTime) {
-    CPU_SCOPE(L"Scene::Tick");
+    CPU_SCOPE(ProfilerScopes::kSceneTick);
 
     if (input_ != nullptr && actions_ != nullptr)
     {
@@ -357,7 +358,7 @@ void Scene::Render(Renderer* renderer) {
     if (!renderer) {
         return;
     }
-    CPU_SCOPE(L"Scene::Render");
+    CPU_SCOPE(ProfilerScopes::kSceneRender);
 
     if (actions_->WasActionPressed("Wireframe", *input_)) {
         renderer->SetWireframeMode(!renderer->GetWireframeMode());
@@ -407,65 +408,65 @@ void Scene::Render(Renderer* renderer) {
 
     RenderGraph rg;
     auto pClear = rg.AddPass("PrologueClear", {},
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_PrologueClear"); Pass_PrologueClear(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(ProfilerScopes::kPassPrologueClear); Pass_PrologueClear(renderer, ctx); });
 
     auto pShadow = rg.AddPass("CSM", { pClear },
         [this, renderer, &view, &proj, &invView, &invProj, zNear, zFar, camDir, &buckets]
         (RenderGraph::PassContext ctx) {
-            CPU_SCOPE(L"Pass_CSM");
+            CPU_SCOPE(ProfilerScopes::kPassCSM);
             Pass_CSM(renderer, ctx, view, proj, invView, invProj, zNear, zFar, camDir, buckets);
         });
 
     auto pGbuf = rg.AddPass("GBuffer", { pShadow },
         [this, renderer, &view, &proj, &buckets](RenderGraph::PassContext ctx) {
-            CPU_SCOPE(L"Pass_GBuffer");
+            CPU_SCOPE(ProfilerScopes::kPassGBuffer);
             Pass_GBuffer(renderer, ctx, view, proj, buckets);
         });
 
     auto pLight = rg.AddPassMT("Lighting", { pGbuf }, { pShadow },
         [this, renderer, &view, &proj, &invView, &invProj, camDir](RenderGraph::PassContext ctx) {
-            CPU_SCOPE(L"Pass_Lighting");
+            CPU_SCOPE(ProfilerScopes::kPassLighting);
             Pass_Lighting(renderer, ctx, view, proj, invView, invProj, camDir);
         });
 
     auto pPointLights = rg.AddPass("PointLights", { pLight },
         [this, renderer, &view, &proj, &invView, &invProj](RenderGraph::PassContext ctx) {
-            CPU_SCOPE(L"Pass_PointLights");
+            CPU_SCOPE(ProfilerScopes::kPassPointLights);
             Pass_PointLights(renderer, ctx, view, proj, invView, invProj);
         });
 
     auto pSky = rg.AddPass("Skybox", { pPointLights },
         [this, renderer, &view, &proj](RenderGraph::PassContext ctx) {
-            CPU_SCOPE(L"Pass_Skybox");
+            CPU_SCOPE(ProfilerScopes::kPassSkybox);
             Pass_Skybox(renderer, ctx, view, proj);
         });
 
     auto pSSR = rg.AddPass("SSR", { pSky },
         [this, renderer, &view, &proj, &invView, &invProj, zNear, zFar](RenderGraph::PassContext ctx) {
-            CPU_SCOPE(L"Pass_SSR");
+            CPU_SCOPE(ProfilerScopes::kPassSSR);
             Pass_SSR(renderer, ctx, view, proj, invView, invProj, zNear, zFar);
         });
 
     auto pBlur = rg.AddPass("SSR.Blur", { pSSR },
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_SSR.Blur"); Pass_SSR_Blur(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(ProfilerScopes::kPassSSRBlur); Pass_SSR_Blur(renderer, ctx); });
 
     auto pCompose = rg.AddPass("Compose", { pBlur },
         [this, renderer, &view, &proj, &invView, &invProj, zNear, zFar](RenderGraph::PassContext ctx) {
-            CPU_SCOPE(L"Pass_Compose");
+            CPU_SCOPE(ProfilerScopes::kPassCompose);
             Pass_Compose(renderer, ctx, view, proj, invView, invProj, zNear, zFar);
         });
 
     auto pTransp = rg.AddPass("Transparent", { pCompose },
         [this, renderer, &view, &proj, &buckets](RenderGraph::PassContext ctx) {
-            CPU_SCOPE(L"Pass_Transparent");
+            CPU_SCOPE(ProfilerScopes::kPassTransparent);
             Pass_Transparent(renderer, ctx, view, proj, buckets);
         });
 
     auto pTone = rg.AddPass("Tonemap", { pTransp },
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_Tonemap"); Pass_Tonemap(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(ProfilerScopes::kPassTonemap); Pass_Tonemap(renderer, ctx); });
 
     rg.AddPass("Debug", { pTone },
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_Debug"); Pass_Debug(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(ProfilerScopes::kPassDebug); Pass_Debug(renderer, ctx); });
 
 #if TASKSYSTEM_ENABLE_PARALLEL_EXECUTION
     rg.ExecuteParallel(renderer, TaskSystem::Get());
@@ -474,17 +475,17 @@ void Scene::Render(Renderer* renderer) {
 #endif
 
     {
-        CPU_SCOPE(L"Frame Async Wait");
+        CPU_SCOPE(ProfilerScopes::kFrameAsyncWait);
         TaskSystem::Get().WaitForTrackedAsyncTasks();
     }
 
     RenderGraph epilogueRG;
     epilogueRG.AddPass("Overlay", {},
-        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(L"Pass_Overlay"); Pass_Overlay(renderer, ctx); });
+        [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(ProfilerScopes::kPassOverlay); Pass_Overlay(renderer, ctx); });
     epilogueRG.Execute(renderer);
     
     {
-        CPU_SCOPE(L"Overlay Async Wait");
+        CPU_SCOPE(ProfilerScopes::kOverlayAsyncWait);
         TaskSystem::Get().WaitForTrackedAsyncTasks();
     }
     renderer->EndFrame();
@@ -509,7 +510,7 @@ void Scene::RenderObjectBatch(Renderer* renderer,
 
     auto renderJob = [renderer, &view, &proj, &objects, useBundles, chunkSize, batchIndex, bindGbufOrScene](std::size_t jobIndex)
     {
-        CPU_SCOPE(L"RenderObjectBatch.Async");
+        CPU_SCOPE(ProfilerScopes::kRenderObjectBatchAsync);
         const size_t begin = jobIndex * chunkSize;
         const size_t end = std::min(begin + chunkSize, objects.size());
 
@@ -525,7 +526,7 @@ void Scene::RenderObjectBatch(Renderer* renderer,
         else {
             auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
             {
-                GPU_SCOPE(t.cl, L"RenderObjectBatch");
+                GPU_SCOPE(t.cl, ProfilerScopes::kRenderObjectBatchGpu);
                 if (bindGbufOrScene)
                 {
                     renderer->BindGBuffer(t.cl, Renderer::ClearMode::None); // без очистки!
@@ -576,7 +577,7 @@ void Scene::RenderShadowBatch(Renderer* renderer,
 
     auto shadowJob = [renderer, &objects, &lightView, &lightProj, cascadeIndex, chunkSize, batchIndex](std::size_t jobIndex)
     {
-        CPU_SCOPE(L"RenderShadowBatch.Async");
+        CPU_SCOPE(ProfilerScopes::kRenderShadowBatchAsync);
         const size_t begin = jobIndex * chunkSize;
         const size_t end = std::min(begin + chunkSize, objects.size());
 
@@ -584,7 +585,7 @@ void Scene::RenderShadowBatch(Renderer* renderer,
         auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         t.cl->SetName(L"RenderShadowBatch");
         {
-            GPU_SCOPE(t.cl, L"RenderShadowBatch");
+            GPU_SCOPE(t.cl, ProfilerScopes::kRenderShadowBatchGpu);
 
             // важное: привязываем нужный тайл атласа каскада, без очистки
             renderer->BindShadowTarget(t.cl, cascadeIndex, /*clear=*/false);
@@ -614,7 +615,7 @@ void Scene::Pass_PrologueClear(Renderer* r, RenderGraph::PassContext ctx)
     auto t = r->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_PrologueClear");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassPrologueClear);
         r->RecordBindAndClear(t.cl);
     }
     r->EndThreadCommandList(t, ctx.batchIndex);
@@ -628,7 +629,7 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
     auto d = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     d.cl->SetName(L"CSM");
     {
-        GPU_SCOPE(d.cl, L"Pass_CSM");
+        GPU_SCOPE(d.cl, ProfilerScopes::kPassCSM);
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(d.cl, D.shadow.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE);
         renderer->BindShadowTarget(d.cl, 0, /*clear=*/true);
@@ -649,7 +650,7 @@ void Scene::Pass_CSM(Renderer* renderer, RenderGraph::PassContext ctx,
     TaskSystem& tasks = TaskSystem::Get();
     auto csmJob = [this, renderer, &buckets, &invView, &invProj, &proj, camDir, sunDirWS = dirLight_.dir, batchIndex](std::size_t idx)
     {
-        CPU_SCOPE(L"CSM.PerCascade");
+        CPU_SCOPE(ProfilerScopes::kCSMPerCascade);
         const auto& D = renderer->GetDeferredForFrame();
 
         float sliceNear = cachedSplitsVS_[idx], sliceFar = cachedSplitsVS_[idx + 1];
@@ -749,7 +750,7 @@ void Scene::Pass_GBuffer(Renderer* renderer, RenderGraph::PassContext ctx,
     rgGB.AddPass("GBuffer.Driver", {}, [renderer](RenderGraph::PassContext sub) {
         auto driver = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         {
-            GPU_SCOPE(driver.cl, L"GBuffer.Driver");
+            GPU_SCOPE(driver.cl, ProfilerScopes::kGBufferDriver);
 
             const auto& D = renderer->GetDeferredForFrame();
             renderer->Transition(driver.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
@@ -791,7 +792,7 @@ void Scene::Pass_Lighting(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_Lighting");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassLighting);
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(t.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
         renderer->Transition(t.cl, D.gb1.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -866,7 +867,7 @@ void Scene::Pass_PointLights(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_PointLights");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassPointLights);
 
         const auto& D = renderer->GetDeferredForFrame();
 
@@ -904,7 +905,7 @@ void Scene::Pass_Skybox(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_Skybox");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassSkybox);
 
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(t.cl, D.light.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
@@ -927,7 +928,7 @@ void Scene::Pass_SSR(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_SSR");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassSSR);
         const auto& D = renderer->GetDeferredForFrame();
 
         renderer->Transition(t.cl, D.depth.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -968,7 +969,7 @@ void Scene::Pass_SSR_Blur(Renderer* renderer, RenderGraph::PassContext ctx)
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_SSR.Blur");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassSSRBlur);
         const auto& D = renderer->GetDeferredForFrame();
         // X Pass---
         renderer->Transition(t.cl, D.ssr.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -1025,7 +1026,7 @@ void Scene::Pass_Compose(Renderer* renderer, RenderGraph::PassContext ctx,
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_Compose");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassCompose);
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(t.cl, D.gb0.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
         renderer->Transition(t.cl, D.gb1.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -1082,7 +1083,7 @@ void Scene::Pass_Transparent(Renderer* renderer, RenderGraph::PassContext ctx,
     rgTr.AddPass("Transparent.Driver", {}, [renderer](RenderGraph::PassContext sub) {
         auto driver = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         {
-            GPU_SCOPE(driver.cl, L"Transparent.Driver");
+            GPU_SCOPE(driver.cl, ProfilerScopes::kTransparentDriver);
             const auto& D = renderer->GetDeferredForFrame();
             renderer->Transition(driver.cl, D.scene.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
             renderer->Transition(driver.cl, D.depth.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE);
@@ -1115,7 +1116,7 @@ void Scene::Pass_Tonemap(Renderer* renderer, RenderGraph::PassContext ctx)
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_Tonemap");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassTonemap);
         const auto& D = renderer->GetDeferredForFrame();
         renderer->Transition(t.cl, D.scene.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
         renderer->RecordBindDefaultsNoClear(t.cl);
@@ -1145,7 +1146,7 @@ void Scene::Pass_Debug(Renderer* renderer, RenderGraph::PassContext ctx)
     auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
     t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
     {
-        GPU_SCOPE(t.cl, L"Pass_Debug");
+        GPU_SCOPE(t.cl, ProfilerScopes::kPassDebug);
         renderer->RecordBindDefaultsNoClear(t.cl);
 
         auto h = renderer->GetRenderContextPool()->Acquire();
@@ -1169,7 +1170,7 @@ void Scene::Pass_Overlay(Renderer* renderer, RenderGraph::PassContext ctx)
         auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         t.cl->SetName(std::wstring(ctx.passName.begin(), ctx.passName.end()).data());
         {
-            GPU_SCOPE(t.cl, L"Pass_Overlay");
+            GPU_SCOPE(t.cl, ProfilerScopes::kPassOverlay);
             renderer->RecordBindDefaultsNoClear(t.cl);
             if (showProfiler_)
             {

--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -14,6 +14,7 @@
 #include "Renderer.h"
 #include "FontAtlas.h"
 #include "Profiler.h"
+#include "ProfilerScopes.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -188,7 +189,7 @@ void TextManager::AddTextf(RegionId id, float px, const float4& color, const wch
 // ======== СБОРКА / ОТРИСОВКА ========
 void TextManager::Build(Renderer* r, ID3D12GraphicsCommandList* /*cl*/) {
     if (font_ == nullptr) { return; }
-    CPU_SCOPE(L"TextManager::Build");
+    CPU_SCOPE(ProfilerScopes::kTextManagerBuild);
 
     // 0) Предподсчёт глифов для единого reserve
     size_t totalGlyphs = 0;
@@ -272,7 +273,7 @@ void TextManager::Build(Renderer* r, ID3D12GraphicsCommandList* /*cl*/) {
 }
 
 void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
-    CPU_SCOPE(L"TextManager::Draw");
+    CPU_SCOPE(ProfilerScopes::kTextManagerDraw);
     // 1) фон
     if (!rectVerts_.empty() && !rectIdx_.empty() && matRect_) {
         auto h = r->GetRenderContextPool()->Acquire();
@@ -528,7 +529,7 @@ void TextManager::EmitGlyphRun(int x, int y, float xOffset, const float4& color,
 // Позиционная отрисовка теперь тоже через BuildGlyphRun + EmitGlyphRun
 void TextManager::EmitTextImmediate(int x, int y, const float4& color, float px, std::wstring_view text) {
     if (font_ == nullptr) { return; }
-    CPU_SCOPE(L"TextManager::EmitTextImmediate");
+    CPU_SCOPE(ProfilerScopes::kTextManagerEmitImmediate);
     GlyphRun run;
     float width = 0.0f;
     BuildGlyphRun(text, px, run, width);

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="MeshManager.cpp" />
     <ClCompile Include="PointLight.cpp" />
     <ClCompile Include="Profiler.cpp" />
+    <ClCompile Include="ProfilerScopes.cpp" />
     <ClCompile Include="RenderContextPool.cpp" />
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="SamplerManager.cpp" />
@@ -208,6 +209,7 @@
     <ClInclude Include="MeshManager.h" />
     <ClInclude Include="PointLight.h" />
     <ClInclude Include="Profiler.h" />
+    <ClInclude Include="ProfilerScopes.h" />
     <ClInclude Include="RenderContext.h" />
     <ClInclude Include="RenderContextPool.h" />
     <ClInclude Include="Renderer.h" />

--- a/test_cube.vcxproj.filters
+++ b/test_cube.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="Profiler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ProfilerScopes.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera.h">
@@ -246,6 +249,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Profiler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ProfilerScopes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- wrap the trace string table into a dedicated class that owns literal/dynamic registration, capture tracking, and key release helpers
- reuse profiler-owned buffers for CPU/GPU samples and trace dump data instead of allocating temporary vectors each frame
- unify trace sample/event data so capture nodes drain straight into the trace event list while dynamic string registrations auto-track their capture keys

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d3b8abe9f083298a5bb3939bdd6e35