### PR TITLE
Add FFT ocean simulation infrastructure

### DIFF
--- a/GpuTexture2D.cpp
+++ b/GpuTexture2D.cpp
@@ -1,0 +1,265 @@
+#include "GpuTexture2D.h"
+
+#include "Renderer.h"
+#include "Helpers.h"
+
+#include <stdexcept>
+#include <cstring>
+
+using Microsoft::WRL::ComPtr;
+
+bool GpuTexture2D::Create(Renderer* renderer,
+    UINT width,
+    UINT height,
+    DXGI_FORMAT format,
+    UINT mipLevels,
+    D3D12_RESOURCE_FLAGS flags,
+    D3D12_RESOURCE_STATES initialState,
+    const D3D12_CLEAR_VALUE* clearValue)
+{
+    if (!renderer) {
+        return false;
+    }
+
+    auto* device = renderer->GetDevice();
+    if (!device) {
+        return false;
+    }
+
+    D3D12_HEAP_PROPERTIES heap{};
+    heap.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+    D3D12_RESOURCE_DESC desc{};
+    desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    desc.Width = width;
+    desc.Height = height;
+    desc.DepthOrArraySize = 1;
+    desc.MipLevels = static_cast<UINT16>(mipLevels);
+    desc.Format = format;
+    desc.SampleDesc.Count = 1;
+    desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    desc.Flags = flags;
+
+    HRESULT hr = device->CreateCommittedResource(
+        &heap,
+        D3D12_HEAP_FLAG_NONE,
+        &desc,
+        initialState,
+        clearValue,
+        IID_PPV_ARGS(&resource_));
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    renderer->SetResourceState(resource_.Get(), initialState);
+
+    format_ = format;
+    width_ = width;
+    height_ = height;
+    mipLevels_ = mipLevels;
+    flags_ = flags;
+
+    return true;
+}
+
+bool GpuTexture2D::CreateFromData(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    DXGI_FORMAT format,
+    UINT width,
+    UINT height,
+    UINT mipLevels,
+    D3D12_RESOURCE_FLAGS flags,
+    const void* data,
+    size_t rowPitchBytes,
+    D3D12_RESOURCE_STATES finalState,
+    std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    if (!renderer || !uploadCmdList || data == nullptr) {
+        return false;
+    }
+
+    auto* device = renderer->GetDevice();
+    if (!device) {
+        return false;
+    }
+
+    D3D12_HEAP_PROPERTIES heap{};
+    heap.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+    D3D12_RESOURCE_DESC desc{};
+    desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    desc.Width = width;
+    desc.Height = height;
+    desc.DepthOrArraySize = 1;
+    desc.MipLevels = static_cast<UINT16>(mipLevels);
+    desc.Format = format;
+    desc.SampleDesc.Count = 1;
+    desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    desc.Flags = flags;
+
+    HRESULT hr = device->CreateCommittedResource(
+        &heap,
+        D3D12_HEAP_FLAG_NONE,
+        &desc,
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        nullptr,
+        IID_PPV_ARGS(&resource_));
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    D3D12_PLACED_SUBRESOURCE_FOOTPRINT footprint{};
+    UINT numRows = 0;
+    UINT64 rowSize = 0;
+    UINT64 totalBytes = 0;
+    device->GetCopyableFootprints(&desc, 0, 1, 0, &footprint, &numRows, &rowSize, &totalBytes);
+
+    D3D12_HEAP_PROPERTIES uploadHeap{};
+    uploadHeap.Type = D3D12_HEAP_TYPE_UPLOAD;
+
+    D3D12_RESOURCE_DESC uploadDesc{};
+    uploadDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+    uploadDesc.Width = totalBytes;
+    uploadDesc.Height = 1;
+    uploadDesc.DepthOrArraySize = 1;
+    uploadDesc.MipLevels = 1;
+    uploadDesc.SampleDesc.Count = 1;
+    uploadDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+
+    ComPtr<ID3D12Resource> upload;
+    hr = device->CreateCommittedResource(
+        &uploadHeap,
+        D3D12_HEAP_FLAG_NONE,
+        &uploadDesc,
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        nullptr,
+        IID_PPV_ARGS(&upload));
+    if (FAILED(hr)) {
+        resource_.Reset();
+        return false;
+    }
+
+    uint8_t* mapped = nullptr;
+    D3D12_RANGE range{ 0, 0 };
+    hr = upload->Map(0, &range, reinterpret_cast<void**>(&mapped));
+    if (FAILED(hr)) {
+        resource_.Reset();
+        upload.Reset();
+        return false;
+    }
+
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(data);
+    for (UINT row = 0; row < numRows; ++row) {
+        std::memcpy(mapped + footprint.Offset + row * footprint.Footprint.RowPitch,
+            src + row * rowPitchBytes,
+            rowPitchBytes);
+    }
+    upload->Unmap(0, nullptr);
+
+    D3D12_TEXTURE_COPY_LOCATION dst{};
+    dst.pResource = resource_.Get();
+    dst.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+    dst.SubresourceIndex = 0;
+
+    D3D12_TEXTURE_COPY_LOCATION srcLoc{};
+    srcLoc.pResource = upload.Get();
+    srcLoc.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+    srcLoc.PlacedFootprint = footprint;
+
+    uploadCmdList->CopyTextureRegion(&dst, 0, 0, 0, &srcLoc, nullptr);
+
+    D3D12_RESOURCE_BARRIER barrier{};
+    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    barrier.Transition.pResource = resource_.Get();
+    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+    barrier.Transition.StateAfter = finalState;
+    barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    uploadCmdList->ResourceBarrier(1, &barrier);
+
+    if (uploadKeepAlive) {
+        uploadKeepAlive->push_back(upload);
+    }
+
+    renderer->SetResourceState(resource_.Get(), finalState);
+
+    format_ = format;
+    width_ = width;
+    height_ = height;
+    mipLevels_ = mipLevels;
+    flags_ = flags;
+
+    return true;
+}
+
+void GpuTexture2D::AllocateDescriptorHeap_(ID3D12Device* device, UINT count)
+{
+    if (count == 0) {
+        cpuHeap_.Reset();
+        srvCPU_ = {};
+        uavCPU_ = {};
+        return;
+    }
+
+    D3D12_DESCRIPTOR_HEAP_DESC desc{};
+    desc.NumDescriptors = count;
+    desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+    desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+
+    ThrowIfFailed(device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&cpuHeap_)));
+    auto start = cpuHeap_->GetCPUDescriptorHandleForHeapStart();
+    srvCPU_ = {};
+    uavCPU_ = {};
+
+    if (count >= 1) {
+        srvCPU_ = start;
+    }
+    if (count >= 2) {
+        const UINT incr = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+        uavCPU_ = srvCPU_;
+        uavCPU_.ptr += incr;
+    }
+}
+
+void GpuTexture2D::CreateViews(Renderer* renderer,
+    bool createSrv,
+    bool createUav,
+    DXGI_FORMAT srvFormat,
+    DXGI_FORMAT uavFormat,
+    UINT mipLevels)
+{
+    if (!renderer) {
+        return;
+    }
+    auto* device = renderer->GetDevice();
+    if (!device || !resource_) {
+        return;
+    }
+
+    UINT descriptorCount = (createSrv ? 1u : 0u) + (createUav ? 1u : 0u);
+    AllocateDescriptorHeap_(device, descriptorCount);
+
+    D3D12_CPU_DESCRIPTOR_HANDLE cursor = {};
+    if (createSrv) {
+        cursor = srvCPU_;
+        D3D12_SHADER_RESOURCE_VIEW_DESC srv{};
+        srv.Format = srvFormat;
+        srv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+        srv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        srv.Texture2D.MipLevels = mipLevels;
+        srv.Texture2D.MostDetailedMip = 0;
+        srv.Texture2D.ResourceMinLODClamp = 0.0f;
+        device->CreateShaderResourceView(resource_.Get(), &srv, srvCPU_);
+    }
+
+    if (createUav) {
+        if (!createSrv) {
+            uavCPU_ = cpuHeap_->GetCPUDescriptorHandleForHeapStart();
+        }
+        D3D12_UNORDERED_ACCESS_VIEW_DESC uav{};
+        uav.Format = uavFormat;
+        uav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+        uav.Texture2D.MipSlice = 0;
+        uav.Texture2D.PlaneSlice = 0;
+        device->CreateUnorderedAccessView(resource_.Get(), nullptr, &uav, uavCPU_);
+    }
+}

--- a/GpuTexture2D.h
+++ b/GpuTexture2D.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <wrl.h>
+#include <d3d12.h>
+#include <vector>
+
+class Renderer;
+
+class GpuTexture2D {
+public:
+    GpuTexture2D() = default;
+
+    bool Create(Renderer* renderer,
+        UINT width,
+        UINT height,
+        DXGI_FORMAT format,
+        UINT mipLevels,
+        D3D12_RESOURCE_FLAGS flags,
+        D3D12_RESOURCE_STATES initialState,
+        const D3D12_CLEAR_VALUE* clearValue = nullptr);
+
+    bool CreateFromData(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        DXGI_FORMAT format,
+        UINT width,
+        UINT height,
+        UINT mipLevels,
+        D3D12_RESOURCE_FLAGS flags,
+        const void* data,
+        size_t rowPitchBytes,
+        D3D12_RESOURCE_STATES finalState,
+        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive = nullptr);
+
+    void CreateViews(Renderer* renderer,
+        bool createSrv,
+        bool createUav,
+        DXGI_FORMAT srvFormat,
+        DXGI_FORMAT uavFormat,
+        UINT mipLevels = 1);
+
+    ID3D12Resource* GetResource() const { return resource_.Get(); }
+    DXGI_FORMAT GetFormat() const { return format_; }
+    UINT GetWidth() const { return width_; }
+    UINT GetHeight() const { return height_; }
+    UINT GetMipLevels() const { return mipLevels_; }
+
+    D3D12_CPU_DESCRIPTOR_HANDLE GetSrvCPU() const { return srvCPU_; }
+    D3D12_CPU_DESCRIPTOR_HANDLE GetUavCPU() const { return uavCPU_; }
+    bool HasSrv() const { return srvCPU_.ptr != 0; }
+    bool HasUav() const { return uavCPU_.ptr != 0; }
+
+private:
+    void AllocateDescriptorHeap_(ID3D12Device* device, UINT count);
+
+    Microsoft::WRL::ComPtr<ID3D12Resource> resource_;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> cpuHeap_;
+    D3D12_CPU_DESCRIPTOR_HANDLE srvCPU_{};
+    D3D12_CPU_DESCRIPTOR_HANDLE uavCPU_{};
+
+    DXGI_FORMAT format_ = DXGI_FORMAT_UNKNOWN;
+    UINT width_ = 0;
+    UINT height_ = 0;
+    UINT mipLevels_ = 1;
+    D3D12_RESOURCE_FLAGS flags_ = D3D12_RESOURCE_FLAG_NONE;
+};

--- a/OceanFFT.cpp
+++ b/OceanFFT.cpp
@@ -1,0 +1,811 @@
+#include "OceanFFT.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cfloat>
+#include <limits>
+#include <random>
+#include <vector>
+#include <cstring>
+
+#include "Helpers.h"
+#include "Material.h"
+#include "MaterialManager.h"
+#include "RenderContext.h"
+#include "RenderContextPool.h"
+#include "Renderer.h"
+#include "UploadManager.h"
+
+using Microsoft::WRL::ComPtr;
+
+namespace {
+constexpr float kPi = 3.14159265358979323846f;
+
+inline uint32_t FloatAsUint(float v) {
+    uint32_t bits;
+    std::memcpy(&bits, &v, sizeof(bits));
+    return bits;
+}
+
+float DegreesToRadians(float deg) {
+    return deg * (kPi / 180.0f);
+}
+
+float Clamp(float v, float minV, float maxV) {
+    return std::max(minV, std::min(v, maxV));
+}
+
+} // namespace
+
+struct SpectrumParameters
+{
+    float scale;
+    float angle;
+    float spreadBlend;
+    float swell;
+    float alpha;
+    float peakOmega;
+    float gamma;
+    float shortWavesFade;
+};
+
+struct OceanFFTSystem::SpectrumBuffer {
+    bool Initialize(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        const void* data,
+        size_t byteSize,
+        std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+    {
+        if (!renderer || !uploadCmdList || data == nullptr) {
+            return false;
+        }
+
+        UploadManager uploader(renderer->GetDevice(), uploadCmdList);
+        buffer_ = uploader.CreateBufferWithData(data, byteSize,
+            D3D12_RESOURCE_FLAG_NONE,
+            D3D12_RESOURCE_STATE_GENERIC_READ);
+        uploader.StealKeepAlive(uploadKeepAlive);
+        renderer->SetResourceState(buffer_.Get(), D3D12_RESOURCE_STATE_GENERIC_READ);
+
+        D3D12_DESCRIPTOR_HEAP_DESC hd{};
+        hd.NumDescriptors = 1;
+        hd.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+        hd.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+        ThrowIfFailed(renderer->GetDevice()->CreateDescriptorHeap(&hd, IID_PPV_ARGS(&cpuHeap_)));
+
+        srv_ = cpuHeap_->GetCPUDescriptorHandleForHeapStart();
+
+        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+        srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        srvDesc.Buffer.FirstElement = 0;
+        srvDesc.Buffer.NumElements = static_cast<UINT>(byteSize / sizeof(SpectrumParameters));
+        srvDesc.Buffer.StructureByteStride = sizeof(SpectrumParameters);
+        srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+        renderer->GetDevice()->CreateShaderResourceView(buffer_.Get(), &srvDesc, srv_);
+        return true;
+    }
+
+    D3D12_CPU_DESCRIPTOR_HANDLE GetSRV() const { return srv_; }
+    ID3D12Resource* GetResource() const { return buffer_.Get(); }
+
+private:
+    ComPtr<ID3D12Resource> buffer_;
+    ComPtr<ID3D12DescriptorHeap> cpuHeap_;
+    D3D12_CPU_DESCRIPTOR_HANDLE srv_{};
+};
+
+class OceanFFTSystem::FastFourierTransform {
+public:
+    bool Initialize(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        UINT size,
+        std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive);
+
+    void IFFT2D(Renderer* renderer,
+        ID3D12GraphicsCommandList* cl,
+        GpuTexture2D& input,
+        GpuTexture2D& buffer,
+        bool outputToInput,
+        bool scale,
+        bool permute);
+
+    D3D12_CPU_DESCRIPTOR_HANDLE GetPrecomputedSRV(Renderer* renderer);
+
+private:
+    void DispatchPrecompute(Renderer* renderer, ID3D12GraphicsCommandList* cl);
+
+    UINT size_ = 0;
+    UINT logSize_ = 0;
+
+    GpuTexture2D precomputedData_;
+
+    std::shared_ptr<Material> matPrecompute_;
+    std::shared_ptr<Material> matHorizontalIFFT_;
+    std::shared_ptr<Material> matVerticalIFFT_;
+    std::shared_ptr<Material> matScale_;
+    std::shared_ptr<Material> matPermute_;
+};
+
+class OceanFFTSystem::Cascade {
+public:
+    bool Initialize(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        UINT size,
+        const OceanCascadeConfig& config,
+        const OceanWavesSettings& settings,
+        SpectrumBuffer& spectrumBuffer,
+        const GpuTexture2D& gaussianNoise,
+        std::shared_ptr<Material> initialSpectrum,
+        std::shared_ptr<Material> conjugateSpectrum,
+        std::shared_ptr<Material> timeSpectrum,
+        std::shared_ptr<Material> mergeMaterial,
+        FastFourierTransform& fft,
+        std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive);
+
+    void Update(Renderer* renderer,
+        ID3D12GraphicsCommandList* cl,
+        FastFourierTransform& fft,
+        float time,
+        float deltaTime);
+
+    const GpuTexture2D& Displacement() const { return displacement_; }
+    const GpuTexture2D& Derivatives() const { return derivatives_; }
+    const GpuTexture2D& Turbulence() const { return turbulence_; }
+
+private:
+    void CalculateInitialSpectrum(Renderer* renderer,
+        ID3D12GraphicsCommandList* cl,
+        const OceanWavesSettings& settings,
+        SpectrumBuffer& spectrumBuffer,
+        const GpuTexture2D& gaussianNoise);
+
+    void CalculateTimeDependentSpectrum(Renderer* renderer,
+        ID3D12GraphicsCommandList* cl,
+        float time);
+
+    void MergeDisplacement(Renderer* renderer,
+        ID3D12GraphicsCommandList* cl,
+        float deltaTime);
+
+    UINT size_ = 0;
+    float lengthScale_ = 0.0f;
+    float cutoffLow_ = 0.0f;
+    float cutoffHigh_ = 0.0f;
+    float lambda_ = 1.0f;
+
+    GpuTexture2D initialSpectrum_;
+    GpuTexture2D waveData_;
+    GpuTexture2D h0kBuffer_;
+
+    GpuTexture2D dx_dz_;
+    GpuTexture2D dy_dxz_;
+    GpuTexture2D dyx_dyz_;
+    GpuTexture2D dxx_dzz_;
+    GpuTexture2D fftBuffer_;
+
+    GpuTexture2D displacement_;
+    GpuTexture2D derivatives_;
+    GpuTexture2D turbulence_;
+
+    std::shared_ptr<Material> matInitial_;
+    std::shared_ptr<Material> matConjugate_;
+    std::shared_ptr<Material> matTimeDependent_;
+    std::shared_ptr<Material> matMerge_;
+};
+
+// -----------------------------------------------------------------------------
+// FastFourierTransform implementation
+// -----------------------------------------------------------------------------
+
+bool OceanFFTSystem::FastFourierTransform::Initialize(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    UINT size,
+    std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    size_ = size;
+    logSize_ = 0;
+    UINT n = size;
+    while (n > 1) {
+        n >>= 1u;
+        ++logSize_;
+    }
+
+    Material::ComputeDesc desc{};
+    desc.shaderFile = L"shaders/ocean_fft.hlsl";
+
+    desc.csEntry = "PrecomputeTwiddleFactorsAndInputIndices";
+    matPrecompute_ = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+
+    desc.csEntry = "HorizontalStepInverseFFT";
+    matHorizontalIFFT_ = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+
+    desc.csEntry = "VerticalStepInverseFFT";
+    matVerticalIFFT_ = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+
+    desc.csEntry = "Scale";
+    matScale_ = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+
+    desc.csEntry = "Permute";
+    matPermute_ = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+
+    if (!precomputedData_.Create(renderer,
+        logSize_,
+        size_,
+        DXGI_FORMAT_R32G32B32A32_FLOAT,
+        1,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+
+    precomputedData_.CreateViews(renderer,
+        /*srv*/true,
+        /*uav*/true,
+        DXGI_FORMAT_R32G32B32A32_FLOAT,
+        DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+    DispatchPrecompute(renderer, uploadCmdList);
+
+    renderer->Transition(uploadCmdList, precomputedData_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    if (uploadKeepAlive) {
+        // No additional uploads created here, but keep interface consistent
+        (void)uploadKeepAlive;
+    }
+
+    return true;
+}
+
+void OceanFFTSystem::FastFourierTransform::DispatchPrecompute(Renderer* renderer,
+    ID3D12GraphicsCommandList* cl)
+{
+    if (!renderer || !cl) {
+        return;
+    }
+
+    renderer->Transition(cl, precomputedData_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+    auto& ctx = ctxHandle.ref();
+    ctx.ClearFast();
+    ctx.constants[0] = { size_, 0u, 0u };
+    auto uav = renderer->StageSrvUavTable({ precomputedData_.GetUavCPU(), precomputedData_.GetUavCPU(), precomputedData_.GetUavCPU() });
+    ctx.table[4] = uav.gpu;
+
+    matPrecompute_->Bind(cl, ctx);
+    const UINT groupsX = logSize_;
+    const UINT groupsY = std::max<UINT>(1u, (size_ / 2u + 7u) / 8u);
+    cl->Dispatch(groupsX, groupsY, 1);
+    renderer->UAVBarrier(cl, precomputedData_.GetResource());
+}
+
+D3D12_CPU_DESCRIPTOR_HANDLE OceanFFTSystem::FastFourierTransform::GetPrecomputedSRV(Renderer* renderer)
+{
+    (void)renderer;
+    return precomputedData_.GetSrvCPU();
+}
+
+void OceanFFTSystem::FastFourierTransform::IFFT2D(Renderer* renderer,
+    ID3D12GraphicsCommandList* cl,
+    GpuTexture2D& input,
+    GpuTexture2D& buffer,
+    bool outputToInput,
+    bool scale,
+    bool permute)
+{
+    if (!renderer || !cl) {
+        return;
+    }
+
+    renderer->Transition(cl, input.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    renderer->Transition(cl, buffer.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    bool pingPong = false;
+
+    const UINT groupCount = std::max<UINT>(1u, size_ / 8u);
+
+    for (UINT step = 0; step < logSize_; ++step) {
+        pingPong = !pingPong;
+
+        auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+        auto& ctx = ctxHandle.ref();
+        ctx.ClearFast();
+        ctx.constants[0] = { size_, step, pingPong ? 1u : 0u };
+        auto srv = renderer->StageSrvUavTable({ precomputedData_.GetSrvCPU() });
+        ctx.table[0] = srv.gpu;
+        auto uav = renderer->StageSrvUavTable({ precomputedData_.GetUavCPU(), input.GetUavCPU(), buffer.GetUavCPU() });
+        ctx.table[4] = uav.gpu;
+
+        matHorizontalIFFT_->Bind(cl, ctx);
+        cl->Dispatch(groupCount, groupCount, 1);
+        renderer->UAVBarrier(cl, pingPong ? buffer.GetResource() : input.GetResource());
+    }
+
+    for (UINT step = 0; step < logSize_; ++step) {
+        pingPong = !pingPong;
+
+        auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+        auto& ctx = ctxHandle.ref();
+        ctx.ClearFast();
+        ctx.constants[0] = { size_, step, pingPong ? 1u : 0u };
+        auto srv = renderer->StageSrvUavTable({ precomputedData_.GetSrvCPU() });
+        ctx.table[0] = srv.gpu;
+        auto uav = renderer->StageSrvUavTable({ precomputedData_.GetUavCPU(), input.GetUavCPU(), buffer.GetUavCPU() });
+        ctx.table[4] = uav.gpu;
+
+        matVerticalIFFT_->Bind(cl, ctx);
+        cl->Dispatch(groupCount, groupCount, 1);
+        renderer->UAVBarrier(cl, pingPong ? buffer.GetResource() : input.GetResource());
+    }
+
+    if (pingPong && outputToInput) {
+        renderer->Transition(cl, buffer.GetResource(), D3D12_RESOURCE_STATE_COPY_SOURCE);
+        renderer->Transition(cl, input.GetResource(), D3D12_RESOURCE_STATE_COPY_DEST);
+        cl->CopyResource(input.GetResource(), buffer.GetResource());
+        renderer->Transition(cl, buffer.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+        renderer->Transition(cl, input.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+        pingPong = false;
+    }
+
+    GpuTexture2D& resultTexture = (outputToInput || !pingPong) ? input : buffer;
+
+    if (permute) {
+        auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+        auto& ctx = ctxHandle.ref();
+        ctx.ClearFast();
+        ctx.constants[0] = { size_, 0u, 0u };
+        auto srv = renderer->StageSrvUavTable({ precomputedData_.GetSrvCPU() });
+        ctx.table[0] = srv.gpu;
+        auto uav = renderer->StageSrvUavTable({ resultTexture.GetUavCPU(), resultTexture.GetUavCPU(), resultTexture.GetUavCPU() });
+        ctx.table[4] = uav.gpu;
+
+        matPermute_->Bind(cl, ctx);
+        cl->Dispatch(groupCount, groupCount, 1);
+        renderer->UAVBarrier(cl, resultTexture.GetResource());
+    }
+
+    if (scale) {
+        auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+        auto& ctx = ctxHandle.ref();
+        ctx.ClearFast();
+        ctx.constants[0] = { size_, 0u, 0u };
+        auto srv = renderer->StageSrvUavTable({ precomputedData_.GetSrvCPU() });
+        ctx.table[0] = srv.gpu;
+        auto uav = renderer->StageSrvUavTable({ resultTexture.GetUavCPU(), resultTexture.GetUavCPU(), resultTexture.GetUavCPU() });
+        ctx.table[4] = uav.gpu;
+
+        matScale_->Bind(cl, ctx);
+        cl->Dispatch(groupCount, groupCount, 1);
+        renderer->UAVBarrier(cl, resultTexture.GetResource());
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Cascade implementation
+// -----------------------------------------------------------------------------
+
+bool OceanFFTSystem::Cascade::Initialize(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    UINT size,
+    const OceanCascadeConfig& config,
+    const OceanWavesSettings& settings,
+    SpectrumBuffer& spectrumBuffer,
+    const GpuTexture2D& gaussianNoise,
+    std::shared_ptr<Material> initialSpectrum,
+    std::shared_ptr<Material> conjugateSpectrum,
+    std::shared_ptr<Material> timeSpectrum,
+    std::shared_ptr<Material> mergeMaterial,
+    FastFourierTransform& fft,
+    std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    (void)uploadKeepAlive;
+    size_ = size;
+    lengthScale_ = config.lengthScale;
+    cutoffLow_ = config.cutoffLow;
+    cutoffHigh_ = config.cutoffHigh;
+    lambda_ = settings.lambda;
+
+    matInitial_ = std::move(initialSpectrum);
+    matConjugate_ = std::move(conjugateSpectrum);
+    matTimeDependent_ = std::move(timeSpectrum);
+    matMerge_ = std::move(mergeMaterial);
+
+    if (!initialSpectrum_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32B32A32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    initialSpectrum_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32B32A32_FLOAT, DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+    if (!waveData_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32B32A32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    waveData_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32B32A32_FLOAT, DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+    if (!h0kBuffer_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    h0kBuffer_.CreateViews(renderer, false, true, DXGI_FORMAT_R32G32_FLOAT, DXGI_FORMAT_R32G32_FLOAT);
+
+    if (!dx_dz_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    dx_dz_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32_FLOAT, DXGI_FORMAT_R32G32_FLOAT);
+
+    if (!dy_dxz_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    dy_dxz_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32_FLOAT, DXGI_FORMAT_R32G32_FLOAT);
+
+    if (!dyx_dyz_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    dyx_dyz_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32_FLOAT, DXGI_FORMAT_R32G32_FLOAT);
+
+    if (!dxx_dzz_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    dxx_dzz_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32_FLOAT, DXGI_FORMAT_R32G32_FLOAT);
+
+    if (!fftBuffer_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    fftBuffer_.CreateViews(renderer, false, true, DXGI_FORMAT_R32G32_FLOAT, DXGI_FORMAT_R32G32_FLOAT);
+
+    if (!displacement_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32B32A32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    displacement_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32B32A32_FLOAT, DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+    if (!derivatives_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32B32A32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    derivatives_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32B32A32_FLOAT, DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+    if (!turbulence_.Create(renderer, size_, size_, DXGI_FORMAT_R32G32B32A32_FLOAT,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS))
+    {
+        return false;
+    }
+    turbulence_.CreateViews(renderer, true, true, DXGI_FORMAT_R32G32B32A32_FLOAT, DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+    CalculateInitialSpectrum(renderer, uploadCmdList, settings, spectrumBuffer, gaussianNoise);
+
+    renderer->Transition(uploadCmdList, initialSpectrum_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(uploadCmdList, waveData_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    return true;
+}
+
+void OceanFFTSystem::Cascade::CalculateInitialSpectrum(Renderer* renderer,
+    ID3D12GraphicsCommandList* cl,
+    const OceanWavesSettings& settings,
+    SpectrumBuffer& spectrumBuffer,
+    const GpuTexture2D& gaussianNoise)
+{
+    renderer->Transition(cl, initialSpectrum_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    renderer->Transition(cl, waveData_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    renderer->Transition(cl, h0kBuffer_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+    auto& ctx = ctxHandle.ref();
+    ctx.ClearFast();
+    ctx.constants[0] = {
+        size_,
+        FloatAsUint(lengthScale_),
+        FloatAsUint(cutoffHigh_),
+        FloatAsUint(cutoffLow_),
+        FloatAsUint(settings.gravity),
+        FloatAsUint(settings.depth),
+        0u,
+        0u
+    };
+
+    auto srvs = renderer->StageSrvUavTable({ gaussianNoise.GetSrvCPU(), spectrumBuffer.GetSRV() });
+    ctx.table[0] = srvs.gpu;
+    auto uavs = renderer->StageSrvUavTable({ initialSpectrum_.GetUavCPU(), waveData_.GetUavCPU(), h0kBuffer_.GetUavCPU() });
+    ctx.table[4] = uavs.gpu;
+
+    matInitial_->Bind(cl, ctx);
+    const UINT groupCount = std::max<UINT>(1u, size_ / 8u);
+    cl->Dispatch(groupCount, groupCount, 1);
+    renderer->UAVBarrier(cl, waveData_.GetResource());
+    renderer->UAVBarrier(cl, h0kBuffer_.GetResource());
+
+    ctx.ClearFast();
+    auto uavsConjugate = renderer->StageSrvUavTable({ initialSpectrum_.GetUavCPU(), waveData_.GetUavCPU(), h0kBuffer_.GetUavCPU() });
+    ctx.table[4] = uavsConjugate.gpu;
+    matConjugate_->Bind(cl, ctx);
+    cl->Dispatch(groupCount, groupCount, 1);
+    renderer->UAVBarrier(cl, initialSpectrum_.GetResource());
+}
+
+void OceanFFTSystem::Cascade::CalculateTimeDependentSpectrum(Renderer* renderer,
+    ID3D12GraphicsCommandList* cl,
+    float time)
+{
+    renderer->Transition(cl, dx_dz_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    renderer->Transition(cl, dy_dxz_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    renderer->Transition(cl, dyx_dyz_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    renderer->Transition(cl, dxx_dzz_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    renderer->Transition(cl, initialSpectrum_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, waveData_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+    auto& ctx = ctxHandle.ref();
+    ctx.ClearFast();
+    ctx.constants[0] = { FloatAsUint(time) };
+    auto srvs = renderer->StageSrvUavTable({ initialSpectrum_.GetSrvCPU(), waveData_.GetSrvCPU() });
+    ctx.table[0] = srvs.gpu;
+    auto uavs = renderer->StageSrvUavTable({ dx_dz_.GetUavCPU(), dy_dxz_.GetUavCPU(), dyx_dyz_.GetUavCPU(), dxx_dzz_.GetUavCPU() });
+    ctx.table[4] = uavs.gpu;
+
+    const UINT groupCount = std::max<UINT>(1u, size_ / 8u);
+    matTimeDependent_->Bind(cl, ctx);
+    cl->Dispatch(groupCount, groupCount, 1);
+
+    renderer->UAVBarrier(cl, dx_dz_.GetResource());
+    renderer->UAVBarrier(cl, dy_dxz_.GetResource());
+    renderer->UAVBarrier(cl, dyx_dyz_.GetResource());
+    renderer->UAVBarrier(cl, dxx_dzz_.GetResource());
+}
+
+void OceanFFTSystem::Cascade::MergeDisplacement(Renderer* renderer,
+    ID3D12GraphicsCommandList* cl,
+    float deltaTime)
+{
+    renderer->Transition(cl, dx_dz_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, dy_dxz_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, dyx_dyz_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, dxx_dzz_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    renderer->Transition(cl, displacement_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    renderer->Transition(cl, derivatives_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    renderer->Transition(cl, turbulence_.GetResource(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+    auto& ctx = ctxHandle.ref();
+    ctx.ClearFast();
+    ctx.constants[0] = { FloatAsUint(lambda_), FloatAsUint(deltaTime) };
+    auto srvs = renderer->StageSrvUavTable({ dx_dz_.GetSrvCPU(), dy_dxz_.GetSrvCPU(), dyx_dyz_.GetSrvCPU(), dxx_dzz_.GetSrvCPU() });
+    ctx.table[0] = srvs.gpu;
+    auto uavs = renderer->StageSrvUavTable({ displacement_.GetUavCPU(), derivatives_.GetUavCPU(), turbulence_.GetUavCPU() });
+    ctx.table[4] = uavs.gpu;
+
+    const UINT groupCount = std::max<UINT>(1u, size_ / 8u);
+    matMerge_->Bind(cl, ctx);
+    cl->Dispatch(groupCount, groupCount, 1);
+
+    renderer->UAVBarrier(cl, displacement_.GetResource());
+    renderer->UAVBarrier(cl, derivatives_.GetResource());
+    renderer->UAVBarrier(cl, turbulence_.GetResource());
+
+    renderer->Transition(cl, displacement_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, derivatives_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, turbulence_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+}
+
+void OceanFFTSystem::Cascade::Update(Renderer* renderer,
+    ID3D12GraphicsCommandList* cl,
+    FastFourierTransform& fft,
+    float time,
+    float deltaTime)
+{
+    CalculateTimeDependentSpectrum(renderer, cl, time);
+
+    fft.IFFT2D(renderer, cl, dx_dz_, fftBuffer_, true, false, true);
+    fft.IFFT2D(renderer, cl, dy_dxz_, fftBuffer_, true, false, true);
+    fft.IFFT2D(renderer, cl, dyx_dyz_, fftBuffer_, true, false, true);
+    fft.IFFT2D(renderer, cl, dxx_dzz_, fftBuffer_, true, false, true);
+
+    renderer->Transition(cl, dx_dz_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, dy_dxz_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, dyx_dyz_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    renderer->Transition(cl, dxx_dzz_.GetResource(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    MergeDisplacement(renderer, cl, deltaTime);
+}
+
+// -----------------------------------------------------------------------------
+// OceanFFTSystem implementation
+// -----------------------------------------------------------------------------
+
+OceanFFTSystem::OceanFFTSystem()
+{
+    settings_.gravity = 9.81f;
+    settings_.depth = 500.0f;
+    settings_.lambda = 1.0f;
+    settings_.local = { 1.0f, 0.5f, -29.81f, 100000.0f, 1.0f, 0.198f, 3.3f, 0.01f };
+    settings_.swell = { 0.0f, 1.0f, 0.0f, 300000.0f, 1.0f, 1.0f, 3.3f, 0.01f };
+}
+
+OceanFFTSystem::~OceanFFTSystem() = default;
+
+namespace {
+
+SpectrumParameters BuildSpectrumParameters(const OceanWavesSettings& settings,
+    const OceanDisplaySpectrumSettings& display)
+{
+    SpectrumParameters p{};
+    p.scale = display.scale;
+    p.angle = DegreesToRadians(display.windDirection);
+    p.spreadBlend = display.spreadBlend;
+    p.swell = Clamp(display.swell, 0.01f, 1.0f);
+    if (display.windSpeed <= 0.0f) {
+        p.alpha = 0.0f;
+        p.peakOmega = 0.0f;
+    } else {
+        p.alpha = 0.076f * std::pow(settings.gravity * display.fetch / (display.windSpeed * display.windSpeed), -0.22f);
+        p.peakOmega = 22.0f * std::pow(display.windSpeed * display.fetch / (settings.gravity * settings.gravity), -0.33f);
+    }
+    p.gamma = display.peakEnhancement;
+    p.shortWavesFade = display.shortWavesFade;
+    return p;
+}
+
+} // namespace
+
+bool OceanFFTSystem::Initialize(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    if (!renderer || !uploadCmdList) {
+        return false;
+    }
+
+    size_ = 256;
+
+    fft_ = std::make_unique<FastFourierTransform>();
+    if (!fft_->Initialize(renderer, uploadCmdList, size_, uploadKeepAlive)) {
+        return false;
+    }
+
+    const size_t noiseCount = size_t(size_) * size_t(size_);
+    std::vector<float> gaussian(noiseCount * 2ull);
+    std::mt19937 rng(1337);
+    std::normal_distribution<float> normal(0.0f, 1.0f);
+    for (size_t i = 0; i < gaussian.size(); ++i) {
+        gaussian[i] = normal(rng);
+    }
+
+    if (!gaussianNoise_.CreateFromData(renderer, uploadCmdList, DXGI_FORMAT_R32G32_FLOAT,
+        size_, size_, 1,
+        D3D12_RESOURCE_FLAG_NONE,
+        gaussian.data(),
+        size_t(size_) * sizeof(float) * 2u,
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+        uploadKeepAlive))
+    {
+        return false;
+    }
+    gaussianNoise_.CreateViews(renderer, true, false, DXGI_FORMAT_R32G32_FLOAT, DXGI_FORMAT_R32G32_FLOAT);
+
+    SpectrumParameters params[2];
+    params[0] = BuildSpectrumParameters(settings_, settings_.local);
+    params[1] = BuildSpectrumParameters(settings_, settings_.swell);
+
+    spectrumBuffer_ = std::make_unique<SpectrumBuffer>();
+    if (!spectrumBuffer_->Initialize(renderer, uploadCmdList, params, sizeof(params), uploadKeepAlive)) {
+        return false;
+    }
+
+    Material::ComputeDesc desc{};
+    desc.shaderFile = L"shaders/ocean_initial_spectrum.hlsl";
+    desc.csEntry = "CalculateInitialSpectrum";
+    auto matInitial = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+    desc.csEntry = "CalculateConjugatedSpectrum";
+    auto matConjugate = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+
+    desc.shaderFile = L"shaders/ocean_time_dependent.hlsl";
+    desc.csEntry = "CalculateAmplitudes";
+    auto matTime = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+
+    desc.shaderFile = L"shaders/ocean_merge.hlsl";
+    desc.csEntry = "FillResultTextures";
+    auto matMerge = renderer->GetMaterialManager()->GetOrCreateCompute(renderer, desc);
+
+    const float lengthScale0 = 250.0f;
+    const float lengthScale1 = 17.0f;
+    const float lengthScale2 = 5.0f;
+
+    const float boundary1 = 2.0f * kPi / lengthScale1 * 6.0f;
+    const float boundary2 = 2.0f * kPi / lengthScale2 * 6.0f;
+
+    std::array<OceanCascadeConfig, 3> configs{};
+    configs[0] = { lengthScale0, 0.0001f, boundary1 };
+    configs[1] = { lengthScale1, boundary1, boundary2 };
+    configs[2] = { lengthScale2, boundary2, std::numeric_limits<float>::max() };
+
+    for (size_t i = 0; i < cascades_.size(); ++i) {
+        cascades_[i] = std::make_unique<Cascade>();
+        if (!cascades_[i]->Initialize(renderer, uploadCmdList, size_, configs[i], settings_, *spectrumBuffer_,
+            gaussianNoise_, matInitial, matConjugate, matTime, matMerge, *fft_, uploadKeepAlive))
+        {
+            return false;
+        }
+    }
+
+    time_ = 0.0f;
+    deltaTime_ = 0.0f;
+
+    return true;
+}
+
+void OceanFFTSystem::Tick(float deltaTime)
+{
+    deltaTime_ = deltaTime;
+    time_ += deltaTime;
+}
+
+void OceanFFTSystem::Dispatch(Renderer* renderer, ID3D12GraphicsCommandList* cl)
+{
+    if (!renderer || !cl || !fft_) {
+        return;
+    }
+
+    for (auto& cascade : cascades_) {
+        if (cascade) {
+            cascade->Update(renderer, cl, *fft_, time_, deltaTime_);
+        }
+    }
+}
+
+void OceanFFTSystem::Reset()
+{
+    cascades_ = {};
+    spectrumBuffer_.reset();
+    fft_.reset();
+    gaussianNoise_ = GpuTexture2D();
+    time_ = 0.0f;
+    deltaTime_ = 0.0f;
+}
+
+const GpuTexture2D& OceanFFTSystem::GetDisplacement(size_t cascadeIndex) const
+{
+    return cascades_.at(cascadeIndex)->Displacement();
+}
+
+const GpuTexture2D& OceanFFTSystem::GetDerivatives(size_t cascadeIndex) const
+{
+    return cascades_.at(cascadeIndex)->Derivatives();
+}
+
+const GpuTexture2D& OceanFFTSystem::GetTurbulence(size_t cascadeIndex) const
+{
+    return cascades_.at(cascadeIndex)->Turbulence();
+}
+

--- a/OceanFFT.h
+++ b/OceanFFT.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <vector>
+#include <wrl.h>
+
+#include <d3d12.h>
+
+#include "GpuTexture2D.h"
+
+class Renderer;
+
+struct OceanDisplaySpectrumSettings {
+    float scale = 1.0f;
+    float windSpeed = 0.0f;
+    float windDirection = 0.0f; // degrees
+    float fetch = 0.0f;
+    float spreadBlend = 1.0f;
+    float swell = 0.2f;
+    float peakEnhancement = 3.3f;
+    float shortWavesFade = 0.01f;
+};
+
+struct OceanWavesSettings {
+    float gravity = 9.81f;
+    float depth = 500.0f;
+    float lambda = 1.0f;
+    OceanDisplaySpectrumSettings local;
+    OceanDisplaySpectrumSettings swell;
+};
+
+struct OceanCascadeConfig {
+    float lengthScale = 250.0f;
+    float cutoffLow = 0.0f;
+    float cutoffHigh = 1.0f;
+};
+
+class OceanFFTSystem {
+public:
+    OceanFFTSystem();
+    ~OceanFFTSystem();
+
+    bool Initialize(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive);
+
+    void Tick(float deltaTime);
+    void Dispatch(Renderer* renderer, ID3D12GraphicsCommandList* cl);
+
+    void Reset();
+
+    const GpuTexture2D& GetDisplacement(size_t cascadeIndex) const;
+    const GpuTexture2D& GetDerivatives(size_t cascadeIndex) const;
+    const GpuTexture2D& GetTurbulence(size_t cascadeIndex) const;
+
+private:
+    struct SpectrumBuffer;
+    class FastFourierTransform;
+    class Cascade;
+
+    OceanWavesSettings settings_{};
+    UINT size_ = 256;
+    float time_ = 0.0f;
+    float deltaTime_ = 0.0f;
+
+    std::unique_ptr<FastFourierTransform> fft_;
+    std::unique_ptr<SpectrumBuffer> spectrumBuffer_;
+    GpuTexture2D gaussianNoise_;
+
+    std::array<std::unique_ptr<Cascade>, 3> cascades_{};
+};
+

--- a/ProfilerScopes.cpp
+++ b/ProfilerScopes.cpp
@@ -18,6 +18,7 @@ const Profiler::ScopeNameKey kRendererTransition = Profiler::RegisterTraceLitera
 const Profiler::ScopeNameKey kSceneTick = Profiler::RegisterTraceLiteral(L"Scene::Tick");
 const Profiler::ScopeNameKey kSceneRender = Profiler::RegisterTraceLiteral(L"Scene::Render");
 const Profiler::ScopeNameKey kPassPrologueClear = Profiler::RegisterTraceLiteral(L"Pass_PrologueClear");
+const Profiler::ScopeNameKey kPassOceanFFT = Profiler::RegisterTraceLiteral(L"Pass_OceanFFT");
 const Profiler::ScopeNameKey kPassCSM = Profiler::RegisterTraceLiteral(L"Pass_CSM");
 const Profiler::ScopeNameKey kPassGBuffer = Profiler::RegisterTraceLiteral(L"Pass_GBuffer");
 const Profiler::ScopeNameKey kPassLighting = Profiler::RegisterTraceLiteral(L"Pass_Lighting");

--- a/ProfilerScopes.h
+++ b/ProfilerScopes.h
@@ -24,6 +24,7 @@ extern const Profiler::ScopeNameKey kRendererTransition;
 extern const Profiler::ScopeNameKey kSceneTick;
 extern const Profiler::ScopeNameKey kSceneRender;
 extern const Profiler::ScopeNameKey kPassPrologueClear;
+extern const Profiler::ScopeNameKey kPassOceanFFT;
 extern const Profiler::ScopeNameKey kPassCSM;
 extern const Profiler::ScopeNameKey kPassGBuffer;
 extern const Profiler::ScopeNameKey kPassLighting;

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -9,6 +9,7 @@
 #include "DebugGrid.h"
 #include "GpuInstancedModels.h"
 #include "Helpers.h"
+#include "OceanFFT.h"
 #include "Renderer.h"
 #include "RenderGraph.h"
 #include "StaticMesh.h"
@@ -244,6 +245,12 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
     skyBox_->Init(renderer, uploadCmdList, uploadKeepAlive);
     skyBox_->SetExposure(0.2f);
 
+    oceanSystem_ = std::make_unique<OceanFFTSystem>();
+    if (!oceanSystem_->Initialize(renderer, uploadCmdList, uploadKeepAlive))
+    {
+        oceanSystem_.reset();
+    }
+
     pointLights_.emplace_back(); pointLights_.back().SetDesc({ {0,2,0}, 6.0f, {1,0.8f,0.6f}, 5.0f });
     pointLights_.emplace_back(); pointLights_.back().SetDesc({ {-4,1,-2}, 5.0f, {0.6f,0.7f,1.0f}, 8.0f });
 
@@ -335,6 +342,10 @@ void Scene::Tick(float deltaTime) {
             showProfiler_ = !showProfiler_;
         }
     }
+    if (oceanSystem_)
+    {
+        oceanSystem_->Tick(deltaTime);
+    }
     auto& tasks = TaskSystem::Get();
 
 #if TASKSYSTEM_ENABLE_PARALLEL_EXECUTION
@@ -378,6 +389,21 @@ void Scene::Render(Renderer* renderer) {
 
     TaskSystem::Get().WaitForTrackedAsyncTasks();
 
+    RenderGraph rg;
+    auto pOcean = rg.AddPass("OceanFFT", {}, [this, renderer](RenderGraph::PassContext ctx) {
+        if (!oceanSystem_)
+        {
+            return;
+        }
+        auto t = renderer->BeginThreadCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
+        t.cl->SetName(L"OceanFFT");
+        {
+            GPU_SCOPE(t.cl, ProfilerScopes::kPassOceanFFT);
+            oceanSystem_->Dispatch(renderer, t.cl);
+        }
+        renderer->EndThreadCommandList(t, ctx.batchIndex);
+    });
+
     // матрицы кадра и параметры камеры/света (как у тебя)
     const float aspect = float(renderer->GetWidth()) / float(renderer->GetHeight());
     const mat4 view = camera_.GetViewMatrix();
@@ -406,8 +432,7 @@ void Scene::Render(Renderer* renderer) {
     }
     const auto& buckets = renderBuckets_;
 
-    RenderGraph rg;
-    auto pClear = rg.AddPass("PrologueClear", {},
+    auto pClear = rg.AddPass("PrologueClear", { pOcean },
         [this, renderer](RenderGraph::PassContext ctx) { CPU_SCOPE(ProfilerScopes::kPassPrologueClear); Pass_PrologueClear(renderer, ctx); });
 
     auto pShadow = rg.AddPass("CSM", { pClear },
@@ -1197,4 +1222,5 @@ void Scene::Clear()
         bucket.clear();
     }
     skyBox_.reset();
+    oceanSystem_.reset();
 }

--- a/Scene.h
+++ b/Scene.h
@@ -12,6 +12,7 @@
 #include "PointLight.h"
 
 class Renderer;
+class OceanFFTSystem;
 
 class Scene {
 public:
@@ -164,5 +165,7 @@ private:
     DirectionalLight dirLight_;
 
     std::unique_ptr<Skybox> skyBox_;
+
+    std::unique_ptr<OceanFFTSystem> oceanSystem_;
 
 };

--- a/shaders/ocean_fft.hlsl
+++ b/shaders/ocean_fft.hlsl
@@ -1,0 +1,108 @@
+// RootSignature: CONSTANTS(b0,count=3) TABLE(SRV(t0)) TABLE(UAV(u4) UAV(u5) UAV(u6))
+static const float PI = 3.14159265358979323846f;
+
+cbuffer FFTParams : register(b0)
+{
+    uint Size;
+    uint Step;
+    uint PingPong;
+};
+
+RWTexture2D<float4> PrecomputeBuffer : register(u4);
+RWTexture2D<float2> Buffer0 : register(u5);
+RWTexture2D<float2> Buffer1 : register(u6);
+Texture2D<float4> PrecomputedData : register(t0);
+
+float2 ComplexMult(float2 a, float2 b)
+{
+    return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+}
+
+float2 ComplexExp(float2 a)
+{
+    return float2(cos(a.y), sin(a.y)) * exp(a.x);
+}
+
+[numthreads(1, 8, 1)]
+void PrecomputeTwiddleFactorsAndInputIndices(uint3 id : SV_DispatchThreadID)
+{
+    uint b = Size >> (id.x + 1);
+    float2 mult = 2.0f * PI * float2(0.0f, 1.0f) / Size;
+    uint i = (2 * b * (id.y / b) + id.y % b) % Size;
+    float2 twiddle = ComplexExp(-mult * ((id.y / b) * b));
+    PrecomputeBuffer[id.xy] = float4(twiddle.x, twiddle.y, i, i + b);
+    PrecomputeBuffer[uint2(id.x, id.y + Size / 2)] = float4(-twiddle.x, -twiddle.y, i, i + b);
+}
+
+[numthreads(8, 8, 1)]
+void HorizontalStepFFT(uint3 id : SV_DispatchThreadID)
+{
+    float4 data = PrecomputedData[uint2(Step, id.x)];
+    uint2 inputsIndices = (uint2)data.ba;
+    if (PingPong != 0)
+    {
+        Buffer1[id.xy] = Buffer0[uint2(inputsIndices.x, id.y)] + ComplexMult(data.rg, Buffer0[uint2(inputsIndices.y, id.y)]);
+    }
+    else
+    {
+        Buffer0[id.xy] = Buffer1[uint2(inputsIndices.x, id.y)] + ComplexMult(data.rg, Buffer1[uint2(inputsIndices.y, id.y)]);
+    }
+}
+
+[numthreads(8, 8, 1)]
+void VerticalStepFFT(uint3 id : SV_DispatchThreadID)
+{
+    float4 data = PrecomputedData[uint2(Step, id.y)];
+    uint2 inputsIndices = (uint2)data.ba;
+    if (PingPong != 0)
+    {
+        Buffer1[id.xy] = Buffer0[uint2(id.x, inputsIndices.x)] + ComplexMult(data.rg, Buffer0[uint2(id.x, inputsIndices.y)]);
+    }
+    else
+    {
+        Buffer0[id.xy] = Buffer1[uint2(id.x, inputsIndices.x)] + ComplexMult(data.rg, Buffer1[uint2(id.x, inputsIndices.y)]);
+    }
+}
+
+[numthreads(8, 8, 1)]
+void HorizontalStepInverseFFT(uint3 id : SV_DispatchThreadID)
+{
+    float4 data = PrecomputedData[uint2(Step, id.x)];
+    uint2 inputsIndices = (uint2)data.ba;
+    if (PingPong != 0)
+    {
+        Buffer1[id.xy] = Buffer0[uint2(inputsIndices.x, id.y)] + ComplexMult(float2(data.r, -data.g), Buffer0[uint2(inputsIndices.y, id.y)]);
+    }
+    else
+    {
+        Buffer0[id.xy] = Buffer1[uint2(inputsIndices.x, id.y)] + ComplexMult(float2(data.r, -data.g), Buffer1[uint2(inputsIndices.y, id.y)]);
+    }
+}
+
+[numthreads(8, 8, 1)]
+void VerticalStepInverseFFT(uint3 id : SV_DispatchThreadID)
+{
+    float4 data = PrecomputedData[uint2(Step, id.y)];
+    uint2 inputsIndices = (uint2)data.ba;
+    if (PingPong != 0)
+    {
+        Buffer1[id.xy] = Buffer0[uint2(id.x, inputsIndices.x)] + ComplexMult(float2(data.r, -data.g), Buffer0[uint2(id.x, inputsIndices.y)]);
+    }
+    else
+    {
+        Buffer0[id.xy] = Buffer1[uint2(id.x, inputsIndices.x)] + ComplexMult(float2(data.r, -data.g), Buffer1[uint2(id.x, inputsIndices.y)]);
+    }
+}
+
+[numthreads(8, 8, 1)]
+void Scale(uint3 id : SV_DispatchThreadID)
+{
+    float inv = 1.0f / (float(Size) * float(Size));
+    Buffer0[id.xy] = Buffer0[id.xy] * inv;
+}
+
+[numthreads(8, 8, 1)]
+void Permute(uint3 id : SV_DispatchThreadID)
+{
+    Buffer0[id.xy] = Buffer0[id.xy] * (1.0f - 2.0f * float((id.x + id.y) % 2));
+}

--- a/shaders/ocean_initial_spectrum.hlsl
+++ b/shaders/ocean_initial_spectrum.hlsl
@@ -1,0 +1,174 @@
+// RootSignature: CONSTANTS(b0,count=8) TABLE(SRV(t0) SRV(t1)) TABLE(UAV(u4) UAV(u5) UAV(u6))
+static const float PI = 3.14159265358979323846f;
+
+cbuffer InitialSpectrumParams : register(b0)
+{
+    uint Size;
+    float LengthScale;
+    float CutoffHigh;
+    float CutoffLow;
+    float GravityAcceleration;
+    float Depth;
+    float _pad0;
+    float _pad1;
+};
+
+Texture2D<float2> Noise : register(t0);
+
+struct SpectrumParameters
+{
+    float scale;
+    float angle;
+    float spreadBlend;
+    float swell;
+    float alpha;
+    float peakOmega;
+    float gamma;
+    float shortWavesFade;
+};
+StructuredBuffer<SpectrumParameters> Spectrums : register(t1);
+
+RWTexture2D<float4> H0 : register(u4);
+RWTexture2D<float4> WavesData : register(u5);
+RWTexture2D<float2> H0K : register(u6);
+
+float Frequency(float k, float g, float depth)
+{
+    return sqrt(g * k * tanh(min(k * depth, 20.0f)));
+}
+
+float FrequencyDerivative(float k, float g, float depth)
+{
+    float th = tanh(min(k * depth, 20.0f));
+    float ch = cosh(k * depth);
+    return g * (depth * k / (ch * ch) + th) / Frequency(k, g, depth) * 0.5f;
+}
+
+float NormalisationFactor(float s)
+{
+    float s2 = s * s;
+    float s3 = s2 * s;
+    float s4 = s3 * s;
+    if (s < 5.0f)
+    {
+        return -0.000564f * s4 + 0.00776f * s3 - 0.044f * s2 + 0.192f * s + 0.163f;
+    }
+    return -4.80e-08f * s4 + 1.07e-05f * s3 - 9.53e-04f * s2 + 5.90e-02f * s + 3.93e-01f;
+}
+
+float DonelanBannerBeta(float x)
+{
+    if (x < 0.95f)
+    {
+        return 2.61f * pow(abs(x), 1.3f);
+    }
+    if (x < 1.6f)
+    {
+        return 2.28f * pow(abs(x), -1.3f);
+    }
+    float p = -0.4f + 0.8393f * exp(-0.567f * log(x * x));
+    return pow(10.0f, p);
+}
+
+float DonelanBanner(float theta, float omega, float peakOmega)
+{
+    float beta = DonelanBannerBeta(omega / peakOmega);
+    float sech = 1.0f / cosh(beta * theta);
+    return beta * 0.5f / tanh(beta * PI) * sech * sech;
+}
+
+float Cosine2s(float theta, float s)
+{
+    return NormalisationFactor(s) * pow(abs(cos(0.5f * theta)), 2.0f * s);
+}
+
+float SpreadPower(float omega, float peakOmega)
+{
+    if (omega > peakOmega)
+    {
+        return 9.77f * pow(abs(omega / peakOmega), -2.5f);
+    }
+    return 6.97f * pow(abs(omega / peakOmega), 5.0f);
+}
+
+float DirectionSpectrum(float theta, float omega, SpectrumParameters pars)
+{
+    float s = SpreadPower(omega, pars.peakOmega) + 16.0f * tanh(min(omega / pars.peakOmega, 20.0f)) * pars.swell * pars.swell;
+    return lerp(2.0f / PI * cos(theta) * cos(theta), Cosine2s(theta - pars.angle, s), pars.spreadBlend);
+}
+
+float TMACorrection(float omega, float g, float depth)
+{
+    float omegaH = omega * sqrt(depth / g);
+    if (omegaH <= 1.0f)
+    {
+        return 0.5f * omegaH * omegaH;
+    }
+    if (omegaH < 2.0f)
+    {
+        float t = 2.0f - omegaH;
+        return 1.0f - 0.5f * t * t;
+    }
+    return 1.0f;
+}
+
+float JONSWAP(float omega, float g, float depth, SpectrumParameters pars)
+{
+    float sigma = (omega <= pars.peakOmega) ? 0.07f : 0.09f;
+    float r = exp(-(omega - pars.peakOmega) * (omega - pars.peakOmega) /
+        (2.0f * sigma * sigma * pars.peakOmega * pars.peakOmega));
+
+    float oneOverOmega = 1.0f / omega;
+    float peakOmegaOverOmega = pars.peakOmega / omega;
+    float powTerm = pow(abs(peakOmegaOverOmega), 4.0f);
+    return pars.scale * TMACorrection(omega, g, depth) * pars.alpha * g * g *
+        pow(oneOverOmega, 5.0f) * exp(-1.25f * powTerm * powTerm) * pow(abs(pars.gamma), r);
+}
+
+float ShortWavesFade(float kLength, SpectrumParameters pars)
+{
+    return exp(-pars.shortWavesFade * pars.shortWavesFade * kLength * kLength);
+}
+
+[numthreads(8, 8, 1)]
+void CalculateInitialSpectrum(uint3 id : SV_DispatchThreadID)
+{
+    float deltaK = 2.0f * PI / LengthScale;
+    int nx = int(id.x) - int(Size / 2u);
+    int nz = int(id.y) - int(Size / 2u);
+    float2 k = float2(nx, nz) * deltaK;
+    float kLength = length(k);
+
+    if (kLength <= CutoffHigh && kLength >= CutoffLow)
+    {
+        float kAngle = atan2(k.y, k.x);
+        float omega = Frequency(kLength, GravityAcceleration, Depth);
+        WavesData[id.xy] = float4(k.x, 1.0f / max(kLength, 1e-6f), k.y, omega);
+        float dOmegadk = FrequencyDerivative(kLength, GravityAcceleration, Depth);
+
+        float spectrum = JONSWAP(omega, GravityAcceleration, Depth, Spectrums[0]) *
+            DirectionSpectrum(kAngle, omega, Spectrums[0]) * ShortWavesFade(kLength, Spectrums[0]);
+        if (Spectrums[1].scale > 0.0f)
+        {
+            spectrum += JONSWAP(omega, GravityAcceleration, Depth, Spectrums[1]) *
+                DirectionSpectrum(kAngle, omega, Spectrums[1]) * ShortWavesFade(kLength, Spectrums[1]);
+        }
+
+        float scale = sqrt(2.0f * spectrum * abs(dOmegadk) / max(kLength, 1e-6f) * deltaK * deltaK);
+        H0K[id.xy] = Noise[id.xy] * scale;
+    }
+    else
+    {
+        H0K[id.xy] = float2(0.0f, 0.0f);
+        WavesData[id.xy] = float4(k.x, 1.0f, k.y, 0.0f);
+    }
+}
+
+[numthreads(8, 8, 1)]
+void CalculateConjugatedSpectrum(uint3 id : SV_DispatchThreadID)
+{
+    float2 h0K = H0K[id.xy];
+    uint2 mirror = uint2((Size - id.x) % Size, (Size - id.y) % Size);
+    float2 h0MinusK = H0K[mirror];
+    H0[id.xy] = float4(h0K.x, h0K.y, h0MinusK.x, -h0MinusK.y);
+}

--- a/shaders/ocean_merge.hlsl
+++ b/shaders/ocean_merge.hlsl
@@ -1,0 +1,33 @@
+// RootSignature: CONSTANTS(b0,count=2) TABLE(SRV(t0) SRV(t1) SRV(t2) SRV(t3)) TABLE(UAV(u4) UAV(u5) UAV(u6))
+cbuffer MergeParams : register(b0)
+{
+    float Lambda;
+    float DeltaTime;
+};
+
+RWTexture2D<float3> Displacement : register(u4);
+RWTexture2D<float4> Derivatives : register(u5);
+RWTexture2D<float4> Turbulence : register(u6);
+
+Texture2D<float2> Dx_Dz : register(t0);
+Texture2D<float2> Dy_Dxz : register(t1);
+Texture2D<float2> Dyx_Dyz : register(t2);
+Texture2D<float2> Dxx_Dzz : register(t3);
+
+[numthreads(8, 8, 1)]
+void FillResultTextures(uint3 id : SV_DispatchThreadID)
+{
+    float2 DxDz = Dx_Dz[id.xy];
+    float2 DyDxz = Dy_Dxz[id.xy];
+    float2 DyxDyz = Dyx_Dyz[id.xy];
+    float2 DxxDzz = Dxx_Dzz[id.xy];
+
+    Displacement[id.xy] = float3(Lambda * DxDz.x, DyDxz.x, Lambda * DxDz.y);
+    Derivatives[id.xy] = float4(DyxDyz, DxxDzz * Lambda);
+
+    float jacobian = (1.0f + Lambda * DxxDzz.x) * (1.0f + Lambda * DxxDzz.y) - Lambda * Lambda * DyDxz.y * DyDxz.y;
+    float current = Turbulence[id.xy].x;
+    float updated = current + DeltaTime * 0.5f / max(jacobian, 0.5f);
+    updated = min(jacobian, updated);
+    Turbulence[id.xy] = float4(updated, updated, updated, updated);
+}

--- a/shaders/ocean_time_dependent.hlsl
+++ b/shaders/ocean_time_dependent.hlsl
@@ -1,0 +1,44 @@
+// RootSignature: CONSTANTS(b0,count=1) TABLE(SRV(t0) SRV(t1)) TABLE(UAV(u4) UAV(u5) UAV(u6) UAV(u7))
+cbuffer TimeParams : register(b0)
+{
+    float Time;
+};
+
+RWTexture2D<float2> Dx_Dz : register(u4);
+RWTexture2D<float2> Dy_Dxz : register(u5);
+RWTexture2D<float2> Dyx_Dyz : register(u6);
+RWTexture2D<float2> Dxx_Dzz : register(u7);
+
+Texture2D<float4> H0 : register(t0);
+Texture2D<float4> WavesData : register(t1);
+
+float2 ComplexMult(float2 a, float2 b)
+{
+    return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+}
+
+[numthreads(8, 8, 1)]
+void CalculateAmplitudes(uint3 id : SV_DispatchThreadID)
+{
+    float4 wave = WavesData[id.xy];
+    float phase = wave.w * Time;
+    float2 exponent = float2(cos(phase), sin(phase));
+    float2 h = ComplexMult(H0[id.xy].xy, exponent) + ComplexMult(H0[id.xy].zw, float2(exponent.x, -exponent.y));
+    float2 ih = float2(-h.y, h.x);
+
+    float2 displacementX = ih * wave.x * wave.y;
+    float2 displacementY = h;
+    float2 displacementZ = ih * wave.z * wave.y;
+
+    float2 displacementX_dx = -h * wave.x * wave.x * wave.y;
+    float2 displacementY_dx = ih * wave.x;
+    float2 displacementZ_dx = -h * wave.x * wave.z * wave.y;
+
+    float2 displacementY_dz = ih * wave.z;
+    float2 displacementZ_dz = -h * wave.z * wave.z * wave.y;
+
+    Dx_Dz[id.xy] = float2(displacementX.x - displacementZ.y, displacementX.y + displacementZ.x);
+    Dy_Dxz[id.xy] = float2(displacementY.x - displacementZ_dx.y, displacementY.y + displacementZ_dx.x);
+    Dyx_Dyz[id.xy] = float2(displacementY_dx.x - displacementY_dz.y, displacementY_dx.y + displacementY_dz.x);
+    Dxx_Dzz[id.xy] = float2(displacementX_dx.x - displacementZ_dz.y, displacementX_dx.y + displacementZ_dz.x);
+}

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -173,6 +173,8 @@
     <ClCompile Include="ProfilerScopes.cpp" />
     <ClCompile Include="RenderContextPool.cpp" />
     <ClCompile Include="Renderer.cpp" />
+    <ClCompile Include="GpuTexture2D.cpp" />
+    <ClCompile Include="OceanFFT.cpp" />
     <ClCompile Include="SamplerManager.cpp" />
     <ClCompile Include="Scene.cpp" />
     <ClCompile Include="RenderableObject.cpp" />
@@ -213,6 +215,8 @@
     <ClInclude Include="RenderContext.h" />
     <ClInclude Include="RenderContextPool.h" />
     <ClInclude Include="Renderer.h" />
+    <ClInclude Include="GpuTexture2D.h" />
+    <ClInclude Include="OceanFFT.h" />
     <ClInclude Include="RenderGraph.h" />
     <ClInclude Include="RootSignatureLayout.h" />
     <ClInclude Include="RootSignatureParser.h" />

--- a/test_cube.vcxproj.filters
+++ b/test_cube.vcxproj.filters
@@ -114,6 +114,12 @@
     <ClCompile Include="PointLight.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="GpuTexture2D.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="OceanFFT.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="StaticMesh.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -177,6 +183,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Texture2D.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GpuTexture2D.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OceanFFT.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="SamplerManager.h">


### PR DESCRIPTION
## Summary
- add a reusable GPU texture helper for SRV/UAV render targets
- implement the ocean FFT system with cascades, spectrum preparation, and per-frame dispatch
- port the FFT-based compute shaders for spectra, transforms, and merge and integrate them into the scene render graph with profiling

## Testing
- not run (platform-specific build system)

------
https://chatgpt.com/codex/tasks/task_e_68d40b59443083298bab235f1f288dab