### PR TITLE
Refine camera speed controls

### DIFF
--- a/ActionMap.cpp
+++ b/ActionMap.cpp
@@ -68,16 +68,6 @@ bool ActionMap::LoadFromJsonFile(const std::wstring& path) {
 
     actions_.clear();
 
-    if (j.contains("speed")) {
-        auto sp = j["speed"];
-        if (sp.contains("move") && sp["move"].is_number()) {
-            moveSpeed_ = sp["move"].get<float>();
-        }
-        if (sp.contains("sprintMultiplier") && sp["sprintMultiplier"].is_number()) {
-            sprintMultiplier_ = sp["sprintMultiplier"].get<float>();
-        }
-    }
-
     if (j.contains("actions") && j["actions"].is_array()) {
         for (auto& a : j["actions"]) {
             if (!a.contains("name") || !a["name"].is_string()) {

--- a/ActionMap.h
+++ b/ActionMap.h
@@ -17,10 +17,6 @@ public:
     bool  WasActionReleased(const std::string& name, const InputManager& input) const;
     float GetAxis(const std::string& name, const InputManager& input) const;
 
-    // Параметры скорости/сенс
-    float MoveSpeed() const { return moveSpeed_; }
-    float SprintMultiplier() const { return sprintMultiplier_; }
-
 private:
     struct Digital {
         // любой из keys или mouseButtons активен -> true
@@ -50,6 +46,4 @@ private:
 
 private:
     robin_hood::unordered_map<std::string, Action> actions_;
-    float moveSpeed_ = 3.0f;
-    float sprintMultiplier_ = 2.5f;
 };

--- a/Camera.cpp
+++ b/Camera.cpp
@@ -22,10 +22,21 @@ void Camera::UpdateFromActions(InputManager& input, const ActionMap& map, float 
         }
     }
 
+    // корректировка скорости перемещения колесом мыши
+    const int wheel = input.MouseWheelDelta();
+    if (wheel != 0) {
+        constexpr float kWheelStep = 0.2f;
+        constexpr float kMinMultiplier = 0.2f;
+        constexpr float kMaxMultiplier = 5.0f;
+        const float ticks = static_cast<float>(wheel) / 120.0f;
+        moveSpeedMultiplier_ += ticks * kWheelStep;
+        moveSpeedMultiplier_ = Clamp(moveSpeedMultiplier_, kMinMultiplier, kMaxMultiplier);
+    }
+
     // ходьба
-    float speed = map.MoveSpeed();
+    float speed = moveSpeed_ * moveSpeedMultiplier_;
     if (map.IsActionDown("Sprint", input)) {
-        speed *= map.SprintMultiplier();
+        speed *= sprintMultiplier_;
     }
     const float mx = map.GetAxis("MoveX", input);
     const float my = map.GetAxis("MoveY", input);

--- a/Camera.h
+++ b/Camera.h
@@ -52,6 +52,9 @@ private:
     float3 position_;
     float pitch_; // вверх/вниз, ограничить [-pi/2+eps, pi/2-eps]
     float yaw_;   // влево/вправо, можно не ограничивать
+    float moveSpeed_ = 3.0f;
+    float sprintMultiplier_ = 2.5f;
+    float moveSpeedMultiplier_ = 1.0f;
 
     void ClampPitch() {
         const float limit = XM_PIDIV2 - 0.01f;

--- a/InputManager.cpp
+++ b/InputManager.cpp
@@ -18,6 +18,7 @@ void InputManager::NewFrame() {
     for (auto& v : keyReleased_) { v = 0; }
     mouseDX_ = 0;
     mouseDY_ = 0;
+    mouseWheelDelta_ = 0;
 }
 
 void InputManager::SetMouseCapture(bool capture) {
@@ -101,6 +102,10 @@ void InputManager::OnWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) 
         case WM_MBUTTONUP: { mButtonDown_ = false; break; }
         case WM_RBUTTONDOWN: { rButtonDown_ = true; break; }
         case WM_RBUTTONUP: { rButtonDown_ = false; break; }
+        case WM_MOUSEWHEEL: {
+            mouseWheelDelta_ += GET_WHEEL_DELTA_WPARAM(wParam);
+            break;
+        }
         case WM_ACTIVATE: {
             if (LOWORD(wParam) == WA_INACTIVE) {
                 SetMouseCapture(false);

--- a/InputManager.h
+++ b/InputManager.h
@@ -26,6 +26,7 @@ public:
     // Мышь
     int  MouseDeltaX() const { return mouseDX_; }
     int  MouseDeltaY() const { return mouseDY_; }
+    int  MouseWheelDelta() const { return mouseWheelDelta_; }
     bool IsRButtonDown() const { return rButtonDown_; }
     bool IsLButtonDown() const { return lButtonDown_; }
     bool IsMButtonDown() const { return mButtonDown_; }
@@ -50,5 +51,6 @@ private:
 
     int mouseDX_ = 0;
     int mouseDY_ = 0;
+    int mouseWheelDelta_ = 0;
     bool mouseCaptured_ = false;
 };


### PR DESCRIPTION
## Summary
- move the camera's base and sprint speeds into the Camera class
- adjust wheel-based speed scaling to use fixed 0.2 increments clamped between 0.2 and 5

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da84158b78832981cb334cc2cf9bdc