### PR TITLE
Seed ocean simulation with URP defaults

### DIFF
--- a/OceanSimulation.cpp
+++ b/OceanSimulation.cpp
@@ -10,34 +10,294 @@
 #include "Renderer.h"
 #include "RenderContextPool.h"
 #include "UploadManager.h"
+#include "OceanSpectrum.h"
 
 using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    constexpr float kGravity = 9.81f;
-    constexpr float kChoppiness = 1.0f;
     constexpr UINT kThreadGroupSize = 8;
-
-    inline float PhillipsSpectrum(float kLen, float kDotW, float windSpeed, float patchLength, float spectrumScale)
-    {
-        if (kLen < Math::EPS)
-        {
-            return 0.0f;
-        }
-
-        const float L = (windSpeed * windSpeed) / kGravity;
-        const float damping = 0.001f;
-
-        float phillips = spectrumScale * std::exp(-1.0f / (kLen * kLen * L * L));
-        phillips /= (kLen * kLen * kLen * kLen);
-        phillips *= (kDotW * kDotW);
-        phillips *= std::exp(-kLen * kLen * damping * damping);
-        return std::max(phillips, 0.0f);
-    }
 }
 
-OceanSimulation::OceanSimulation() = default;
+OceanSimulation::OceanSimulation()
+{
+    InitializeDefaultAssets();
+    RefreshDerivedSettings();
+}
+
+void OceanSimulation::InitializeDefaultAssets()
+{
+    defaultSettings_ = OceanSimulationSettings();
+    defaultSettings_.SetResolution(OceanSimulationSettings::ResolutionValue::Eight);
+    defaultSettings_.SetCascadeCount(OceanSimulationSettings::CascadesNumberValue::Four);
+    defaultSettings_.SetAnisotropyLevel(6u);
+    defaultSettings_.SetSimulateFoam(false);
+    defaultSettings_.SetUpdateSpectrum(true);
+    defaultSettings_.SetReadbackMode(OceanSimulationSettings::ReadbackCascadesMode::None);
+    defaultSettings_.SetSamplingIterations(3u);
+    defaultSettings_.SetDomainsMode(OceanSimulationSettings::CascadeDomainsMode::Auto);
+    defaultSettings_.SetSimulationScale(665.91f);
+    defaultSettings_.SetAllowOverlap(true);
+    defaultSettings_.SetMinWavesInCascade(6.0f);
+    defaultSettings_.SetManualLengthScales(Math::float4(858.72f, 167.0f, 30.84f, 5.62f));
+
+    settings_ = defaultSettings_;
+
+    defaultEqualizerPreset_ = std::make_shared<EqualizerPreset>();
+    defaultEqualizerPreset_->SetScaleFilters({
+        { EqualizerPreset::FilterType::Lowshelf, -1.5f, -0.55f, 2.38f }
+    });
+    defaultEqualizerPreset_->SetChopFilters({
+        { EqualizerPreset::FilterType::Bell, 0.0f, 0.4f, 0.77f }
+    });
+
+    defaultSwellPreset_ = std::make_shared<SwellPreset>();
+    SpectrumParams swellSpectrum = defaultSwellPreset_->GetSpectrum();
+    swellSpectrum.energySpectrum = SpectrumParams::EnergySpectrumModel::PM;
+    swellSpectrum.windSpeed = 6.3f;
+    swellSpectrum.fetch = 0.0f;
+    swellSpectrum.peaking = 0.0f;
+    swellSpectrum.scale = 0.016f;
+    swellSpectrum.cutoffWavelength = 1.67f;
+    swellSpectrum.alignment = 1.0f;
+    swellSpectrum.extraAlignment = 1.0f;
+    defaultSwellPreset_->SetSpectrum(swellSpectrum);
+    defaultSwellPreset_->SetReferenceWaveHeight(0.0f);
+
+    defaultLocalPresets_.clear();
+    defaultLocalPresets_.reserve(6);
+
+    const auto makeSpectrum = [](float windSpeed,
+                                 float fetch,
+                                 float peaking,
+                                 float scale,
+                                 float cutoff,
+                                 float alignment,
+                                 float extraAlignment)
+    {
+        SpectrumParams spectrum = SpectrumParams::GetDefaultLocal();
+        spectrum.energySpectrum = SpectrumParams::EnergySpectrumModel::PM;
+        spectrum.windSpeed = windSpeed;
+        spectrum.fetch = fetch;
+        spectrum.peaking = peaking;
+        spectrum.scale = scale;
+        spectrum.cutoffWavelength = cutoff;
+        spectrum.alignment = alignment;
+        spectrum.extraAlignment = extraAlignment;
+        return spectrum;
+    };
+
+    const auto makeFoam = [](float decayRate,
+                             float coverage,
+                             float density,
+                             float sharpness,
+                             float persistence,
+                             float trail,
+                             float trailStrength,
+                             const Math::float2& trailSize,
+                             float underwater,
+                             const Math::float4& cascadesWeights)
+    {
+        FoamParams foam = FoamParams::GetDefault();
+        foam.decayRate = decayRate;
+        foam.coverage = coverage;
+        foam.density = density;
+        foam.sharpness = sharpness;
+        foam.persistence = persistence;
+        foam.trail = trail;
+        foam.trailTextureStrength = trailStrength;
+        foam.trailTextureSize = trailSize;
+        foam.underwater = underwater;
+        foam.cascadesWeights = cascadesWeights;
+        return foam;
+    };
+
+    const auto addLocalPreset = [&](float windForce,
+                                     const SpectrumParams& spectrum,
+                                     float referenceWaveHeight,
+                                     float chop,
+                                     const FoamParams& foam)
+    {
+        auto preset = std::make_shared<LocalWavesPreset>();
+        preset->SetSpectrum(spectrum);
+        preset->SetReferenceWaveHeight(referenceWaveHeight);
+        preset->SetChop(chop);
+        preset->SetFoam(foam);
+        preset->SetEqualizer(defaultEqualizerPreset_);
+        preset->SetWindForce(windForce);
+        defaultLocalPresets_.push_back(preset);
+        return preset;
+    };
+
+    FoamParams calmFoam = FoamParams::GetDefault();
+    calmFoam.cascadesWeights = Math::float4(1.0f, 1.0f, 1.0f, 1.0f);
+
+    defaultLocalPreset_ = addLocalPreset(0.0f,
+        makeSpectrum(1.5f, 100.0f, 3.3f, 0.011f, 0.01f, 0.794f, 0.0f),
+        0.0f,
+        1.0f,
+        calmFoam);
+
+    addLocalPreset(1.0f,
+        makeSpectrum(1.5f, 100.0f, 3.3f, 0.248f, 0.01f, 1.0f, 0.0f),
+        0.0f,
+        1.0f,
+        calmFoam);
+
+    addLocalPreset(2.0f,
+        makeSpectrum(2.5f, 100.0f, 3.3f, 1.0f, 0.01f, 1.0f, 0.0f),
+        0.26f,
+        1.25f,
+        calmFoam);
+
+    addLocalPreset(3.0f,
+        makeSpectrum(4.5f, 100.0f, 3.3f, 1.0f, 0.01f, 1.0f, 0.0f),
+        0.93f,
+        1.41f,
+        makeFoam(0.2f, 0.662f, 13.2f, 1.0f, 0.768f, 0.0f, 0.503f,
+            Math::float2(50.0f, 25.0f), 0.407f, Math::float4(1.0f, 1.0f, 0.5f, 0.3f)));
+
+    addLocalPreset(4.0f,
+        makeSpectrum(7.0f, 100.0f, 3.3f, 1.0f, 0.01f, 1.0f, 0.0f),
+        1.84f,
+        1.44f,
+        makeFoam(0.1f, 0.61f, 19.38f, 0.651f, 0.746f, 0.0f, 0.5f,
+            Math::float2(100.0f, 50.0f), 0.46f, Math::float4(2.0f, 1.0f, 0.3f, 0.2f)));
+
+    addLocalPreset(5.0f,
+        makeSpectrum(9.2f, 100.0f, 3.3f, 1.0f, 0.01f, 1.0f, 0.0f),
+        3.4f,
+        1.49f,
+        makeFoam(0.02f, 0.575f, 13.99f, 0.5f, 0.762f, 0.265f, 0.5f,
+            Math::float2(100.0f, 50.0f), 0.476f, Math::float4(3.0f, 1.0f, 0.3f, 0.2f)));
+
+    inputsProvider_ = OceanSimulationInputsProvider();
+    inputsProvider_.SetMode(OceanSimulationInputsProvider::InputsProviderMode::Scale);
+    inputsProvider_.SetTimeScale(1.0f);
+    inputsProvider_.SetDepth(1000.0f);
+    inputsProvider_.SetSwellPreset(defaultSwellPreset_);
+    inputsProvider_.SetLocalWavesPreset(defaultLocalPreset_);
+    inputsProvider_.SetLocalWavesArray(defaultLocalPresets_);
+    inputsProvider_.SetDefaultEqualizer(defaultEqualizerPreset_);
+
+    windForce01_ = 0.029f;
+    inputsProvider_.SetDisplayWindForce(windForce01_);
+}
+
+void OceanSimulation::SetSettings(const OceanSimulationSettings& settings)
+{
+    settings_ = settings;
+    RefreshDerivedSettings();
+
+    initialized_ = false;
+    h0Data_.clear();
+    waveData_.clear();
+
+    h0Buffer_.Reset();
+    waveDataBuffer_.Reset();
+    displacement_.Reset();
+    descriptorHeap_.Reset();
+    descriptorIncr_ = 0;
+    h0Srv_ = {};
+    waveDataSrv_ = {};
+    displacementSrvs_.clear();
+    displacementUavs_.clear();
+
+    spectrumMaterial_.reset();
+    fftMaterial_.reset();
+    fftPostMaterial_.reset();
+    mipMaterial_.reset();
+
+    mipCount_ = 1u;
+}
+
+void OceanSimulation::SetInputsProvider(const OceanSimulationInputsProvider& provider)
+{
+    inputsProvider_ = provider;
+    inputsProvider_.SetDisplayWindForce(windForce01_);
+    initialized_ = false;
+}
+
+void OceanSimulation::SetSceneVariables(float localWindDirectionDegrees, float swellDirectionDegrees, float windForce01)
+{
+    localWindDirection_ = localWindDirectionDegrees;
+    swellDirection_ = swellDirectionDegrees;
+    windForce01_ = Math::Saturate(windForce01);
+    inputsProvider_.SetDisplayWindForce(windForce01_);
+    initialized_ = false;
+}
+
+void OceanSimulation::RefreshDerivedSettings()
+{
+    resolution_ = settings_.GetResolution();
+    cascadeCount_ = settings_.GetCascadeCount();
+    arraySliceCount_ = cascadeCount_ * 2u;
+
+    lengthScales_ = settings_.ComputeLengthScales();
+    invLengthScales_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+    float* invData = &invLengthScales_.x;
+    float* lengthData = &lengthScales_.x;
+    for (UINT i = 0; i < kClipLevels; ++i)
+    {
+        if (i < cascadeCount_ && lengthData[i] > Math::EPS)
+        {
+            invData[i] = 1.0f / lengthData[i];
+        }
+        else
+        {
+            invData[i] = 0.0f;
+            if (i >= cascadeCount_)
+            {
+                lengthData[i] = 0.0f;
+            }
+        }
+    }
+
+    basePatchLength_ = (cascadeCount_ > 0 && lengthData[0] > Math::EPS) ? lengthData[0] : 0.0f;
+
+    settings_.CalculateCascadeDomains(cutoffsLow_, cutoffsHigh_);
+}
+
+float OceanSimulation::ComputeCascadeContribution(float kLength, UINT cascade) const
+{
+    if (cascade >= cascadeCount_)
+    {
+        return 0.0f;
+    }
+
+    const float* low = &cutoffsLow_.x;
+    const float* high = &cutoffsHigh_.x;
+
+    const float cascadeHigh = high[cascade];
+    const float cascadeLow = low[cascade];
+    if (cascadeHigh <= Math::EPS || kLength > cascadeHigh || kLength < cascadeLow)
+    {
+        return 0.0f;
+    }
+
+    float total = 0.0f;
+    for (UINT i = 0; i < cascadeCount_; ++i)
+    {
+        const float highValue = high[i];
+        if (highValue <= Math::EPS)
+        {
+            continue;
+        }
+
+        if (kLength <= highValue && kLength >= low[i])
+        {
+            total += 1.0f;
+        }
+    }
+
+    if (total <= Math::EPS)
+    {
+        return 0.0f;
+    }
+
+    return 1.0f / total;
+}
 
 uint32_t OceanSimulation::FloatToBits(float value)
 {
@@ -76,7 +336,7 @@ void OceanSimulation::CreateResources(Renderer* renderer,
     ID3D12GraphicsCommandList* uploadCmdList,
     std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive)
 {
-    if (!renderer)
+    if (!renderer || resolution_ == 0 || cascadeCount_ == 0)
     {
         return;
     }
@@ -96,7 +356,7 @@ void OceanSimulation::CreateResources(Renderer* renderer,
     uploader.StealKeepAlive(uploadKeepAlive);
 
     mipCount_ = 1u;
-    UINT size = kResolution;
+    UINT size = std::max<UINT>(1u, resolution_);
     while (size > 1u)
     {
         size = std::max<UINT>(1u, size / 2u);
@@ -111,9 +371,9 @@ void OceanSimulation::CreateResources(Renderer* renderer,
     D3D12_RESOURCE_DESC texDesc{};
     texDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
     texDesc.Alignment = 0;
-    texDesc.Width = kResolution;
-    texDesc.Height = kResolution;
-    texDesc.DepthOrArraySize = kArraySlices;
+    texDesc.Width = resolution_;
+    texDesc.Height = resolution_;
+    texDesc.DepthOrArraySize = static_cast<UINT16>(arraySliceCount_);
     texDesc.MipLevels = static_cast<UINT16>(mipCount_);
     texDesc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
     texDesc.SampleDesc.Count = 1;
@@ -130,7 +390,7 @@ void OceanSimulation::CreateResources(Renderer* renderer,
 
 void OceanSimulation::CreateDescriptors(ID3D12Device* device)
 {
-    if (!device)
+    if (!device || !displacement_ || arraySliceCount_ == 0)
     {
         return;
     }
@@ -185,7 +445,7 @@ void OceanSimulation::CreateDescriptors(ID3D12Device* device)
     texSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
     texSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
     texSrv.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
-    texSrv.Texture2DArray.ArraySize = kArraySlices;
+    texSrv.Texture2DArray.ArraySize = arraySliceCount_;
     texSrv.Texture2DArray.FirstArraySlice = 0;
     texSrv.Texture2DArray.MostDetailedMip = 0;
     texSrv.Texture2DArray.MipLevels = 1;
@@ -201,7 +461,7 @@ void OceanSimulation::CreateDescriptors(ID3D12Device* device)
     D3D12_UNORDERED_ACCESS_VIEW_DESC texUav{};
     texUav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
     texUav.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
-    texUav.Texture2DArray.ArraySize = kArraySlices;
+    texUav.Texture2DArray.ArraySize = arraySliceCount_;
     texUav.Texture2DArray.FirstArraySlice = 0;
     texUav.Texture2DArray.PlaneSlice = 0;
 
@@ -214,7 +474,7 @@ void OceanSimulation::CreateDescriptors(ID3D12Device* device)
 
 void OceanSimulation::CreateMaterials(Renderer* renderer)
 {
-    if (!renderer)
+    if (!renderer || resolution_ == 0)
     {
         return;
     }
@@ -229,8 +489,9 @@ void OceanSimulation::CreateMaterials(Renderer* renderer)
     Material::ComputeDesc fftDesc{};
     fftDesc.shaderFile = L"shaders/ocean_fft.hlsl";
     fftDesc.csEntry = "Fft";
-    fftDesc.defines.emplace_back("FFT_SIZE", std::to_string(kResolution));
-    const uint32_t logSize = static_cast<uint32_t>(std::log2(static_cast<float>(kResolution)));
+    fftDesc.defines.emplace_back("FFT_SIZE", std::to_string(resolution_));
+    const float logSizeFloat = std::log2(static_cast<float>(std::max<UINT>(1u, resolution_)));
+    const uint32_t logSize = static_cast<uint32_t>(std::round(logSizeFloat));
     fftDesc.defines.emplace_back("FFT_LOG_SIZE", std::to_string(logSize));
     fftMaterial_ = materialMgr->GetOrCreateCompute(renderer, fftDesc);
 
@@ -246,79 +507,147 @@ void OceanSimulation::CreateMaterials(Renderer* renderer)
 
 void OceanSimulation::BuildSpectrum()
 {
-    const size_t perCascade = size_t(kResolution) * size_t(kResolution);
-    const size_t total = perCascade * size_t(kCascadeCount);
+    RefreshDerivedSettings();
 
-    h0Data_.resize(total);
-    waveData_.resize(total);
+    inputsProvider_.SetDisplayWindForce(windForce01_);
+    inputsProvider_.PopulateInputs(inputs_, windForce01_);
 
-    std::vector<Math::float2> h0Seed(total);
+    timeScale_ = inputs_.timeScale;
+    waterDepth_ = inputs_.depth;
+    chopValue_ = inputs_.chop;
+    displacementAmplitude_ = inputs_.referenceWaveHeight;
+
+    auto equalizer0 = inputs_.equalizerRamp0 ? inputs_.equalizerRamp0 : EqualizerPreset::CreateDefault();
+    auto equalizer1 = inputs_.equalizerRamp1 ? inputs_.equalizerRamp1 : EqualizerPreset::CreateDefault();
+
+    if (resolution_ == 0 || cascadeCount_ == 0)
+    {
+        h0Data_.clear();
+        waveData_.clear();
+        return;
+    }
+
+    const size_t perCascade = size_t(resolution_) * size_t(resolution_);
+    const size_t total = perCascade * size_t(cascadeCount_);
+
+    h0Data_.assign(total, Math::float4(0.0f, 0.0f, 0.0f, 0.0f));
+    waveData_.assign(total, Math::float4(0.0f, 0.0f, 0.0f, 0.0f));
+
+    std::vector<Math::float2> h0Seed(total, Math::float2(0.0f, 0.0f));
 
     std::mt19937 rng(1337u);
     std::normal_distribution<float> gauss(0.0f, 1.0f);
 
-    const Math::float2 windDirNorm = windDir_.Normalized();
+    const float* lengthData = &lengthScales_.x;
+    const float localWindRad = localWindDirection_ * Math::DEG2RAD;
+    const float swellWindRad = swellDirection_ * Math::DEG2RAD;
+    const SpectrumParams localSpectrum = inputs_.local;
+    const SpectrumParams swellSpectrum = inputs_.swell;
+    const bool hasSwell = swellSpectrum.scale > Math::EPS;
+    const float equalizerRange = std::max(EqualizerPreset::kXMax - EqualizerPreset::kXMin, Math::EPS);
 
-    auto SetComponent = [](Math::float4& v, UINT index, float value)
+    for (UINT cascade = 0; cascade < cascadeCount_; ++cascade)
     {
-        float* data = &v.x;
-        if (index < 4)
+        const float patchLength = lengthData[cascade];
+        if (patchLength <= Math::EPS)
         {
-            data[index] = value;
+            continue;
         }
-    };
 
-    for (UINT cascade = 0; cascade < kCascadeCount; ++cascade)
-    {
-        const float patchLength = basePatchLength_ * std::pow(2.0f, static_cast<float>(cascade));
-        SetComponent(lengthScales_, cascade, patchLength);
-        SetComponent(invLengthScales_, cascade, patchLength > Math::EPS ? (1.0f / patchLength) : 0.0f);
+        const float deltaK = Math::TWO_PI / patchLength;
 
-        const float twoPiOverL = Math::TWO_PI / patchLength;
-        const float lambda = kChoppiness;
-
-        for (UINT y = 0; y < kResolution; ++y)
+        for (UINT y = 0; y < resolution_; ++y)
         {
-            const int iy = static_cast<int>(y) - static_cast<int>(kResolution / 2);
-            for (UINT x = 0; x < kResolution; ++x)
+            const int iy = static_cast<int>(y) - static_cast<int>(resolution_ / 2);
+            for (UINT x = 0; x < resolution_; ++x)
             {
-                const int ix = static_cast<int>(x) - static_cast<int>(kResolution / 2);
-                const size_t idx = size_t(cascade) * perCascade + size_t(y) * size_t(kResolution) + size_t(x);
+                const int ix = static_cast<int>(x) - static_cast<int>(resolution_ / 2);
+                const size_t idx = size_t(cascade) * perCascade + size_t(y) * size_t(resolution_) + size_t(x);
 
-                Math::float2 kVec(float(ix) * twoPiOverL, float(iy) * twoPiOverL);
+                Math::float2 kVec(float(ix) * deltaK, float(iy) * deltaK);
                 const float kLen = std::sqrt(kVec.x * kVec.x + kVec.y * kVec.y);
 
                 if (kLen < Math::EPS)
                 {
-                    h0Seed[idx] = Math::float2(0.0f, 0.0f);
                     waveData_[idx] = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
                     continue;
                 }
 
-                Math::float2 kNorm = kVec / kLen;
-                float kDotW = Math::Clamp(kNorm.Dot(windDirNorm), -1.0f, 1.0f);
-                const float spectrum = PhillipsSpectrum(kLen, kDotW, windSpeed_, patchLength, spectrumScale_);
-                const float sigma = std::sqrt(spectrum) * 0.70710678f;
+                const float contribution = ComputeCascadeContribution(kLen, cascade);
+                if (contribution <= 0.0f)
+                {
+                    waveData_[idx] = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+                    continue;
+                }
 
-                h0Seed[idx] = Math::float2(gauss(rng) * sigma, gauss(rng) * sigma);
+                const float theta = std::atan2(kVec.y, kVec.x);
+                const float omega = OceanSpectrum::Frequency(kLen, waterDepth_);
+                if (omega <= Math::EPS)
+                {
+                    waveData_[idx] = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+                    continue;
+                }
 
-                const float omega = std::sqrt(kGravity * kLen);
+                float spectrum = OceanSpectrum::FullSpectrum(omega, theta - localWindRad, localSpectrum, waterDepth_);
+                spectrum *= localSpectrum.scale;
+                spectrum *= OceanSpectrum::ShortWavesFade(kLen, localSpectrum.cutoffWavelength);
+
+                if (hasSwell)
+                {
+                    float swellValue = OceanSpectrum::FullSpectrum(omega, theta - swellWindRad, swellSpectrum, waterDepth_);
+                    swellValue *= swellSpectrum.scale;
+                    swellValue *= OceanSpectrum::ShortWavesFade(kLen, swellSpectrum.cutoffWavelength);
+                    spectrum += swellValue;
+                }
+
+                if (spectrum <= 0.0f)
+                {
+                    waveData_[idx] = Math::float4(kVec.x, 0.0f, kVec.y, 0.0f);
+                    continue;
+                }
+
+                const float dOmegadk = OceanSpectrum::FrequencyDerivative(kLen, waterDepth_);
+                const float spectralFactor = std::max(0.0f, 2.0f * spectrum * std::abs(dOmegadk) / kLen);
+                if (spectralFactor <= Math::EPS)
+                {
+                    waveData_[idx] = Math::float4(kVec.x, 0.0f, kVec.y, 0.0f);
+                    continue;
+                }
+
+                const float logTerm = std::log10(Math::TWO_PI / kLen);
+                float rampU = (logTerm - EqualizerPreset::kXMin) / equalizerRange;
+                rampU = Math::Saturate(rampU);
+                const Math::float2 eq0Sample = equalizer0->Sample(rampU);
+                const Math::float2 eq1Sample = equalizer1->Sample(rampU);
+                const Math::float2 eqSample = Math::float2::Lerp(eq0Sample, eq1Sample, inputs_.equalizerLerpValue);
+
+                const float scaleRamp = eqSample.x;
+                const float lambda = chopValue_ * eqSample.y;
+
+                const float amplitude = contribution * scaleRamp * std::sqrt(spectralFactor) * deltaK;
+                if (amplitude <= Math::EPS)
+                {
+                    waveData_[idx] = Math::float4(kVec.x, 0.0f, kVec.y, omega);
+                    continue;
+                }
+
+                h0Seed[idx] = Math::float2(gauss(rng) * amplitude, gauss(rng) * amplitude);
                 waveData_[idx] = Math::float4(kVec.x, lambda, kVec.y, omega);
             }
         }
     }
 
-    for (UINT cascade = 0; cascade < kCascadeCount; ++cascade)
+    for (UINT cascade = 0; cascade < cascadeCount_; ++cascade)
     {
-        for (UINT y = 0; y < kResolution; ++y)
+        for (UINT y = 0; y < resolution_; ++y)
         {
-            for (UINT x = 0; x < kResolution; ++x)
+            for (UINT x = 0; x < resolution_; ++x)
             {
-                const size_t idx = size_t(cascade) * perCascade + size_t(y) * size_t(kResolution) + size_t(x);
+                const size_t idx = size_t(cascade) * perCascade + size_t(y) * size_t(resolution_) + size_t(x);
 
-                const UINT negX = (kResolution - x) % kResolution;
-                const UINT negY = (kResolution - y) % kResolution;
-                const size_t negIdx = size_t(cascade) * perCascade + size_t(negY) * size_t(kResolution) + size_t(negX);
+                const UINT negX = (resolution_ - x) % resolution_;
+                const UINT negY = (resolution_ - y) % resolution_;
+                const size_t negIdx = size_t(cascade) * perCascade + size_t(negY) * size_t(resolution_) + size_t(negX);
 
                 const Math::float2 h0 = h0Seed[idx];
                 const Math::float2 h0Neg = h0Seed[negIdx];
@@ -355,7 +684,7 @@ void OceanSimulation::Update(Renderer* renderer, ID3D12GraphicsCommandList* cl, 
 
 void OceanSimulation::DispatchSpectrum(Renderer* renderer, ID3D12GraphicsCommandList* cl, float timeSeconds)
 {
-    if (!spectrumMaterial_)
+    if (!spectrumMaterial_ || resolution_ == 0 || cascadeCount_ == 0)
     {
         return;
     }
@@ -366,10 +695,10 @@ void OceanSimulation::DispatchSpectrum(Renderer* renderer, ID3D12GraphicsCommand
     auto& ctx = ctxHandle.ref();
 
     ctx.constants[0] = {
-        kResolution,
-        kCascadeCount,
+        resolution_,
+        cascadeCount_,
         FloatToBits(timeSeconds),
-        kResolution * kResolution
+        resolution_ * resolution_
     };
 
     auto srvTable = renderer->StageSrvUavTable({ h0Srv_, waveDataSrv_ });
@@ -380,15 +709,15 @@ void OceanSimulation::DispatchSpectrum(Renderer* renderer, ID3D12GraphicsCommand
 
     spectrumMaterial_->Bind(cl, ctx);
 
-    const UINT groups = (kResolution + kThreadGroupSize - 1u) / kThreadGroupSize;
-    cl->Dispatch(groups, groups, kCascadeCount);
+    const UINT groups = (resolution_ + kThreadGroupSize - 1u) / kThreadGroupSize;
+    cl->Dispatch(groups, groups, cascadeCount_);
 
     renderer->UAVBarrier(cl, displacement_.Get());
 }
 
 void OceanSimulation::DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList* cl)
 {
-    if (!fftMaterial_)
+    if (!fftMaterial_ || arraySliceCount_ == 0 || resolution_ == 0)
     {
         return;
     }
@@ -401,14 +730,14 @@ void OceanSimulation::DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList*
         auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
         auto& ctx = ctxHandle.ref();
         ctx.constants[0] = {
-            kArraySlices,
+            arraySliceCount_,
             0u,
             1u,
             0u,
         };
         ctx.table[1] = uavTable.gpu;
         fftMaterial_->Bind(cl, ctx);
-        cl->Dispatch(1, kResolution, 1);
+        cl->Dispatch(1, resolution_, 1);
     }
 
     renderer->UAVBarrier(cl, displacement_.Get());
@@ -417,14 +746,14 @@ void OceanSimulation::DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList*
         auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
         auto& ctx = ctxHandle.ref();
         ctx.constants[0] = {
-            kArraySlices,
+            arraySliceCount_,
             1u,
             1u,
             0u,
         };
         ctx.table[1] = uavTable.gpu;
         fftMaterial_->Bind(cl, ctx);
-        cl->Dispatch(1, kResolution, 1);
+        cl->Dispatch(1, resolution_, 1);
     }
 
     renderer->UAVBarrier(cl, displacement_.Get());
@@ -432,7 +761,7 @@ void OceanSimulation::DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList*
 
 void OceanSimulation::DispatchFFTPost(Renderer* renderer, ID3D12GraphicsCommandList* cl)
 {
-    if (!fftPostMaterial_)
+    if (!fftPostMaterial_ || arraySliceCount_ == 0 || resolution_ == 0)
     {
         return;
     }
@@ -444,7 +773,7 @@ void OceanSimulation::DispatchFFTPost(Renderer* renderer, ID3D12GraphicsCommandL
     auto ctxHandle = renderer->GetRenderContextPool()->Acquire();
     auto& ctx = ctxHandle.ref();
     ctx.constants[0] = {
-        kArraySlices,
+        arraySliceCount_,
         1u,
         1u,
         0u,
@@ -453,7 +782,7 @@ void OceanSimulation::DispatchFFTPost(Renderer* renderer, ID3D12GraphicsCommandL
 
     fftPostMaterial_->Bind(cl, ctx);
 
-    const UINT groups = (kResolution + kThreadGroupSize - 1u) / kThreadGroupSize;
+    const UINT groups = (resolution_ + kThreadGroupSize - 1u) / kThreadGroupSize;
     cl->Dispatch(groups, groups, 1);
 
     renderer->UAVBarrier(cl, displacement_.Get());
@@ -461,15 +790,15 @@ void OceanSimulation::DispatchFFTPost(Renderer* renderer, ID3D12GraphicsCommandL
 
 void OceanSimulation::GenerateMips(Renderer* renderer, ID3D12GraphicsCommandList* cl)
 {
-    if (!mipMaterial_ || mipCount_ <= 1)
+    if (!mipMaterial_ || mipCount_ <= 1 || arraySliceCount_ == 0 || resolution_ == 0)
     {
         return;
     }
 
     renderer->Transition(cl, displacement_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
-    UINT srcWidth = kResolution;
-    UINT srcHeight = kResolution;
+    UINT srcWidth = resolution_;
+    UINT srcHeight = resolution_;
 
     for (UINT mip = 1; mip < mipCount_; ++mip)
     {
@@ -484,7 +813,7 @@ void OceanSimulation::GenerateMips(Renderer* renderer, ID3D12GraphicsCommandList
             srcHeight,
             dstWidth,
             dstHeight,
-            kArraySlices,
+            arraySliceCount_,
             mip,
             0u,
             0u
@@ -500,7 +829,7 @@ void OceanSimulation::GenerateMips(Renderer* renderer, ID3D12GraphicsCommandList
 
         const UINT groupsX = (dstWidth + kThreadGroupSize - 1u) / kThreadGroupSize;
         const UINT groupsY = (dstHeight + kThreadGroupSize - 1u) / kThreadGroupSize;
-        cl->Dispatch(groupsX, groupsY, kArraySlices);
+        cl->Dispatch(groupsX, groupsY, arraySliceCount_);
 
         renderer->UAVBarrier(cl, displacement_.Get());
 

--- a/OceanSimulation.h
+++ b/OceanSimulation.h
@@ -9,6 +9,8 @@
 #include <wrl/client.h>
 
 #include "Math.h"
+#include "OceanSimulationInputs.h"
+#include "OceanSimulationSettings.h"
 
 class Renderer;
 class Material;
@@ -16,10 +18,7 @@ class Material;
 class OceanSimulation
 {
 public:
-    static constexpr UINT kResolution = 256;
-    static constexpr UINT kCascadeCount = 4;
-    static constexpr UINT kClipLevels = kCascadeCount;
-    static constexpr UINT kArraySlices = kCascadeCount * 2;
+    static constexpr UINT kClipLevels = 4;
 
     OceanSimulation();
     ~OceanSimulation() = default;
@@ -30,6 +29,17 @@ public:
 
     void Update(Renderer* renderer, ID3D12GraphicsCommandList* cl, float timeSeconds);
     void OnHotReload(Renderer* renderer);
+
+    void SetSettings(const OceanSimulationSettings& settings);
+    void SetInputsProvider(const OceanSimulationInputsProvider& provider);
+    OceanSimulationInputsProvider& GetInputsProvider() { return inputsProvider_; }
+    const OceanSimulationInputsProvider& GetInputsProvider() const { return inputsProvider_; }
+
+    void SetSceneVariables(float localWindDirectionDegrees, float swellDirectionDegrees, float windForce01);
+    const OceanSimulationSettings& GetSettings() const { return settings_; }
+
+    UINT GetResolution() const { return resolution_; }
+    UINT GetCascadeCount() const { return cascadeCount_; }
 
     float GetPatchLength() const { return basePatchLength_; }
     const Math::float4& GetLengthScales() const { return lengthScales_; }
@@ -50,21 +60,42 @@ private:
     void DispatchFFT(Renderer* renderer, ID3D12GraphicsCommandList* cl);
     void DispatchFFTPost(Renderer* renderer, ID3D12GraphicsCommandList* cl);
     void GenerateMips(Renderer* renderer, ID3D12GraphicsCommandList* cl);
+    void RefreshDerivedSettings();
+    float ComputeCascadeContribution(float kLength, UINT cascade) const;
+    void InitializeDefaultAssets();
 
     static uint32_t FloatToBits(float value);
 
 private:
     bool initialized_ = false;
 
-    float basePatchLength_ = 200.0f;
-    float windSpeed_ = 12.0f;
-    Math::float2 windDir_ = Math::float2(1.0f, 0.0f);
-    float spectrumScale_ = 3.0e-3f;
+    OceanSimulationSettings defaultSettings_;
+    OceanSimulationSettings settings_;
+    float basePatchLength_ = 0.0f;
     float displacementAmplitude_ = 1.5f;
     float timeScale_ = 1.0f;
+    float localWindDirection_ = 0.0f;
+    float swellDirection_ = 0.0f;
+    float windForce01_ = 0.0f;
+    float waterDepth_ = 1000.0f;
+    float chopValue_ = 1.0f;
+
+    std::shared_ptr<EqualizerPreset> defaultEqualizerPreset_;
+    std::shared_ptr<SwellPreset> defaultSwellPreset_;
+    std::shared_ptr<LocalWavesPreset> defaultLocalPreset_;
+    std::vector<std::shared_ptr<LocalWavesPreset>> defaultLocalPresets_;
+
+    OceanSimulationInputsProvider inputsProvider_;
+    OceanSimulationInputs inputs_;
 
     Math::float4 lengthScales_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
     Math::float4 invLengthScales_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+    Math::float4 cutoffsLow_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+    Math::float4 cutoffsHigh_ = Math::float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+    UINT resolution_ = 0;
+    UINT cascadeCount_ = 0;
+    UINT arraySliceCount_ = 0;
 
     std::vector<Math::float4> h0Data_;
     std::vector<Math::float4> waveData_;

--- a/OceanSimulationInputs.cpp
+++ b/OceanSimulationInputs.cpp
@@ -1,0 +1,336 @@
+#include "OceanSimulationInputs.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+    inline float InverseLerp(float a, float b, float value)
+    {
+        if (std::abs(b - a) < Math::EPS)
+        {
+            return 0.0f;
+        }
+        return Math::Saturate((value - a) / (b - a));
+    }
+}
+
+FoamParams FoamParams::GetDefault()
+{
+    return FoamParams();
+}
+
+FoamParams FoamParams::Lerp(const FoamParams& lhs, const FoamParams& rhs, float t)
+{
+    FoamParams result;
+    result.decayRate = Math::Lerp(lhs.decayRate, rhs.decayRate, t);
+    result.coverage = Math::Lerp(lhs.coverage, rhs.coverage, t);
+    result.density = Math::Lerp(lhs.density, rhs.density, t);
+    result.sharpness = Math::Lerp(lhs.sharpness, rhs.sharpness, t);
+    result.persistence = Math::Lerp(lhs.persistence, rhs.persistence, t);
+    result.trail = Math::Lerp(lhs.trail, rhs.trail, t);
+    result.trailTextureStrength = Math::Lerp(lhs.trailTextureStrength, rhs.trailTextureStrength, t);
+    result.trailTextureSize = Math::float2(
+        Math::Lerp(lhs.trailTextureSize.x, rhs.trailTextureSize.x, t),
+        Math::Lerp(lhs.trailTextureSize.y, rhs.trailTextureSize.y, t));
+    result.underwater = Math::Lerp(lhs.underwater, rhs.underwater, t);
+    result.cascadesWeights = Math::float4(
+        Math::Lerp(lhs.cascadesWeights.x, rhs.cascadesWeights.x, t),
+        Math::Lerp(lhs.cascadesWeights.y, rhs.cascadesWeights.y, t),
+        Math::Lerp(lhs.cascadesWeights.z, rhs.cascadesWeights.z, t),
+        Math::Lerp(lhs.cascadesWeights.w, rhs.cascadesWeights.w, t));
+    return result;
+}
+
+SpectrumParams SpectrumParams::Lerp(const SpectrumParams& lhs, const SpectrumParams& rhs, float t)
+{
+    SpectrumParams result;
+    result.energySpectrum = (t < 0.5f) ? lhs.energySpectrum : rhs.energySpectrum;
+    result.windSpeed = Math::Lerp(lhs.windSpeed, rhs.windSpeed, t);
+    result.fetch = Math::Lerp(lhs.fetch, rhs.fetch, t);
+    result.peaking = Math::Lerp(lhs.peaking, rhs.peaking, t);
+    result.scale = Math::Lerp(lhs.scale, rhs.scale, t);
+    result.cutoffWavelength = Math::Lerp(lhs.cutoffWavelength, rhs.cutoffWavelength, t);
+    result.alignment = Math::Lerp(lhs.alignment, rhs.alignment, t);
+    result.extraAlignment = Math::Lerp(lhs.extraAlignment, rhs.extraAlignment, t);
+    return result;
+}
+
+SpectrumParams SpectrumParams::GetDefaultLocal()
+{
+    SpectrumParams s;
+    s.energySpectrum = EnergySpectrumModel::PM;
+    s.windSpeed = 5.0f;
+    s.fetch = 100.0f;
+    s.peaking = 3.3f;
+    s.scale = 1.0f;
+    s.cutoffWavelength = 0.01f;
+    s.alignment = 1.0f;
+    s.extraAlignment = 0.0f;
+    return s;
+}
+
+SpectrumParams SpectrumParams::GetDefaultSwell()
+{
+    SpectrumParams s;
+    s.energySpectrum = EnergySpectrumModel::JONSWAP;
+    s.windSpeed = 10.0f;
+    s.fetch = 100.0f;
+    s.peaking = 10.0f;
+    s.scale = 0.0f;
+    s.cutoffWavelength = 1.0f;
+    s.alignment = 1.0f;
+    s.extraAlignment = 0.8f;
+    return s;
+}
+
+EqualizerPreset::EqualizerPreset() = default;
+
+EqualizerPreset::EqualizerPreset(std::vector<Filter> scaleFilters, std::vector<Filter> chopFilters)
+    : scaleFilters_(std::move(scaleFilters))
+    , chopFilters_(std::move(chopFilters))
+{
+}
+
+Math::float2 EqualizerPreset::Sample(float normalizedU) const
+{
+    const float u = Math::Saturate(normalizedU);
+    const float x = Math::Lerp(kXMin, kXMax, u);
+    const float scale = EvaluateFilters(scaleFilters_, x);
+    const float chop = EvaluateFilters(chopFilters_, x);
+    return Math::float2(scale, chop);
+}
+
+void EqualizerPreset::SetScaleFilters(std::vector<Filter> filters)
+{
+    scaleFilters_ = std::move(filters);
+}
+
+void EqualizerPreset::SetChopFilters(std::vector<Filter> filters)
+{
+    chopFilters_ = std::move(filters);
+}
+
+std::shared_ptr<EqualizerPreset> EqualizerPreset::CreateDefault()
+{
+    return std::make_shared<EqualizerPreset>();
+}
+
+float EqualizerPreset::EvaluateFilters(const std::vector<Filter>& filters, float x)
+{
+    if (filters.empty())
+    {
+        return 1.0f;
+    }
+
+    float value = 1.0f;
+    for (const Filter& filter : filters)
+    {
+        const float width = std::max(kMinWidth, filter.width);
+        float arg = 0.0f;
+        switch (filter.type)
+        {
+        case FilterType::Bell:
+            arg = (x - filter.center);
+            value += filter.value * std::exp(-arg * arg / (width * width));
+            break;
+        case FilterType::Highshelf:
+            arg = std::min(x - filter.center, 0.0f);
+            value += filter.value * std::exp(-arg * arg / (width * width));
+            break;
+        case FilterType::Lowshelf:
+            arg = std::max(x - filter.center, 0.0f);
+            value += filter.value * std::exp(-arg * arg / (width * width));
+            break;
+        default:
+            break;
+        }
+    }
+
+    return std::max(0.0f, value);
+}
+
+SwellPreset::SwellPreset()
+    : spectrum_(SpectrumParams::GetDefaultSwell())
+    , referenceWaveHeight_(0.0f)
+{
+}
+
+LocalWavesPreset::LocalWavesPreset()
+    : spectrum_(SpectrumParams::GetDefaultLocal())
+    , foam_(FoamParams::GetDefault())
+    , equalizer_(EqualizerPreset::CreateDefault())
+    , referenceWaveHeight_(1.0f)
+    , chop_(1.0f)
+    , windForce_(0.0f)
+{
+}
+
+OceanSimulationInputsProvider::OceanSimulationInputsProvider()
+    : swell_(std::make_shared<SwellPreset>())
+    , localPreset_(std::make_shared<LocalWavesPreset>())
+    , defaultEqualizer_(EqualizerPreset::CreateDefault())
+{
+    UpdateMaxWindForce();
+}
+
+void OceanSimulationInputsProvider::SetDisplayWindForce(float value)
+{
+    displayWindForce01_ = Math::Saturate(value);
+}
+
+void OceanSimulationInputsProvider::SetSwellPreset(const std::shared_ptr<SwellPreset>& swell)
+{
+    swell_ = swell ? swell : std::make_shared<SwellPreset>();
+}
+
+void OceanSimulationInputsProvider::SetLocalWavesPreset(const std::shared_ptr<LocalWavesPreset>& preset)
+{
+    localPreset_ = preset ? preset : std::make_shared<LocalWavesPreset>();
+}
+
+void OceanSimulationInputsProvider::SetLocalWavesArray(const std::vector<std::shared_ptr<LocalWavesPreset>>& presets)
+{
+    localPresets_ = presets;
+    UpdateMaxWindForce();
+}
+
+void OceanSimulationInputsProvider::SetDefaultEqualizer(const std::shared_ptr<EqualizerPreset>& preset)
+{
+    defaultEqualizer_ = preset ? preset : EqualizerPreset::CreateDefault();
+}
+
+void OceanSimulationInputsProvider::PopulateInputs(OceanSimulationInputs& target) const
+{
+    PopulateInputs(target, displayWindForce01_);
+}
+
+void OceanSimulationInputsProvider::PopulateInputs(OceanSimulationInputs& target, float windForce01) const
+{
+    windForce01 = displayWindForce01_;
+
+    target.timeScale = timeScale_;
+    target.depth = depth_;
+
+    float referenceWaveHeight = 0.0f;
+    if (swell_)
+    {
+        target.swell = swell_->GetSpectrum();
+        referenceWaveHeight += swell_->GetReferenceWaveHeight();
+    }
+    else
+    {
+        target.swell = SpectrumParams::GetDefaultSwell();
+    }
+
+    if (mode_ == InputsProviderMode::Fixed || localPresets_.size() < 2)
+    {
+        target.foamTrailUpdateTime = 0.0f;
+        if (localPreset_)
+        {
+            ApplyPreset(target, *localPreset_);
+            referenceWaveHeight += localPreset_->GetReferenceWaveHeight();
+        }
+    }
+    else
+    {
+        target.foamTrailUpdateTime = 1.0f;
+        const LerpVars lerp = GetLerpVars(windForce01, maxWindForce_, localPresets_);
+        if (lerp.start && lerp.end)
+        {
+            ApplyPreset(target, *lerp.start, *lerp.end, lerp.t);
+            referenceWaveHeight += Math::Lerp(lerp.start->GetReferenceWaveHeight(),
+                lerp.end->GetReferenceWaveHeight(), lerp.t);
+        }
+    }
+
+    target.referenceWaveHeight = referenceWaveHeight;
+}
+
+OceanSimulationInputsProvider::LerpVars OceanSimulationInputsProvider::GetLerpVars(float windForce01,
+    float maxWindForce,
+    const std::vector<std::shared_ptr<LocalWavesPreset>>& presets)
+{
+    LerpVars result;
+    if (presets.size() < 2)
+    {
+        return result;
+    }
+
+    const float windForce = Math::Saturate(windForce01) * maxWindForce;
+    size_t index = 0;
+    for (; index < presets.size(); ++index)
+    {
+        if (presets[index] && windForce < presets[index]->GetWindForce())
+        {
+            break;
+        }
+    }
+
+    if (index == 0)
+    {
+        return result;
+    }
+
+    if (index >= presets.size())
+    {
+        index = presets.size() - 1;
+    }
+
+    const LocalWavesPreset* prev = presets[index - 1].get();
+    const LocalWavesPreset* next = presets[index].get();
+    if (!prev || !next)
+    {
+        return result;
+    }
+
+    result.start = prev;
+    result.end = next;
+    result.t = InverseLerp(prev->GetWindForce(), next->GetWindForce(), windForce);
+    return result;
+}
+
+void OceanSimulationInputsProvider::ApplyPreset(OceanSimulationInputs& target, const LocalWavesPreset& preset) const
+{
+    target.chop = preset.GetChop();
+    target.local = preset.GetSpectrum();
+    target.foam = preset.GetFoam();
+    target.equalizerLerpValue = 0.0f;
+    target.equalizerRamp0 = GetSafeEqualizer(preset.GetEqualizer());
+    target.equalizerRamp1 = GetSafeEqualizer(nullptr);
+}
+
+void OceanSimulationInputsProvider::ApplyPreset(OceanSimulationInputs& target,
+    const LocalWavesPreset& start,
+    const LocalWavesPreset& end,
+    float t) const
+{
+    target.chop = Math::Lerp(start.GetChop(), end.GetChop(), t);
+    target.local = SpectrumParams::Lerp(start.GetSpectrum(), end.GetSpectrum(), t);
+    target.foam = FoamParams::Lerp(start.GetFoam(), end.GetFoam(), t);
+    target.equalizerLerpValue = t;
+    target.equalizerRamp0 = GetSafeEqualizer(start.GetEqualizer());
+    target.equalizerRamp1 = GetSafeEqualizer(end.GetEqualizer());
+}
+
+std::shared_ptr<EqualizerPreset> OceanSimulationInputsProvider::GetSafeEqualizer(const std::shared_ptr<EqualizerPreset>& preset) const
+{
+    if (preset)
+    {
+        return preset;
+    }
+    return defaultEqualizer_ ? defaultEqualizer_ : EqualizerPreset::CreateDefault();
+}
+
+void OceanSimulationInputsProvider::UpdateMaxWindForce()
+{
+    maxWindForce_ = 0.0f;
+    for (const auto& preset : localPresets_)
+    {
+        if (preset)
+        {
+            maxWindForce_ = std::max(maxWindForce_, preset->GetWindForce());
+        }
+    }
+}
+

--- a/OceanSimulationInputs.h
+++ b/OceanSimulationInputs.h
@@ -1,0 +1,205 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "Math.h"
+
+class EqualizerPreset;
+class LocalWavesPreset;
+class SwellPreset;
+
+struct FoamParams
+{
+    float decayRate = 0.02f;
+    float coverage = 0.0f;
+    float density = 8.4f;
+    float sharpness = 0.5f;
+    float persistence = 0.5f;
+    float trail = 0.0f;
+    float trailTextureStrength = 0.5f;
+    Math::float2 trailTextureSize = Math::float2(100.0f, 50.0f);
+    float underwater = 0.0f;
+    Math::float4 cascadesWeights = Math::float4(1.0f, 1.0f, 1.0f, 1.0f);
+
+    static FoamParams GetDefault();
+    static FoamParams Lerp(const FoamParams& lhs, const FoamParams& rhs, float t);
+};
+
+struct SpectrumParams
+{
+    enum class EnergySpectrumModel
+    {
+        PM,
+        JONSWAP,
+        TMA
+    };
+
+    EnergySpectrumModel energySpectrum = EnergySpectrumModel::PM;
+    float windSpeed = 5.0f;
+    float fetch = 100.0f;
+    float peaking = 3.3f;
+    float scale = 1.0f;
+    float cutoffWavelength = 0.01f;
+    float alignment = 1.0f;
+    float extraAlignment = 0.0f;
+
+    static SpectrumParams Lerp(const SpectrumParams& lhs, const SpectrumParams& rhs, float t);
+    static SpectrumParams GetDefaultLocal();
+    static SpectrumParams GetDefaultSwell();
+};
+
+class EqualizerPreset
+{
+public:
+    enum class FilterType
+    {
+        Bell,
+        Highshelf,
+        Lowshelf
+    };
+
+    struct Filter
+    {
+        FilterType type = FilterType::Bell;
+        float center = 0.0f;
+        float value = 0.0f;
+        float width = 0.5f;
+    };
+
+    static constexpr float kXMin = -1.5f;
+    static constexpr float kXMax = 3.5f;
+    static constexpr float kMinWidth = 0.1f;
+
+    EqualizerPreset();
+    EqualizerPreset(std::vector<Filter> scaleFilters, std::vector<Filter> chopFilters);
+
+    Math::float2 Sample(float normalizedU) const;
+
+    void SetScaleFilters(std::vector<Filter> filters);
+    void SetChopFilters(std::vector<Filter> filters);
+
+    static std::shared_ptr<EqualizerPreset> CreateDefault();
+
+private:
+    static float EvaluateFilters(const std::vector<Filter>& filters, float x);
+
+private:
+    std::vector<Filter> scaleFilters_;
+    std::vector<Filter> chopFilters_;
+};
+
+class SwellPreset
+{
+public:
+    SwellPreset();
+
+    void SetSpectrum(const SpectrumParams& spectrum) { spectrum_ = spectrum; }
+    void SetReferenceWaveHeight(float value) { referenceWaveHeight_ = value; }
+
+    const SpectrumParams& GetSpectrum() const { return spectrum_; }
+    float GetReferenceWaveHeight() const { return referenceWaveHeight_; }
+
+private:
+    SpectrumParams spectrum_;
+    float referenceWaveHeight_ = 0.0f;
+};
+
+class LocalWavesPreset
+{
+public:
+    LocalWavesPreset();
+
+    void SetSpectrum(const SpectrumParams& spectrum) { spectrum_ = spectrum; }
+    void SetReferenceWaveHeight(float value) { referenceWaveHeight_ = value; }
+    void SetChop(float value) { chop_ = value; }
+    void SetFoam(const FoamParams& foam) { foam_ = foam; }
+    void SetEqualizer(const std::shared_ptr<EqualizerPreset>& equalizer) { equalizer_ = equalizer; }
+    void SetWindForce(float value) { windForce_ = value; }
+
+    float GetWindForce() const { return windForce_; }
+    float GetReferenceWaveHeight() const { return referenceWaveHeight_; }
+    const SpectrumParams& GetSpectrum() const { return spectrum_; }
+    const FoamParams& GetFoam() const { return foam_; }
+    float GetChop() const { return chop_; }
+    std::shared_ptr<EqualizerPreset> GetEqualizer() const { return equalizer_; }
+
+private:
+    SpectrumParams spectrum_;
+    FoamParams foam_;
+    std::shared_ptr<EqualizerPreset> equalizer_;
+    float referenceWaveHeight_ = 1.0f;
+    float chop_ = 1.0f;
+    float windForce_ = 0.0f;
+};
+
+struct OceanSimulationInputs
+{
+    float timeScale = 1.0f;
+    float depth = 1000.0f;
+    float chop = 1.0f;
+    FoamParams foam = FoamParams::GetDefault();
+    SpectrumParams local = SpectrumParams::GetDefaultLocal();
+    SpectrumParams swell = SpectrumParams::GetDefaultSwell();
+    std::shared_ptr<EqualizerPreset> equalizerRamp0 = EqualizerPreset::CreateDefault();
+    std::shared_ptr<EqualizerPreset> equalizerRamp1 = EqualizerPreset::CreateDefault();
+    float equalizerLerpValue = 0.0f;
+    float foamTrailUpdateTime = 0.0f;
+    float referenceWaveHeight = 0.0f;
+};
+
+class OceanSimulationInputsProvider
+{
+public:
+    enum class InputsProviderMode
+    {
+        Fixed,
+        Scale
+    };
+
+    OceanSimulationInputsProvider();
+
+    void SetMode(InputsProviderMode mode) { mode_ = mode; }
+    void SetTimeScale(float value) { timeScale_ = value; }
+    void SetDepth(float value) { depth_ = value; }
+    void SetDisplayWindForce(float value);
+    void SetSwellPreset(const std::shared_ptr<SwellPreset>& swell);
+    void SetLocalWavesPreset(const std::shared_ptr<LocalWavesPreset>& preset);
+    void SetLocalWavesArray(const std::vector<std::shared_ptr<LocalWavesPreset>>& presets);
+    void SetDefaultEqualizer(const std::shared_ptr<EqualizerPreset>& preset);
+
+    void PopulateInputs(OceanSimulationInputs& target) const;
+    void PopulateInputs(OceanSimulationInputs& target, float windForce01) const;
+
+private:
+    struct LerpVars
+    {
+        const LocalWavesPreset* start = nullptr;
+        const LocalWavesPreset* end = nullptr;
+        float t = 0.0f;
+    };
+
+    static LerpVars GetLerpVars(float windForce01, float maxWindForce,
+        const std::vector<std::shared_ptr<LocalWavesPreset>>& presets);
+
+    void ApplyPreset(OceanSimulationInputs& target, const LocalWavesPreset& preset) const;
+    void ApplyPreset(OceanSimulationInputs& target,
+        const LocalWavesPreset& start,
+        const LocalWavesPreset& end,
+        float t) const;
+    std::shared_ptr<EqualizerPreset> GetSafeEqualizer(const std::shared_ptr<EqualizerPreset>& preset) const;
+
+    void UpdateMaxWindForce();
+
+private:
+    InputsProviderMode mode_ = InputsProviderMode::Fixed;
+    float timeScale_ = 1.0f;
+    float depth_ = 1000.0f;
+    float displayWindForce01_ = 0.0f;
+    std::shared_ptr<SwellPreset> swell_;
+    std::shared_ptr<LocalWavesPreset> localPreset_;
+    std::vector<std::shared_ptr<LocalWavesPreset>> localPresets_;
+    float maxWindForce_ = 0.0f;
+    std::shared_ptr<EqualizerPreset> defaultEqualizer_;
+};
+

--- a/OceanSimulationSettings.cpp
+++ b/OceanSimulationSettings.cpp
@@ -1,0 +1,114 @@
+#include "OceanSimulationSettings.h"
+
+#include <algorithm>
+#include <array>
+
+OceanSimulationSettings::OceanSimulationSettings()
+    : resolution_(ResolutionValue::Eight)
+    , cascadesNumber_(CascadesNumberValue::Four)
+    , anisoLevel_(6)
+    , simulateFoam_(false)
+    , updateSpectrum_(false)
+    , readbackCascades_(ReadbackCascadesMode::None)
+    , samplingIterations_(3)
+    , domainsMode_(CascadeDomainsMode::Auto)
+    , simulationScale_(200.0f)
+    , allowOverlap_(false)
+    , minWavesInCascade_(6.0f)
+    , manualScales_(Math::float4(0.0f, 0.0f, 0.0f, 0.0f))
+{
+}
+
+Math::float4 OceanSimulationSettings::ComputeLengthScales() const
+{
+    Math::float4 lengthScales(0.0f, 0.0f, 0.0f, 0.0f);
+    float* data = &lengthScales.x;
+
+    if (domainsMode_ == CascadeDomainsMode::Auto)
+    {
+        if (simulationScale_ <= Math::EPS || GetResolution() == 0)
+        {
+            return lengthScales;
+        }
+
+        data[0] = simulationScale_;
+        const float multiplier = kSmallestWaveMultiplierAuto * kMinWavesInCascadeAuto / static_cast<float>(GetResolution());
+        for (int i = 1; i < 4; ++i)
+        {
+            data[i] = data[i - 1] * multiplier;
+        }
+    }
+    else
+    {
+        data[0] = manualScales_.x;
+        data[1] = manualScales_.y;
+        data[2] = manualScales_.z;
+        data[3] = manualScales_.w;
+    }
+
+    return lengthScales;
+}
+
+void OceanSimulationSettings::CalculateCascadeDomains(Math::float4& cutoffsLow, Math::float4& cutoffsHigh) const
+{
+    Math::float4 lengthScales = ComputeLengthScales();
+
+    if (domainsMode_ == CascadeDomainsMode::Auto)
+    {
+        CalculateCascadeDomainsManual(lengthScales, false, kMinWavesInCascadeAuto, cutoffsLow, cutoffsHigh);
+    }
+    else
+    {
+        CalculateCascadeDomainsManual(lengthScales, allowOverlap_, minWavesInCascade_, cutoffsLow, cutoffsHigh);
+    }
+}
+
+void OceanSimulationSettings::CalculateCascadeDomainsManual(const Math::float4& lengthScales,
+    bool allowOverlap,
+    float minWavesInCascade,
+    Math::float4& cutoffsLow,
+    Math::float4& cutoffsHigh) const
+{
+    std::array<float, 4> lows{};
+    std::array<float, 4> highs{};
+
+    const float* scale = &lengthScales.x;
+    const uint32_t resolution = GetResolution();
+    const uint32_t cascadeCount = GetCascadeCount();
+
+    for (uint32_t i = 0; i < 4; ++i)
+    {
+        const float length = scale[i];
+        if (length <= Math::EPS)
+        {
+            lows[i] = 0.0f;
+            highs[i] = 0.0f;
+            continue;
+        }
+
+        lows[i] = 2.0f * Math::PI / length * minWavesInCascade;
+        highs[i] = 2.0f * Math::PI * static_cast<float>(resolution) / length / kSmallestWaveMultiplierAuto;
+    }
+
+    if (cascadeCount > 0)
+    {
+        highs[cascadeCount - 1] *= kSmallestWaveMultiplierAuto * 0.5f;
+    }
+
+    for (uint32_t i = cascadeCount; i < 4; ++i)
+    {
+        lows[i] = 0.0f;
+        highs[i] = 0.0f;
+    }
+
+    if (!allowOverlap)
+    {
+        lows[0] = std::max(lows[0], 0.0f);
+        lows[1] = std::max(lows[1], highs[0]);
+        lows[2] = std::max(lows[2], highs[1]);
+        lows[3] = std::max(lows[3], highs[2]);
+    }
+
+    cutoffsLow = Math::float4(lows[0], lows[1], lows[2], lows[3]);
+    cutoffsHigh = Math::float4(highs[0], highs[1], highs[2], highs[3]);
+}

--- a/OceanSimulationSettings.h
+++ b/OceanSimulationSettings.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <cstdint>
+
+#include "Math.h"
+
+class OceanSimulationSettings
+{
+public:
+    enum class ResolutionValue : uint32_t
+    {
+        Six = 64,
+        Seven = 128,
+        Eight = 256,
+        Nine = 512
+    };
+
+    enum class CascadesNumberValue : uint32_t
+    {
+        Two = 2,
+        Three = 3,
+        Four = 4,
+    };
+
+    enum class ReadbackCascadesMode : uint32_t
+    {
+        None = 0,
+        One = 1,
+        Two = 2,
+    };
+
+    enum class CascadeDomainsMode
+    {
+        Auto,
+        Manual
+    };
+
+    OceanSimulationSettings();
+
+    uint32_t GetResolution() const { return static_cast<uint32_t>(resolution_); }
+    uint32_t GetCascadeCount() const { return static_cast<uint32_t>(cascadesNumber_); }
+    uint32_t GetAnisotropyLevel() const { return static_cast<uint32_t>(anisoLevel_); }
+    bool ShouldUpdateSpectrum() const { return updateSpectrum_; }
+    bool ShouldSimulateFoam() const { return simulateFoam_; }
+    ReadbackCascadesMode GetReadbackMode() const { return readbackCascades_; }
+    uint32_t GetSamplingIterations() const { return static_cast<uint32_t>(samplingIterations_); }
+    CascadeDomainsMode GetDomainsMode() const { return domainsMode_; }
+    float GetSimulationScale() const { return simulationScale_; }
+    bool AllowOverlap() const { return allowOverlap_; }
+    float GetMinWavesInCascade() const { return minWavesInCascade_; }
+    Math::float4 GetManualLengthScales() const { return manualScales_; }
+
+    void SetResolution(ResolutionValue value) { resolution_ = value; }
+    void SetCascadeCount(CascadesNumberValue value) { cascadesNumber_ = value; }
+    void SetAnisotropyLevel(uint32_t value) { anisoLevel_ = static_cast<int>(value); }
+    void SetUpdateSpectrum(bool value) { updateSpectrum_ = value; }
+    void SetSimulateFoam(bool value) { simulateFoam_ = value; }
+    void SetReadbackMode(ReadbackCascadesMode value) { readbackCascades_ = value; }
+    void SetSamplingIterations(uint32_t value) { samplingIterations_ = static_cast<int>(value); }
+    void SetDomainsMode(CascadeDomainsMode value) { domainsMode_ = value; }
+    void SetSimulationScale(float value) { simulationScale_ = value; }
+    void SetAllowOverlap(bool value) { allowOverlap_ = value; }
+    void SetMinWavesInCascade(float value) { minWavesInCascade_ = value; }
+    void SetManualLengthScales(const Math::float4& value) { manualScales_ = value; }
+
+    Math::float4 ComputeLengthScales() const;
+    void CalculateCascadeDomains(Math::float4& cutoffsLow, Math::float4& cutoffsHigh) const;
+
+private:
+    void CalculateCascadeDomainsManual(const Math::float4& lengthScales,
+        bool allowOverlap,
+        float minWavesInCascade,
+        Math::float4& cutoffsLow,
+        Math::float4& cutoffsHigh) const;
+
+private:
+    static constexpr float kSmallestWaveMultiplierAuto = 4.0f;
+    static constexpr float kMinWavesInCascadeAuto = 6.0f;
+
+    ResolutionValue resolution_;
+    CascadesNumberValue cascadesNumber_;
+    int anisoLevel_;
+    bool simulateFoam_;
+    bool updateSpectrum_;
+    ReadbackCascadesMode readbackCascades_;
+    int samplingIterations_;
+    CascadeDomainsMode domainsMode_;
+    float simulationScale_;
+    bool allowOverlap_;
+    float minWavesInCascade_;
+    Math::float4 manualScales_;
+};
+

--- a/OceanSpectrum.cpp
+++ b/OceanSpectrum.cpp
@@ -1,0 +1,196 @@
+#include "OceanSpectrum.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+    constexpr float kPi = Math::PI;
+    constexpr float kGravity = 9.81f;
+    constexpr float kSigmaOverRho = 0.074e-3f;
+
+    float DonelanBannerBeta(float x)
+    {
+        const float ax = std::abs(x);
+        if (ax < 0.95f)
+        {
+            return 2.61f * std::pow(ax, 1.3f);
+        }
+        if (ax < 1.6f)
+        {
+            return 2.28f * std::pow(ax, -1.3f);
+        }
+        const float p = -0.4f + 0.8393f * std::exp(-0.567f * std::log(ax * ax));
+        return std::pow(10.0f, p);
+    }
+
+    float DonelanBanner(float theta, float omega, float peakOmega)
+    {
+        const float beta = DonelanBannerBeta(omega / peakOmega);
+        const float sech = 1.0f / std::cosh(beta * theta);
+        return beta / 2.0f / std::tanh(beta * kPi) * sech * sech;
+    }
+
+    float NormalisationFactor(float s)
+    {
+        const float s2 = s * s;
+        const float s3 = s2 * s;
+        const float s4 = s3 * s;
+        if (s < 5.0f)
+        {
+            return -0.000564f * s4 + 0.00776f * s3 - 0.044f * s2 + 0.192f * s + 0.163f;
+        }
+        return -4.80e-08f * s4 + 1.07e-05f * s3 - 9.53e-04f * s2 + 5.90e-02f * s + 3.93e-01f;
+    }
+
+    float SpreadPowerHasselman(float omega, float peakOmega, float u)
+    {
+        const float ratio = std::abs(omega / peakOmega);
+        if (omega > peakOmega)
+        {
+            return 9.77f * std::pow(ratio, -2.33f - 1.45f * (u * peakOmega / kGravity - 1.17f));
+        }
+        return 6.97f * std::pow(ratio, 4.06f);
+    }
+
+    float Cosine2s(float theta, float s)
+    {
+        return NormalisationFactor(s) * std::pow(std::abs(std::cos(0.5f * theta)), 2.0f * s);
+    }
+
+    float DirectionSpectrum(float theta, float omega, float peakOmega, const SpectrumParams& pars)
+    {
+        const float spreadPower = SpreadPowerHasselman(omega, peakOmega, pars.windSpeed)
+            + Math::Lerp(16.0f * std::tanh(std::min(omega / peakOmega / 10.0f, 20.0f)), 25.0f,
+                pars.extraAlignment) * pars.extraAlignment * pars.extraAlignment;
+        const float spread = Cosine2s(theta, spreadPower);
+        return Math::Lerp(0.5f / kPi, spread, pars.alignment);
+    }
+
+    float PiersonMoskowitzPeakOmega(float u)
+    {
+        const float nu = 0.13f;
+        return 2.0f * kPi * nu * kGravity / std::max(u, Math::EPS);
+    }
+
+    float PiersonMoskowitz(float omega, float peakOmega)
+    {
+        const float invOmega = 1.0f / std::max(omega, Math::EPS);
+        const float peakOverOmega = peakOmega / std::max(omega, Math::EPS);
+        return 8.1e-3f * kGravity * kGravity * invOmega * invOmega * invOmega * invOmega * invOmega
+            * std::exp(-1.25f * std::pow(peakOverOmega, 4.0f));
+    }
+
+    float JonswapAlpha(float chi)
+    {
+        return 0.076f * std::pow(chi, -0.22f);
+    }
+
+    float JonswapPeakOmega(float chi, float u)
+    {
+        const float nu = 3.5f * std::pow(chi, -0.33f);
+        return 2.0f * kPi * nu * kGravity / std::max(u, Math::EPS);
+    }
+
+    float JONSWAP(float omega, float peakOmega, float chi, float gamma)
+    {
+        float sigma = (omega <= peakOmega) ? 0.07f : 0.09f;
+        const float exponent = -(omega - peakOmega) * (omega - peakOmega)
+            / (2.0f * sigma * sigma * peakOmega * peakOmega);
+        const float r = std::exp(exponent);
+        const float invOmega = 1.0f / std::max(omega, Math::EPS);
+        const float peakOverOmega = peakOmega / std::max(omega, Math::EPS);
+        const float gammaClamped = std::max(std::abs(gamma), Math::EPS);
+        return JonswapAlpha(chi) * kGravity * kGravity
+            * std::pow(invOmega, 5.0f)
+            * std::exp(-1.25f * std::pow(peakOverOmega, 4.0f))
+            * std::pow(gammaClamped, r) * 3.3f / gammaClamped;
+    }
+
+    float TMACorrection(float omega, float depth)
+    {
+        const float omegaH = omega * std::sqrt(depth / kGravity);
+        if (omegaH <= 1.0f)
+        {
+            return 0.5f * omegaH * omegaH;
+        }
+        if (omegaH < 2.0f)
+        {
+            const float diff = 2.0f - omegaH;
+            return 1.0f - 0.5f * diff * diff;
+        }
+        return 1.0f;
+    }
+}
+
+namespace OceanSpectrum
+{
+    float Frequency(float k, float depth)
+    {
+        const float kh = std::min(k * depth, 10.0f);
+        const float tanhKh = std::tanh(kh);
+        return std::sqrt(std::max((kGravity * k + kSigmaOverRho * k * k * k) * tanhKh, 0.0f));
+    }
+
+    float FrequencyDerivative(float k, float depth)
+    {
+        const float kh = std::min(k * depth, 10.0f);
+        const float tanhKh = std::tanh(kh);
+        const float coshKh = std::cosh(kh);
+        const float freq = Frequency(k, depth);
+        if (freq < Math::EPS)
+        {
+            return 0.0f;
+        }
+
+        const float term1 = depth * (kSigmaOverRho * k * k * k + kGravity * k)
+            / (coshKh * coshKh);
+        const float term2 = (kGravity + 3.0f * kSigmaOverRho * k * k) * tanhKh;
+        return 0.5f * (term1 + term2) / freq;
+    }
+
+    float FullSpectrum(float omega, float theta, const SpectrumParams& params, float depth)
+    {
+        if (params.windSpeed < Math::EPS)
+        {
+            return 0.0f;
+        }
+
+        const float chiNumerator = kGravity * params.fetch * 1000.0f;
+        float chi = std::abs(chiNumerator / std::max(params.windSpeed * params.windSpeed, Math::EPS));
+        chi = std::min(1.0e4f, chi);
+
+        float peakOmega = 1.0f;
+        float energySpectrum = 1.0f;
+        switch (params.energySpectrum)
+        {
+        case SpectrumParams::EnergySpectrumModel::PM:
+            peakOmega = PiersonMoskowitzPeakOmega(params.windSpeed);
+            energySpectrum = PiersonMoskowitz(omega, peakOmega);
+            break;
+        case SpectrumParams::EnergySpectrumModel::JONSWAP:
+            peakOmega = JonswapPeakOmega(chi, params.windSpeed);
+            energySpectrum = JONSWAP(omega, peakOmega, chi, params.peaking);
+            break;
+        case SpectrumParams::EnergySpectrumModel::TMA:
+            peakOmega = JonswapPeakOmega(chi, params.windSpeed);
+            energySpectrum = JONSWAP(omega, peakOmega, chi, params.peaking) * TMACorrection(omega, depth);
+            break;
+        default:
+            break;
+        }
+
+        const float spread = DirectionSpectrum(theta, omega, peakOmega, params);
+        return energySpectrum * spread;
+    }
+
+    float ShortWavesFade(float kLength, float fadeLength)
+    {
+        if (fadeLength <= Math::EPS)
+        {
+            return 1.0f;
+        }
+        return std::exp(-fadeLength * fadeLength * kLength * kLength);
+    }
+}
+

--- a/OceanSpectrum.h
+++ b/OceanSpectrum.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "OceanSimulationInputs.h"
+
+namespace OceanSpectrum
+{
+    float Frequency(float k, float depth);
+    float FrequencyDerivative(float k, float depth);
+    float FullSpectrum(float omega, float theta, const SpectrumParams& params, float depth);
+    float ShortWavesFade(float kLength, float fadeLength);
+}
+

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -170,6 +170,9 @@
     <ClCompile Include="MeshManager.cpp" />
     <ClCompile Include="OceanRenderable.cpp" />
     <ClCompile Include="OceanSimulation.cpp" />
+    <ClCompile Include="OceanSimulationInputs.cpp" />
+    <ClCompile Include="OceanSpectrum.cpp" />
+    <ClCompile Include="OceanSimulationSettings.cpp" />
     <ClCompile Include="PointLight.cpp" />
     <ClCompile Include="Profiler.cpp" />
     <ClCompile Include="ProfilerScopes.cpp" />
@@ -211,6 +214,9 @@
     <ClInclude Include="MeshManager.h" />
     <ClInclude Include="OceanRenderable.h" />
     <ClInclude Include="OceanSimulation.h" />
+    <ClInclude Include="OceanSimulationInputs.h" />
+    <ClInclude Include="OceanSpectrum.h" />
+    <ClInclude Include="OceanSimulationSettings.h" />
     <ClInclude Include="PointLight.h" />
     <ClInclude Include="Profiler.h" />
     <ClInclude Include="ProfilerScopes.h" />

--- a/test_cube.vcxproj.filters
+++ b/test_cube.vcxproj.filters
@@ -105,6 +105,15 @@
     <ClCompile Include="OceanSimulation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="OceanSimulationInputs.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="OceanSpectrum.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="OceanSimulationSettings.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="OceanRenderable.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -158,6 +167,9 @@
     <ClInclude Include="GpuInstancedModels.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="OceanSimulationSettings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="RootSignatureParser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -195,6 +207,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="OceanSimulation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OceanSimulationInputs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OceanSpectrum.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="OceanRenderable.h">


### PR DESCRIPTION
## Summary
- add a C++ `OceanSimulationInputsProvider` pipeline with spectrum, foam, and equalizer presets mirroring the Unity ScriptableObjects
- port the URP ocean spectrum math (energy spectra, directional spreads, and depth dispersion) so CPU spectrum generation matches the shader implementation
- refactor `OceanSimulation` to drive spectrum initialization from the provider inputs, including wind directions, equalizer ramps, and cascade cutoffs
- seed `OceanSimulation` with default URP settings, equalizers, swell, and Beaufort local wave presets so the provider has in-memory assets for initialization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d68174e31c8329b1a4c7d797a9a1d1