### PR TITLE
Fix ocean compute descriptor bindings

### DIFF
--- a/OceanSimulation.cpp
+++ b/OceanSimulation.cpp
@@ -406,7 +406,7 @@ void OceanSimulation::DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList*
             1u,
             0u,
         };
-        ctx.table[0] = uavTable.gpu;
+        ctx.table[1] = uavTable.gpu;
         fftMaterial_->Bind(cl, ctx);
         cl->Dispatch(1, kResolution, 1);
     }
@@ -422,7 +422,7 @@ void OceanSimulation::DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList*
             1u,
             0u,
         };
-        ctx.table[0] = uavTable.gpu;
+        ctx.table[1] = uavTable.gpu;
         fftMaterial_->Bind(cl, ctx);
         cl->Dispatch(1, kResolution, 1);
     }
@@ -449,7 +449,7 @@ void OceanSimulation::DispatchFFTPost(Renderer* renderer, ID3D12GraphicsCommandL
         1u,
         0u,
     };
-    ctx.table[0] = uavTable.gpu;
+    ctx.table[1] = uavTable.gpu;
 
     fftPostMaterial_->Bind(cl, ctx);
 

--- a/shaders/ocean_fft.hlsl
+++ b/shaders/ocean_fft.hlsl
@@ -1,4 +1,4 @@
-// RootSignature: CONSTANTS(b0,count=4) TABLE(UAV(u0))
+// RootSignature: CONSTANTS(b0,count=4) TABLE(UAV(u1))
 
 #ifndef FFT_SIZE
 #define FFT_SIZE 256
@@ -10,7 +10,7 @@
 
 static const uint Size = FFT_SIZE;
 
-RWTexture2DArray<float4> Target : register(u0);
+RWTexture2DArray<float4> Target : register(u1);
 
 cbuffer FFTParams : register(b0)
 {

--- a/shaders/ocean_generate_mips.hlsl
+++ b/shaders/ocean_generate_mips.hlsl
@@ -1,4 +1,4 @@
-// RootSignature: CONSTANTS(b0,count=8) TABLE(SRV(t0)) TABLE(UAV(u0))
+// RootSignature: CONSTANTS(b0,count=8) TABLE(SRV(t0)) TABLE(UAV(u1))
 
 cbuffer MipParams : register(b0)
 {
@@ -13,7 +13,7 @@ cbuffer MipParams : register(b0)
 };
 
 Texture2DArray<float4> Source : register(t0);
-RWTexture2DArray<float4> Dest : register(u0);
+RWTexture2DArray<float4> Dest : register(u1);
 
 [numthreads(8, 8, 1)]
 void GenerateMip(uint3 dispatchThreadId : SV_DispatchThreadID)

--- a/shaders/ocean_time_spectrum.hlsl
+++ b/shaders/ocean_time_spectrum.hlsl
@@ -1,4 +1,4 @@
-// RootSignature: CONSTANTS(b0,count=4) TABLE(SRV(t0) SRV(t1)) TABLE(UAV(u0))
+// RootSignature: CONSTANTS(b0,count=4) TABLE(SRV(t0) SRV(t1)) TABLE(UAV(u1))
 
 cbuffer SpectrumParams : register(b0)
 {
@@ -10,7 +10,7 @@ cbuffer SpectrumParams : register(b0)
 
 StructuredBuffer<float4> H0 : register(t0);
 StructuredBuffer<float4> Waves : register(t1);
-RWTexture2DArray<float4> Spectrum : register(u0);
+RWTexture2DArray<float4> Spectrum : register(u1);
 
 float2 ComplexMul(float2 a, float2 b)
 {


### PR DESCRIPTION
## Summary
- move the ocean compute UAV bindings to register u1 so SRV and UAV descriptor tables do not collide
- update the ocean FFT dispatch to write to the new UAV table slot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6569b6a548329a65e71fcbdff8422