### PR TITLE
Avoid redundant ocean material creation

### DIFF
--- a/InputLayoutManager.cpp
+++ b/InputLayoutManager.cpp
@@ -78,6 +78,12 @@ void InputLayoutManager::InitBuiltins() {
         .AddInstanceMatrix4x4("TEXCOORD", 4, 1) // per-instance
         .Build(*this, "PosColor_InstMat4x4");
 
+    // pos.xy (-1..1 quads), pos.z = clip level index, uv
+    Builder()
+        .Add("POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0)
+        .Add("TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0)
+        .Build(*this, "PosLevelUV");
+
     Builder()
         .Add("POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0)
         .Add("POSITION", 1, DXGI_FORMAT_R32G32B32_FLOAT, 0)

--- a/OceanRenderable.cpp
+++ b/OceanRenderable.cpp
@@ -1,0 +1,297 @@
+#include "OceanRenderable.h"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "Camera.h"
+#include "Renderer.h"
+#include "SamplerManager.h"
+
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    struct OceanVertex
+    {
+        float px;
+        float py;
+        float pz;
+        float u;
+        float v;
+    };
+}
+
+class OceanRenderable::OceanUniformBinder final : public RenderableObject::UniformBinder
+{
+public:
+    explicit OceanUniformBinder(OceanRenderable& owner) : owner_(owner) {}
+
+    void RebuildHandles(RenderableObject& owner) override
+    {
+        if (Material* material = owner.GetGraphicsMaterial())
+        {
+            modelHandle_ = material->ComputeCBFieldHandle(0, "model");
+            viewHandle_ = material->ComputeCBFieldHandle(0, "view");
+            projHandle_ = material->ComputeCBFieldHandle(0, "proj");
+            clipHandle_ = material->ComputeCBFieldHandle(0, "clipData");
+            simulationParamsHandle_ = material->ComputeCBFieldHandle(0, "simulationParams");
+            viewerParamsHandle_ = material->ComputeCBFieldHandle(0, "viewerParams");
+            cascadeLengthScalesHandle_ = material->ComputeCBFieldHandle(0, "cascadeLengthScales");
+            inverseCascadeLengthScalesHandle_ = material->ComputeCBFieldHandle(0, "inverseCascadeLengthScales");
+        }
+        else
+        {
+            modelHandle_ = {};
+            viewHandle_ = {};
+            projHandle_ = {};
+            clipHandle_ = {};
+            simulationParamsHandle_ = {};
+            viewerParamsHandle_ = {};
+            cascadeLengthScalesHandle_ = {};
+            inverseCascadeLengthScalesHandle_ = {};
+        }
+    }
+
+    void UpdateMainCB(RenderableObject& owner, Renderer* /*renderer*/, const mat4& view, const mat4& proj, uint8_t* cbData) override
+    {
+        Material* material = owner.GetGraphicsMaterial();
+        if (!material)
+        {
+            return;
+        }
+
+        UpdateUniform(owner, modelHandle_, material, owner.GetModelMatrix(), cbData);
+        UpdateUniform(owner, viewHandle_, material, view, cbData);
+        UpdateUniform(owner, projHandle_, material, proj, cbData);
+
+        for (uint32_t i = 0; i < OceanSimulation::kClipLevels; ++i)
+        {
+            const Math::float4 clip = owner_.GetClipData(i);
+            material->UpdateCBField(clipHandle_, clip, cbData, i);
+        }
+
+        UpdateUniform(owner, simulationParamsHandle_, material, owner_.GetSimulationParams(), cbData);
+        UpdateUniform(owner, viewerParamsHandle_, material, owner_.GetViewerParams(), cbData);
+        UpdateUniform(owner, cascadeLengthScalesHandle_, material, owner_.GetCascadeLengthScales(), cbData);
+        UpdateUniform(owner, inverseCascadeLengthScalesHandle_, material, owner_.GetCascadeInvLengthScales(), cbData);
+    }
+
+private:
+    OceanRenderable& owner_;
+    Material::CBFieldHandle modelHandle_{};
+    Material::CBFieldHandle viewHandle_{};
+    Material::CBFieldHandle projHandle_{};
+    Material::CBFieldHandle clipHandle_{};
+    Material::CBFieldHandle simulationParamsHandle_{};
+    Material::CBFieldHandle viewerParamsHandle_{};
+    Material::CBFieldHandle cascadeLengthScalesHandle_{};
+    Material::CBFieldHandle inverseCascadeLengthScalesHandle_{};
+};
+
+OceanRenderable::OceanRenderable(Camera* camera)
+    : RenderableObject("PosLevelUV", L"shaders/ocean_surface.hlsl")
+    , camera_(camera)
+    , simulation_(std::make_unique<OceanSimulation>())
+{
+}
+
+void OceanRenderable::Init(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    auto& gd = GetGraphicsDesc();
+    gd.numRT = 1;
+    gd.rtvFormats[0] = renderer->GetSceneColorFormat();
+    gd.dsvFormat = DXGI_FORMAT_D32_FLOAT;
+    gd.depth.DepthEnable = TRUE;
+    gd.depth.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    gd.raster.CullMode = D3D12_CULL_MODE_NONE;
+
+    if (!GetUniformBinder())
+    {
+        SetUniformBinder(std::make_unique<OceanUniformBinder>(*this));
+    }
+
+    RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
+
+    BuildMesh(renderer, uploadCmdList, uploadKeepAlive);
+    simulation_->Initialize(renderer, uploadCmdList, uploadKeepAlive);
+    lengthScales_ = simulation_->GetLengthScales();
+    invLengthScales_ = simulation_->GetInvLengthScales();
+}
+
+void OceanRenderable::Tick(float deltaTime)
+{
+    elapsedTime_ += deltaTime;
+    if (camera_)
+    {
+        const auto pos = camera_->GetPosition();
+        viewerXZ_ = Math::float2(pos.x, pos.z);
+    }
+    UpdateClipLevels();
+}
+
+void OceanRenderable::RecordCompute(Renderer* renderer, ID3D12GraphicsCommandList* cl)
+{
+    if (!renderer || !cl)
+    {
+        return;
+    }
+    if (!simulation_)
+    {
+        return;
+    }
+    simulation_->Update(renderer, cl, elapsedTime_);
+    lengthScales_ = simulation_->GetLengthScales();
+    invLengthScales_ = simulation_->GetInvLengthScales();
+}
+
+void OceanRenderable::PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* /*cl*/, RenderContext& ctx)
+{
+    if (!renderer || !simulation_)
+    {
+        return;
+    }
+
+    auto tbl = renderer->StageSrvUavTable({ simulation_->GetDisplacementSRV() });
+    ctx.table[0] = tbl.gpu;
+
+    const auto samplers = std::array{ SamplerManager::LinearWrap() };
+    ctx.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplers);
+}
+
+void OceanRenderable::RecordGraphics(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx)
+{
+    if (!renderer || !cl)
+    {
+        return;
+    }
+    if (simulation_)
+    {
+        const D3D12_RESOURCE_STATES srvState =
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE |
+            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+        renderer->Transition(cl, simulation_->GetDisplacementResource(), srvState);
+    }
+    RenderableObject::RecordGraphics(renderer, cl, ctx);
+}
+
+void OceanRenderable::OnMaterialHotReload(Renderer* renderer)
+{
+    RenderableObject::OnMaterialHotReload(renderer);
+    if (simulation_)
+    {
+        simulation_->OnHotReload(renderer);
+    }
+}
+
+void OceanRenderable::BuildMesh(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    const uint32_t resolution = OceanSimulation::kResolution;
+    const uint32_t levels = OceanSimulation::kClipLevels;
+    const uint32_t vertsPerLevel = (resolution + 1u) * (resolution + 1u);
+
+    std::vector<OceanVertex> vertices;
+    vertices.reserve(size_t(vertsPerLevel) * size_t(levels));
+
+    std::vector<uint32_t> indices;
+    indices.reserve(size_t(levels) * size_t(resolution) * size_t(resolution) * 6u);
+
+    for (uint32_t level = 0; level < levels; ++level)
+    {
+        for (uint32_t y = 0; y <= resolution; ++y)
+        {
+            const float fy = static_cast<float>(y) / static_cast<float>(resolution);
+            const float ly = fy * 2.0f - 1.0f;
+            for (uint32_t x = 0; x <= resolution; ++x)
+            {
+                const float fx = static_cast<float>(x) / static_cast<float>(resolution);
+                const float lx = fx * 2.0f - 1.0f;
+                vertices.push_back({ lx, ly, static_cast<float>(level), fx, fy });
+            }
+        }
+
+        const uint32_t baseVertex = level * vertsPerLevel;
+        for (uint32_t y = 0; y < resolution; ++y)
+        {
+            for (uint32_t x = 0; x < resolution; ++x)
+            {
+                const uint32_t i0 = baseVertex + y * (resolution + 1u) + x;
+                const uint32_t i1 = i0 + 1u;
+                const uint32_t i2 = i0 + (resolution + 1u);
+                const uint32_t i3 = i2 + 1u;
+
+                indices.push_back(i0);
+                indices.push_back(i2);
+                indices.push_back(i1);
+
+                indices.push_back(i1);
+                indices.push_back(i2);
+                indices.push_back(i3);
+            }
+        }
+    }
+
+    mesh_->CreateGPUFlexible(renderer->GetDevice(), uploadCmdList, uploadKeepAlive,
+        vertices.data(), static_cast<UINT>(vertices.size()), sizeof(OceanVertex),
+        indices.data(), static_cast<UINT>(indices.size()), DXGI_FORMAT_R32_UINT);
+}
+
+void OceanRenderable::UpdateClipLevels()
+{
+    const float patchLength = simulation_ ? simulation_->GetPatchLength() : 200.0f;
+
+    for (uint32_t level = 0; level < clipLevels_.size(); ++level)
+    {
+        const float scale = patchLength * std::pow(2.0f, static_cast<float>(level));
+        const float half = scale * 0.5f;
+        const float step = scale / static_cast<float>(OceanSimulation::kResolution);
+
+        const float snappedX = std::floor(viewerXZ_.x / step) * step;
+        const float snappedZ = std::floor(viewerXZ_.y / step) * step;
+
+        clipLevels_[level].halfExtent = half;
+        clipLevels_[level].offset = Math::float2(snappedX, snappedZ);
+        clipLevels_[level].step = step;
+    }
+
+    activeClipLevels_ = static_cast<uint32_t>(clipLevels_.size());
+}
+
+Math::float4 OceanRenderable::GetClipData(uint32_t index) const
+{
+    if (index >= activeClipLevels_ || index >= clipLevels_.size())
+    {
+        return Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+    }
+    const auto& lvl = clipLevels_[index];
+    return Math::float4(lvl.offset.x, lvl.offset.y, lvl.halfExtent, lvl.step);
+}
+
+Math::float4 OceanRenderable::GetSimulationParams() const
+{
+    const float patchLength = simulation_ ? simulation_->GetPatchLength() : 200.0f;
+    const float invPatch = (patchLength > Math::EPS) ? (1.0f / patchLength) : 0.0f;
+    return Math::float4(patchLength, invPatch, elapsedTime_, static_cast<float>(activeClipLevels_));
+}
+
+Math::float4 OceanRenderable::GetViewerParams() const
+{
+    const float amplitude = simulation_ ? simulation_->GetDisplacementAmplitude() : 1.0f;
+    return Math::float4(viewerXZ_.x, viewerXZ_.y, amplitude, 0.0f);
+}
+
+Math::float4 OceanRenderable::GetCascadeLengthScales() const
+{
+    return lengthScales_;
+}
+
+Math::float4 OceanRenderable::GetCascadeInvLengthScales() const
+{
+    return invLengthScales_;
+}
+

--- a/OceanRenderable.h
+++ b/OceanRenderable.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <vector>
+
+#include "Math.h"
+#include "RenderableObject.h"
+#include "OceanSimulation.h"
+
+class Camera;
+class SamplerManager;
+
+class OceanRenderable : public RenderableObject
+{
+public:
+    explicit OceanRenderable(Camera* camera);
+    ~OceanRenderable() override = default;
+
+    void Init(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive) override;
+
+    void Tick(float deltaTime) override;
+
+    void RecordCompute(Renderer* renderer, ID3D12GraphicsCommandList* cl) override;
+    void PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx) override;
+    void RecordGraphics(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx) override;
+
+    bool IsTransparent() const override { return true; }
+    bool IsSimpleRender() const override { return false; }
+    bool CastsShadow() const override { return false; }
+
+    void OnMaterialHotReload(Renderer* renderer) override;
+
+private:
+    struct ClipLevel
+    {
+        float halfExtent = 1.0f;
+        Math::float2 offset = Math::float2(0.0f, 0.0f);
+        float step = 1.0f;
+    };
+
+    class OceanUniformBinder;
+
+    void BuildMesh(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive);
+    void UpdateClipLevels();
+
+    Math::float4 GetClipData(uint32_t index) const;
+    Math::float4 GetSimulationParams() const;
+    Math::float4 GetViewerParams() const;
+    Math::float4 GetCascadeLengthScales() const;
+    Math::float4 GetCascadeInvLengthScales() const;
+
+private:
+    Camera* camera_ = nullptr;
+    std::unique_ptr<OceanSimulation> simulation_;
+
+    float elapsedTime_ = 0.0f;
+    Math::float2 viewerXZ_ = Math::float2(0.0f, 0.0f);
+    std::array<ClipLevel, OceanSimulation::kClipLevels> clipLevels_{};
+    uint32_t activeClipLevels_ = OceanSimulation::kClipLevels;
+    Math::float4 lengthScales_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+    Math::float4 invLengthScales_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+};
+

--- a/OceanSimulation.cpp
+++ b/OceanSimulation.cpp
@@ -1,0 +1,510 @@
+#include "OceanSimulation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <random>
+
+#include "Helpers.h"
+#include "Material.h"
+#include "Renderer.h"
+#include "RenderContextPool.h"
+#include "UploadManager.h"
+
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    constexpr float kGravity = 9.81f;
+    constexpr float kChoppiness = 1.0f;
+    constexpr UINT kThreadGroupSize = 8;
+
+    inline float PhillipsSpectrum(float kLen, float kDotW, float windSpeed, float patchLength, float spectrumScale)
+    {
+        if (kLen < Math::EPS)
+        {
+            return 0.0f;
+        }
+
+        const float L = (windSpeed * windSpeed) / kGravity;
+        const float damping = 0.001f;
+
+        float phillips = spectrumScale * std::exp(-1.0f / (kLen * kLen * L * L));
+        phillips /= (kLen * kLen * kLen * kLen);
+        phillips *= (kDotW * kDotW);
+        phillips *= std::exp(-kLen * kLen * damping * damping);
+        return std::max(phillips, 0.0f);
+    }
+}
+
+OceanSimulation::OceanSimulation() = default;
+
+uint32_t OceanSimulation::FloatToBits(float value)
+{
+    uint32_t bits = 0u;
+    std::memcpy(&bits, &value, sizeof(uint32_t));
+    return bits;
+}
+
+void OceanSimulation::Initialize(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    if (initialized_ || !renderer)
+    {
+        return;
+    }
+
+    BuildSpectrum();
+    CreateResources(renderer, uploadCmdList, uploadKeepAlive);
+    CreateDescriptors(renderer->GetDevice());
+    CreateMaterials(renderer);
+
+    initialized_ = true;
+}
+
+void OceanSimulation::OnHotReload(Renderer* renderer)
+{
+    if (!renderer)
+    {
+        return;
+    }
+    CreateMaterials(renderer);
+}
+
+void OceanSimulation::CreateResources(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    if (!renderer)
+    {
+        return;
+    }
+
+    UploadManager uploader(renderer->GetDevice(), uploadCmdList);
+
+    const size_t h0Bytes = h0Data_.size() * sizeof(Math::float4);
+    h0Buffer_ = uploader.CreateBufferWithData(h0Data_.data(), h0Bytes,
+        D3D12_RESOURCE_FLAG_NONE,
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    const size_t waveBytes = waveData_.size() * sizeof(Math::float4);
+    waveDataBuffer_ = uploader.CreateBufferWithData(waveData_.data(), waveBytes,
+        D3D12_RESOURCE_FLAG_NONE,
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    uploader.StealKeepAlive(uploadKeepAlive);
+
+    mipCount_ = 1u;
+    UINT size = kResolution;
+    while (size > 1u)
+    {
+        size = std::max<UINT>(1u, size / 2u);
+        ++mipCount_;
+    }
+
+    auto* device = renderer->GetDevice();
+
+    D3D12_HEAP_PROPERTIES heapProps{};
+    heapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+    D3D12_RESOURCE_DESC texDesc{};
+    texDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    texDesc.Alignment = 0;
+    texDesc.Width = kResolution;
+    texDesc.Height = kResolution;
+    texDesc.DepthOrArraySize = kArraySlices;
+    texDesc.MipLevels = static_cast<UINT16>(mipCount_);
+    texDesc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    texDesc.SampleDesc.Count = 1;
+    texDesc.SampleDesc.Quality = 0;
+    texDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    texDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+
+    ThrowIfFailed(device->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE,
+        &texDesc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr,
+        IID_PPV_ARGS(&displacement_)));
+
+    renderer->SetResourceState(displacement_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+}
+
+void OceanSimulation::CreateDescriptors(ID3D12Device* device)
+{
+    if (!device)
+    {
+        return;
+    }
+
+    const UINT descriptorCount = 2u + mipCount_ * 2u;
+
+    D3D12_DESCRIPTOR_HEAP_DESC heapDesc{};
+    heapDesc.NumDescriptors = descriptorCount;
+    heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+    heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+    ThrowIfFailed(device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&descriptorHeap_)));
+
+    descriptorIncr_ = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    D3D12_CPU_DESCRIPTOR_HANDLE base = descriptorHeap_->GetCPUDescriptorHandleForHeapStart();
+
+    auto Offset = [this](D3D12_CPU_DESCRIPTOR_HANDLE start, UINT index)
+    {
+        start.ptr += SIZE_T(index) * SIZE_T(descriptorIncr_);
+        return start;
+    };
+
+    h0Srv_ = base;
+    waveDataSrv_ = Offset(base, 1);
+
+    displacementSrvs_.resize(mipCount_);
+    displacementUavs_.resize(mipCount_);
+
+    for (UINT mip = 0; mip < mipCount_; ++mip)
+    {
+        displacementSrvs_[mip] = Offset(base, 2 + mip);
+    }
+    for (UINT mip = 0; mip < mipCount_; ++mip)
+    {
+        displacementUavs_[mip] = Offset(base, 2 + mipCount_ + mip);
+    }
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC bufferSrv{};
+    bufferSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    bufferSrv.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+    bufferSrv.Format = DXGI_FORMAT_UNKNOWN;
+
+    bufferSrv.Buffer.FirstElement = 0;
+    bufferSrv.Buffer.NumElements = static_cast<UINT>(h0Data_.size());
+    bufferSrv.Buffer.StructureByteStride = sizeof(Math::float4);
+    bufferSrv.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+    device->CreateShaderResourceView(h0Buffer_.Get(), &bufferSrv, h0Srv_);
+
+    bufferSrv.Buffer.NumElements = static_cast<UINT>(waveData_.size());
+    device->CreateShaderResourceView(waveDataBuffer_.Get(), &bufferSrv, waveDataSrv_);
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC texSrv{};
+    texSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    texSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+    texSrv.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    texSrv.Texture2DArray.ArraySize = kArraySlices;
+    texSrv.Texture2DArray.FirstArraySlice = 0;
+    texSrv.Texture2DArray.MostDetailedMip = 0;
+    texSrv.Texture2DArray.MipLevels = 1;
+    texSrv.Texture2DArray.PlaneSlice = 0;
+    texSrv.Texture2DArray.ResourceMinLODClamp = 0.0f;
+
+    for (UINT mip = 0; mip < mipCount_; ++mip)
+    {
+        texSrv.Texture2DArray.MostDetailedMip = mip;
+        device->CreateShaderResourceView(displacement_.Get(), &texSrv, displacementSrvs_[mip]);
+    }
+
+    D3D12_UNORDERED_ACCESS_VIEW_DESC texUav{};
+    texUav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
+    texUav.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    texUav.Texture2DArray.ArraySize = kArraySlices;
+    texUav.Texture2DArray.FirstArraySlice = 0;
+    texUav.Texture2DArray.PlaneSlice = 0;
+
+    for (UINT mip = 0; mip < mipCount_; ++mip)
+    {
+        texUav.Texture2DArray.MipSlice = mip;
+        device->CreateUnorderedAccessView(displacement_.Get(), nullptr, &texUav, displacementUavs_[mip]);
+    }
+}
+
+void OceanSimulation::CreateMaterials(Renderer* renderer)
+{
+    if (!renderer)
+    {
+        return;
+    }
+
+    auto* materialMgr = renderer->GetMaterialManager();
+
+    Material::ComputeDesc spectrumDesc{};
+    spectrumDesc.shaderFile = L"shaders/ocean_time_spectrum.hlsl";
+    spectrumDesc.csEntry = "CalculateAmplitudes";
+    spectrumMaterial_ = materialMgr->GetOrCreateCompute(renderer, spectrumDesc);
+
+    Material::ComputeDesc fftDesc{};
+    fftDesc.shaderFile = L"shaders/ocean_fft.hlsl";
+    fftDesc.csEntry = "Fft";
+    fftDesc.defines.emplace_back("FFT_SIZE", std::to_string(kResolution));
+    const uint32_t logSize = static_cast<uint32_t>(std::log2(static_cast<float>(kResolution)));
+    fftDesc.defines.emplace_back("FFT_LOG_SIZE", std::to_string(logSize));
+    fftMaterial_ = materialMgr->GetOrCreateCompute(renderer, fftDesc);
+
+    Material::ComputeDesc fftPostDesc = fftDesc;
+    fftPostDesc.csEntry = "PostProcess";
+    fftPostMaterial_ = materialMgr->GetOrCreateCompute(renderer, fftPostDesc);
+
+    Material::ComputeDesc mipDesc{};
+    mipDesc.shaderFile = L"shaders/ocean_generate_mips.hlsl";
+    mipDesc.csEntry = "GenerateMip";
+    mipMaterial_ = materialMgr->GetOrCreateCompute(renderer, mipDesc);
+}
+
+void OceanSimulation::BuildSpectrum()
+{
+    const size_t perCascade = size_t(kResolution) * size_t(kResolution);
+    const size_t total = perCascade * size_t(kCascadeCount);
+
+    h0Data_.resize(total);
+    waveData_.resize(total);
+
+    std::vector<Math::float2> h0Seed(total);
+
+    std::mt19937 rng(1337u);
+    std::normal_distribution<float> gauss(0.0f, 1.0f);
+
+    const Math::float2 windDirNorm = windDir_.Normalized();
+
+    auto SetComponent = [](Math::float4& v, UINT index, float value)
+    {
+        float* data = &v.x;
+        if (index < 4)
+        {
+            data[index] = value;
+        }
+    };
+
+    for (UINT cascade = 0; cascade < kCascadeCount; ++cascade)
+    {
+        const float patchLength = basePatchLength_ * std::pow(2.0f, static_cast<float>(cascade));
+        SetComponent(lengthScales_, cascade, patchLength);
+        SetComponent(invLengthScales_, cascade, patchLength > Math::EPS ? (1.0f / patchLength) : 0.0f);
+
+        const float twoPiOverL = Math::TWO_PI / patchLength;
+        const float lambda = kChoppiness;
+
+        for (UINT y = 0; y < kResolution; ++y)
+        {
+            const int iy = static_cast<int>(y) - static_cast<int>(kResolution / 2);
+            for (UINT x = 0; x < kResolution; ++x)
+            {
+                const int ix = static_cast<int>(x) - static_cast<int>(kResolution / 2);
+                const size_t idx = size_t(cascade) * perCascade + size_t(y) * size_t(kResolution) + size_t(x);
+
+                Math::float2 kVec(float(ix) * twoPiOverL, float(iy) * twoPiOverL);
+                const float kLen = std::sqrt(kVec.x * kVec.x + kVec.y * kVec.y);
+
+                if (kLen < Math::EPS)
+                {
+                    h0Seed[idx] = Math::float2(0.0f, 0.0f);
+                    waveData_[idx] = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+                    continue;
+                }
+
+                Math::float2 kNorm = kVec / kLen;
+                float kDotW = Math::Clamp(kNorm.Dot(windDirNorm), -1.0f, 1.0f);
+                const float spectrum = PhillipsSpectrum(kLen, kDotW, windSpeed_, patchLength, spectrumScale_);
+                const float sigma = std::sqrt(spectrum) * 0.70710678f;
+
+                h0Seed[idx] = Math::float2(gauss(rng) * sigma, gauss(rng) * sigma);
+
+                const float omega = std::sqrt(kGravity * kLen);
+                waveData_[idx] = Math::float4(kVec.x, lambda, kVec.y, omega);
+            }
+        }
+    }
+
+    for (UINT cascade = 0; cascade < kCascadeCount; ++cascade)
+    {
+        for (UINT y = 0; y < kResolution; ++y)
+        {
+            for (UINT x = 0; x < kResolution; ++x)
+            {
+                const size_t idx = size_t(cascade) * perCascade + size_t(y) * size_t(kResolution) + size_t(x);
+
+                const UINT negX = (kResolution - x) % kResolution;
+                const UINT negY = (kResolution - y) % kResolution;
+                const size_t negIdx = size_t(cascade) * perCascade + size_t(negY) * size_t(kResolution) + size_t(negX);
+
+                const Math::float2 h0 = h0Seed[idx];
+                const Math::float2 h0Neg = h0Seed[negIdx];
+                h0Data_[idx] = Math::float4(h0.x, h0.y, h0Neg.x, -h0Neg.y);
+            }
+        }
+    }
+}
+
+void OceanSimulation::Update(Renderer* renderer, ID3D12GraphicsCommandList* cl, float timeSeconds)
+{
+    if (!renderer || !cl)
+    {
+        return;
+    }
+
+    if (!initialized_)
+    {
+        Initialize(renderer, cl, nullptr);
+    }
+
+    const float simTime = timeSeconds * timeScale_;
+
+    DispatchSpectrum(renderer, cl, simTime);
+    DispatchFFT(renderer, cl);
+    DispatchFFTPost(renderer, cl);
+    GenerateMips(renderer, cl);
+
+    const D3D12_RESOURCE_STATES srvState =
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE |
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+    renderer->Transition(cl, displacement_.Get(), srvState);
+}
+
+void OceanSimulation::DispatchSpectrum(Renderer* renderer, ID3D12GraphicsCommandList* cl, float timeSeconds)
+{
+    if (!spectrumMaterial_)
+    {
+        return;
+    }
+
+    renderer->Transition(cl, displacement_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+    auto& ctx = ctxHandle.ref();
+
+    ctx.constants[0] = {
+        kResolution,
+        kCascadeCount,
+        FloatToBits(timeSeconds),
+        kResolution * kResolution
+    };
+
+    auto srvTable = renderer->StageSrvUavTable({ h0Srv_, waveDataSrv_ });
+    auto uavTable = renderer->StageSrvUavTable({ displacementUavs_.empty() ? D3D12_CPU_DESCRIPTOR_HANDLE{} : displacementUavs_[0] });
+
+    ctx.table[0] = srvTable.gpu;
+    ctx.table[1] = uavTable.gpu;
+
+    spectrumMaterial_->Bind(cl, ctx);
+
+    const UINT groups = (kResolution + kThreadGroupSize - 1u) / kThreadGroupSize;
+    cl->Dispatch(groups, groups, kCascadeCount);
+
+    renderer->UAVBarrier(cl, displacement_.Get());
+}
+
+void OceanSimulation::DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList* cl)
+{
+    if (!fftMaterial_)
+    {
+        return;
+    }
+
+    renderer->Transition(cl, displacement_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    auto uavTable = renderer->StageSrvUavTable({ displacementUavs_.empty() ? D3D12_CPU_DESCRIPTOR_HANDLE{} : displacementUavs_[0] });
+
+    {
+        auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+        auto& ctx = ctxHandle.ref();
+        ctx.constants[0] = {
+            kArraySlices,
+            0u,
+            1u,
+            0u,
+        };
+        ctx.table[0] = uavTable.gpu;
+        fftMaterial_->Bind(cl, ctx);
+        cl->Dispatch(1, kResolution, 1);
+    }
+
+    renderer->UAVBarrier(cl, displacement_.Get());
+
+    {
+        auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+        auto& ctx = ctxHandle.ref();
+        ctx.constants[0] = {
+            kArraySlices,
+            1u,
+            1u,
+            0u,
+        };
+        ctx.table[0] = uavTable.gpu;
+        fftMaterial_->Bind(cl, ctx);
+        cl->Dispatch(1, kResolution, 1);
+    }
+
+    renderer->UAVBarrier(cl, displacement_.Get());
+}
+
+void OceanSimulation::DispatchFFTPost(Renderer* renderer, ID3D12GraphicsCommandList* cl)
+{
+    if (!fftPostMaterial_)
+    {
+        return;
+    }
+
+    renderer->Transition(cl, displacement_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    auto uavTable = renderer->StageSrvUavTable({ displacementUavs_.empty() ? D3D12_CPU_DESCRIPTOR_HANDLE{} : displacementUavs_[0] });
+
+    auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+    auto& ctx = ctxHandle.ref();
+    ctx.constants[0] = {
+        kArraySlices,
+        1u,
+        1u,
+        0u,
+    };
+    ctx.table[0] = uavTable.gpu;
+
+    fftPostMaterial_->Bind(cl, ctx);
+
+    const UINT groups = (kResolution + kThreadGroupSize - 1u) / kThreadGroupSize;
+    cl->Dispatch(groups, groups, 1);
+
+    renderer->UAVBarrier(cl, displacement_.Get());
+}
+
+void OceanSimulation::GenerateMips(Renderer* renderer, ID3D12GraphicsCommandList* cl)
+{
+    if (!mipMaterial_ || mipCount_ <= 1)
+    {
+        return;
+    }
+
+    renderer->Transition(cl, displacement_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    UINT srcWidth = kResolution;
+    UINT srcHeight = kResolution;
+
+    for (UINT mip = 1; mip < mipCount_; ++mip)
+    {
+        const UINT dstWidth = std::max<UINT>(1u, srcWidth / 2u);
+        const UINT dstHeight = std::max<UINT>(1u, srcHeight / 2u);
+
+        auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
+        auto& ctx = ctxHandle.ref();
+
+        ctx.constants[0] = {
+            srcWidth,
+            srcHeight,
+            dstWidth,
+            dstHeight,
+            kArraySlices,
+            mip,
+            0u,
+            0u
+        };
+
+        auto srvTable = renderer->StageSrvUavTable({ displacementSrvs_[mip - 1] });
+        auto uavTable = renderer->StageSrvUavTable({ displacementUavs_[mip] });
+
+        ctx.table[0] = srvTable.gpu;
+        ctx.table[1] = uavTable.gpu;
+
+        mipMaterial_->Bind(cl, ctx);
+
+        const UINT groupsX = (dstWidth + kThreadGroupSize - 1u) / kThreadGroupSize;
+        const UINT groupsY = (dstHeight + kThreadGroupSize - 1u) / kThreadGroupSize;
+        cl->Dispatch(groupsX, groupsY, kArraySlices);
+
+        renderer->UAVBarrier(cl, displacement_.Get());
+
+        srcWidth = dstWidth;
+        srcHeight = dstHeight;
+    }
+}

--- a/OceanSimulation.h
+++ b/OceanSimulation.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <d3d12.h>
+#include <wrl/client.h>
+
+#include "Math.h"
+
+class Renderer;
+class Material;
+
+class OceanSimulation
+{
+public:
+    static constexpr UINT kResolution = 256;
+    static constexpr UINT kCascadeCount = 4;
+    static constexpr UINT kClipLevels = kCascadeCount;
+    static constexpr UINT kArraySlices = kCascadeCount * 2;
+
+    OceanSimulation();
+    ~OceanSimulation() = default;
+
+    void Initialize(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive);
+
+    void Update(Renderer* renderer, ID3D12GraphicsCommandList* cl, float timeSeconds);
+    void OnHotReload(Renderer* renderer);
+
+    float GetPatchLength() const { return basePatchLength_; }
+    const Math::float4& GetLengthScales() const { return lengthScales_; }
+    const Math::float4& GetInvLengthScales() const { return invLengthScales_; }
+    float GetDisplacementAmplitude() const { return displacementAmplitude_; }
+
+    D3D12_CPU_DESCRIPTOR_HANDLE GetDisplacementSRV() const { return displacementSrvs_.empty() ? D3D12_CPU_DESCRIPTOR_HANDLE{} : displacementSrvs_[0]; }
+    ID3D12Resource* GetDisplacementResource() const { return displacement_.Get(); }
+
+private:
+    void BuildSpectrum();
+    void CreateResources(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive);
+    void CreateDescriptors(ID3D12Device* device);
+    void CreateMaterials(Renderer* renderer);
+    void DispatchSpectrum(Renderer* renderer, ID3D12GraphicsCommandList* cl, float timeSeconds);
+    void DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList* cl);
+    void DispatchFFTPost(Renderer* renderer, ID3D12GraphicsCommandList* cl);
+    void GenerateMips(Renderer* renderer, ID3D12GraphicsCommandList* cl);
+
+    static uint32_t FloatToBits(float value);
+
+private:
+    bool initialized_ = false;
+
+    float basePatchLength_ = 200.0f;
+    float windSpeed_ = 12.0f;
+    Math::float2 windDir_ = Math::float2(1.0f, 0.0f);
+    float spectrumScale_ = 3.0e-3f;
+    float displacementAmplitude_ = 1.5f;
+    float timeScale_ = 1.0f;
+
+    Math::float4 lengthScales_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+    Math::float4 invLengthScales_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+    std::vector<Math::float4> h0Data_;
+    std::vector<Math::float4> waveData_;
+
+    Microsoft::WRL::ComPtr<ID3D12Resource> h0Buffer_;
+    Microsoft::WRL::ComPtr<ID3D12Resource> waveDataBuffer_;
+    Microsoft::WRL::ComPtr<ID3D12Resource> displacement_;
+
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> descriptorHeap_;
+    UINT descriptorIncr_ = 0;
+    D3D12_CPU_DESCRIPTOR_HANDLE h0Srv_{};
+    D3D12_CPU_DESCRIPTOR_HANDLE waveDataSrv_{};
+    std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> displacementSrvs_;
+    std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> displacementUavs_;
+
+    UINT mipCount_ = 1u;
+
+    std::shared_ptr<Material> spectrumMaterial_;
+    std::shared_ptr<Material> fftMaterial_;
+    std::shared_ptr<Material> fftPostMaterial_;
+    std::shared_ptr<Material> mipMaterial_;
+};
+

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -11,6 +11,7 @@
 #include "Helpers.h"
 #include "Renderer.h"
 #include "RenderGraph.h"
+#include "OceanRenderable.h"
 #include "StaticMesh.h"
 #include "TaskSystem.h"
 #include "TextManager.h"
@@ -297,6 +298,8 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
     }
 
     AddObject(std::make_unique<GpuInstancedModels>("models/teapot.obj", 100, "bronze", "PosNormTanUV", L"shaders/gbuffer_inst.hlsl", L"shaders/instance_anim.hlsl"));
+
+    AddObject(std::make_unique<OceanRenderable>(&camera_));
 
     AddObject(std::make_unique<DebugGrid>(100.0f));
 

--- a/shaders/ocean_fft.hlsl
+++ b/shaders/ocean_fft.hlsl
@@ -1,0 +1,116 @@
+// RootSignature: CONSTANTS(b0,count=4) TABLE(UAV(u0))
+
+#ifndef FFT_SIZE
+#define FFT_SIZE 256
+#endif
+
+#ifndef FFT_LOG_SIZE
+#define FFT_LOG_SIZE 8
+#endif
+
+static const uint Size = FFT_SIZE;
+
+RWTexture2DArray<float4> Target : register(u0);
+
+cbuffer FFTParams : register(b0)
+{
+    uint TargetsCount;
+    uint Direction;
+    uint Inverse;
+    uint Flags;
+};
+
+groupshared float4 BufferA[FFT_SIZE];
+groupshared float4 BufferB[FFT_SIZE];
+
+float2 ComplexMult(float2 a, float2 b)
+{
+    return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+}
+
+void ButterflyValues(uint step, uint index, out uint2 indices, out float2 twiddle)
+{
+    const float twoPi = 6.28318530718f;
+    uint b = Size >> (step + 1);
+    uint w = b * (index / b);
+    uint i = (w + index) % Size;
+    sincos(-twoPi / Size * w, twiddle.y, twiddle.x);
+    if (Inverse != 0)
+    {
+        twiddle.y = -twiddle.y;
+    }
+    indices = uint2(i, i + b);
+}
+
+float4 DoFft(uint threadIndex, float4 input)
+{
+    BufferA[threadIndex] = input;
+    GroupMemoryBarrierWithGroupSync();
+
+    bool flag = false;
+
+    [unroll(FFT_LOG_SIZE)]
+    for (uint step = 0; step < FFT_LOG_SIZE; ++step)
+    {
+        uint2 inputsIndices;
+        float2 twiddle;
+        ButterflyValues(step, threadIndex, inputsIndices, twiddle);
+
+        float4 v = flag ? BufferA[inputsIndices.y] : BufferB[inputsIndices.y];
+        float4 lhs = flag ? BufferA[inputsIndices.x] : BufferB[inputsIndices.x];
+        float4 res = lhs + float4(ComplexMult(twiddle, v.xy), ComplexMult(twiddle, v.zw));
+
+        if (flag)
+        {
+            BufferB[threadIndex] = res;
+        }
+        else
+        {
+            BufferA[threadIndex] = res;
+        }
+
+        flag = !flag;
+        GroupMemoryBarrierWithGroupSync();
+    }
+
+    return flag ? BufferB[threadIndex] : BufferA[threadIndex];
+}
+
+[numthreads(FFT_SIZE, 1, 1)]
+void Fft(uint3 id : SV_DispatchThreadID)
+{
+    uint threadIndex = id.x;
+    uint2 targetIndex = (Direction == 0) ? id.xy : id.yx;
+
+    for (uint k = 0; k < TargetsCount; ++k)
+    {
+        Target[uint3(targetIndex, k)] = DoFft(threadIndex, Target[uint3(targetIndex, k)]);
+    }
+}
+
+float4 DoPostProcess(float4 input, uint2 coord)
+{
+    if (Direction != 0)
+    {
+        input /= (Size * Size);
+    }
+    if (Inverse != 0)
+    {
+        input *= 1.0f - 2.0f * ((coord.x + coord.y) & 1);
+    }
+    return input;
+}
+
+[numthreads(8, 8, 1)]
+void PostProcess(uint3 id : SV_DispatchThreadID)
+{
+    if (id.x >= Size || id.y >= Size)
+    {
+        return;
+    }
+
+    for (uint k = 0; k < TargetsCount; ++k)
+    {
+        Target[uint3(id.xy, k)] = DoPostProcess(Target[uint3(id.xy, k)], id.xy);
+    }
+}

--- a/shaders/ocean_generate_mips.hlsl
+++ b/shaders/ocean_generate_mips.hlsl
@@ -1,0 +1,45 @@
+// RootSignature: CONSTANTS(b0,count=8) TABLE(SRV(t0)) TABLE(UAV(u0))
+
+cbuffer MipParams : register(b0)
+{
+    uint SrcWidth;
+    uint SrcHeight;
+    uint DstWidth;
+    uint DstHeight;
+    uint ArrayCount;
+    uint MipLevel;
+    uint _pad0;
+    uint _pad1;
+};
+
+Texture2DArray<float4> Source : register(t0);
+RWTexture2DArray<float4> Dest : register(u0);
+
+[numthreads(8, 8, 1)]
+void GenerateMip(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+    if (dispatchThreadId.x >= DstWidth || dispatchThreadId.y >= DstHeight || dispatchThreadId.z >= ArrayCount)
+    {
+        return;
+    }
+
+    uint2 srcBase = dispatchThreadId.xy * 2;
+    uint slice = dispatchThreadId.z;
+
+    uint srcMaxX = SrcWidth - 1;
+    uint srcMaxY = SrcHeight - 1;
+
+    float4 sum = 0.0f;
+    [unroll]
+    for (uint oy = 0; oy < 2; ++oy)
+    {
+        [unroll]
+        for (uint ox = 0; ox < 2; ++ox)
+        {
+            uint2 coord = uint2(min(srcBase.x + ox, srcMaxX), min(srcBase.y + oy, srcMaxY));
+            sum += Source.Load(int4(coord, slice, 0));
+        }
+    }
+
+    Dest[uint3(dispatchThreadId.xy, slice)] = sum * 0.25f;
+}

--- a/shaders/ocean_surface.hlsl
+++ b/shaders/ocean_surface.hlsl
@@ -1,0 +1,93 @@
+// RootSignature: CBV(b0) TABLE(SRV(t0)) TABLE(SAMPLER(s0))
+#pragma pack_matrix(row_major)
+
+cbuffer OceanCB : register(b0)
+{
+    float4x4 model;
+    float4x4 view;
+    float4x4 proj;
+    float4 clipData[4]; // xy: offset, z: half extent, w: step
+    float4 simulationParams;           // x: patch length, y: inv patch length, z: time, w: clip level count
+    float4 viewerParams;               // x: viewer x, y: viewer z, z: amplitude, w: unused
+    float4 cascadeLengthScales;        // length scales per cascade
+    float4 inverseCascadeLengthScales; // inv length scales per cascade
+};
+
+Texture2DArray<float4> DisplacementDerivatives : register(t0);
+SamplerState LinearWrapSampler : register(s0);
+
+struct VSInput
+{
+    float3 position : POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+struct VSOutput
+{
+    float4 position : SV_POSITION;
+    float3 worldPos : TEXCOORD0;
+    float3 normalWS : TEXCOORD1;
+    float3 displacementUVW : TEXCOORD2;
+};
+
+static const float3 kDeepColor = float3(0.01f, 0.09f, 0.18f);
+static const float3 kShallowColor = float3(0.06f, 0.25f, 0.35f);
+static const float3 kLightDir = normalize(float3(0.4f, 1.0f, 0.2f));
+
+float3 SampleDisplacement(float2 worldXZ, uint level, float amplitude)
+{
+    float lengthScale = max(cascadeLengthScales[level], 1e-3);
+    float3 uvw = float3(worldXZ / lengthScale, level * 2);
+    float4 sample = DisplacementDerivatives.SampleLevel(LinearWrapSampler, uvw, 0);
+    return float3(sample.x, sample.y, sample.z) * amplitude;
+}
+
+float4 SampleDerivatives(float2 worldXZ, uint level, float amplitude)
+{
+    float lengthScale = max(cascadeLengthScales[level], 1e-3);
+    float3 uvw = float3(worldXZ / lengthScale, level * 2 + 1);
+    float4 sample = DisplacementDerivatives.SampleLevel(LinearWrapSampler, uvw, 0);
+    return sample * amplitude;
+}
+
+VSOutput VSMain(VSInput input)
+{
+    VSOutput output;
+
+    uint clipCount = max((uint)simulationParams.w, 1u);
+    uint level = min((uint)input.position.z, clipCount - 1u);
+
+    float4 clip = clipData[level];
+    float2 worldXZ = input.position.xy * clip.z + clip.xy;
+
+    float amplitude = viewerParams.z;
+
+    float3 displacement = SampleDisplacement(worldXZ, level, amplitude);
+    float4 deriv = SampleDerivatives(worldXZ, level, amplitude);
+
+    float3 world = float3(worldXZ.x + displacement.x, displacement.y, worldXZ.y + displacement.z);
+    output.worldPos = world;
+
+    float denomX = max(1e-3f, 1.0f + deriv.z);
+    float denomZ = max(1e-3f, 1.0f + deriv.w);
+    float2 slope = float2(deriv.x / denomX, deriv.y / denomZ);
+    float3 normal = normalize(float3(-slope.x, 1.0f, -slope.y));
+    output.normalWS = normal;
+    output.displacementUVW = float3(worldXZ, level);
+
+    float4 local = float4(world, 1.0f);
+    float4 worldH = mul(local, model);
+    float4 viewPos = mul(worldH, view);
+    output.position = mul(viewPos, proj);
+    return output;
+}
+
+float4 PSMain(VSOutput input) : SV_TARGET
+{
+    float heightFactor = saturate(input.worldPos.y * 0.5f + 0.5f);
+    float3 baseColor = lerp(kDeepColor, kShallowColor, heightFactor);
+    float3 normal = normalize(input.normalWS);
+    float lighting = saturate(dot(normal, kLightDir)) * 0.7f + 0.3f;
+    float3 color = baseColor * lighting;
+    return float4(color, 1.0f);
+}

--- a/shaders/ocean_time_spectrum.hlsl
+++ b/shaders/ocean_time_spectrum.hlsl
@@ -1,0 +1,84 @@
+// RootSignature: CONSTANTS(b0,count=4) TABLE(SRV(t0,t1)) TABLE(UAV(u0))
+
+cbuffer SpectrumParams : register(b0)
+{
+    uint Resolution;
+    uint Cascades;
+    float Time;
+    uint CascadeStride;
+};
+
+StructuredBuffer<float4> H0 : register(t0);
+StructuredBuffer<float4> Waves : register(t1);
+RWTexture2DArray<float4> Spectrum : register(u0);
+
+float2 ComplexMul(float2 a, float2 b)
+{
+    return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+}
+
+float2 ComplexConj(float2 a)
+{
+    return float2(a.x, -a.y);
+}
+
+[numthreads(8, 8, 1)]
+void CalculateAmplitudes(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+    if (dispatchThreadId.x >= Resolution || dispatchThreadId.y >= Resolution || dispatchThreadId.z >= Cascades)
+    {
+        return;
+    }
+
+    const uint baseIndex = dispatchThreadId.z * CascadeStride
+        + dispatchThreadId.y * Resolution + dispatchThreadId.x;
+
+    float4 wave = Waves[baseIndex];
+    float4 h0 = H0[baseIndex];
+
+    if (wave.w == 0.0f)
+    {
+        Spectrum[uint3(dispatchThreadId.xy, dispatchThreadId.z * 2)] = 0;
+        Spectrum[uint3(dispatchThreadId.xy, dispatchThreadId.z * 2 + 1)] = 0;
+        return;
+    }
+
+    float phase = wave.w * Time;
+    float s, c;
+    sincos(phase, s, c);
+    float2 exponent = float2(c, s);
+
+    float2 h = ComplexMul(h0.xy, exponent) + ComplexMul(float2(h0.z, h0.w), ComplexConj(exponent));
+    float2 ih = float2(-h.y, h.x);
+
+    float kLen = length(wave.xz);
+    float invKLen = (kLen > 1e-4) ? rcp(kLen) : 0.0f;
+
+    float lambda = wave.y;
+
+    float2 displacementX = lambda * ih * wave.x * invKLen;
+    float2 displacementY = h;
+    float2 displacementZ = lambda * ih * wave.z * invKLen;
+
+    float2 displacementX_dx = -lambda * h * wave.x * wave.x * invKLen;
+    float2 displacementY_dx = ih * wave.x;
+    float2 displacementZ_dx = -lambda * h * wave.x * wave.z * invKLen;
+
+    float2 displacementY_dz = ih * wave.z;
+    float2 displacementZ_dz = -lambda * h * wave.z * wave.z * invKLen;
+
+    float4 packed0 = float4(
+        displacementX.x - displacementY.y,
+        displacementX.y + displacementY.x,
+        displacementZ.x - displacementZ_dx.y,
+        displacementZ.y + displacementZ_dx.x);
+
+    float4 packed1 = float4(
+        displacementY_dx.x - displacementY_dz.y,
+        displacementY_dx.y + displacementY_dz.x,
+        displacementX_dx.x - displacementZ_dz.y,
+        displacementX_dx.y + displacementZ_dz.x);
+
+    Spectrum[uint3(dispatchThreadId.xy, dispatchThreadId.z * 2)] = packed0;
+    Spectrum[uint3(dispatchThreadId.xy, dispatchThreadId.z * 2 + 1)] = packed1;
+}

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -168,6 +168,8 @@
     <ClCompile Include="MaterialDataManager.cpp" />
     <ClCompile Include="Mesh.cpp" />
     <ClCompile Include="MeshManager.cpp" />
+    <ClCompile Include="OceanRenderable.cpp" />
+    <ClCompile Include="OceanSimulation.cpp" />
     <ClCompile Include="PointLight.cpp" />
     <ClCompile Include="Profiler.cpp" />
     <ClCompile Include="ProfilerScopes.cpp" />
@@ -207,6 +209,8 @@
     <ClInclude Include="Math.h" />
     <ClInclude Include="Mesh.h" />
     <ClInclude Include="MeshManager.h" />
+    <ClInclude Include="OceanRenderable.h" />
+    <ClInclude Include="OceanSimulation.h" />
     <ClInclude Include="PointLight.h" />
     <ClInclude Include="Profiler.h" />
     <ClInclude Include="ProfilerScopes.h" />
@@ -257,6 +261,18 @@
       <FileType>Document</FileType>
     </Text>
     <Text Include="shaders\lines.hlsl">
+      <FileType>Document</FileType>
+    </Text>
+    <Text Include="shaders\ocean_fft.hlsl">
+      <FileType>Document</FileType>
+    </Text>
+    <Text Include="shaders\ocean_generate_mips.hlsl">
+      <FileType>Document</FileType>
+    </Text>
+    <Text Include="shaders\ocean_time_spectrum.hlsl">
+      <FileType>Document</FileType>
+    </Text>
+    <Text Include="shaders\ocean_surface.hlsl">
       <FileType>Document</FileType>
     </Text>
     <Text Include="shaders\shader.hlsl">

--- a/test_cube.vcxproj.filters
+++ b/test_cube.vcxproj.filters
@@ -102,6 +102,12 @@
     <ClCompile Include="RenderableObjectBase.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="OceanSimulation.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="OceanRenderable.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="RenderContextPool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -186,6 +192,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="MeshManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OceanSimulation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OceanRenderable.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="DebugGrid.h">
@@ -281,6 +293,18 @@
       <Filter>Shaders</Filter>
     </Text>
     <Text Include="shaders\lines.hlsl">
+      <Filter>Shaders</Filter>
+    </Text>
+    <Text Include="shaders\ocean_fft.hlsl">
+      <Filter>Shaders</Filter>
+    </Text>
+    <Text Include="shaders\ocean_generate_mips.hlsl">
+      <Filter>Shaders</Filter>
+    </Text>
+    <Text Include="shaders\ocean_time_spectrum.hlsl">
+      <Filter>Shaders</Filter>
+    </Text>
+    <Text Include="shaders\ocean_surface.hlsl">
       <Filter>Shaders</Filter>
     </Text>
     <Text Include="shaders\shader.hlsl">


### PR DESCRIPTION
## Summary
- stop calling `CreateMaterials` inside the ocean simulation update so materials are not rebuilt every frame
- mark `OceanRenderable` as a complex renderable so it participates in the full render path

## Testing
- not run (Windows Direct3D project)


------
https://chatgpt.com/codex/tasks/task_e_68d4fefbe008832993ae233a8c009221