### PR TITLE
Compute font output paths inside generator

### DIFF
--- a/App.cpp
+++ b/App.cpp
@@ -1,6 +1,7 @@
 #include "App.h"
 #include "Profiler.h"
 #include "ProfilerScopes.h"
+#include "FontGenerator.h"
 #include <cassert>
 
 LRESULT CALLBACK App::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
@@ -176,6 +177,22 @@ void App::Run(HINSTANCE hInstance, int nCmdShow) {
                 if (input.WasKeyPressed(VK_F11)) {
                     constexpr uint32_t kTraceFrames = 120;
                     Profiler::Get().RequestTraceCapture(kTraceFrames);
+                }
+
+                if (input.WasKeyPressed(VK_F8)) {
+                    const bool generateSdf = input.IsKeyDown(VK_SHIFT);
+                    const FontGenerator::OutputType type = generateSdf ? FontGenerator::OutputType::Sdf : FontGenerator::OutputType::Coverage;
+
+                    FontGenerator generator;
+                    FontGenerator::Params params;
+                    params.fontFamily = L"Consolas";
+                    params.pixelHeight = 32;
+                    params.type = type;
+                    params.fontsFolder = L"fonts";
+
+                    if (!generator.Generate(params)) {
+                        OutputDebugStringA("Font generation failed\n");
+                    }
                 }
 
                 double now = GetTimeSeconds();

--- a/FontAtlas.cpp
+++ b/FontAtlas.cpp
@@ -4,6 +4,13 @@
 #include <cwchar>
 #include <algorithm>
 #include <limits>
+#include <cctype>
+
+#pragma warning(push)
+#pragma warning(disable: 26819)
+#include "third_party/json/json.hpp"
+#pragma warning(pop)
+using nlohmann::json;
 
 namespace {
 constexpr uint32_t kInvalidGlyphIndex = std::numeric_limits<uint32_t>::max();
@@ -34,105 +41,96 @@ static std::string ReadAllUtf8(const std::wstring& path) {
 
 bool FontAtlas::Load(Renderer* r, ID3D12GraphicsCommandList* uploadCl, std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive,
                      const std::wstring& jsonPath, const std::wstring& tgaPath) {
-    // JSON (без сторонних либ — парсим по-минимуму под нашу схему)
+    // JSON metadata
     std::string j = ReadAllUtf8(jsonPath);
-    auto findNum = [&](const char* key)->int {
-        std::string k = std::string("\"") + key + "\":";
-        size_t p = j.find(k);
-        if (p == std::string::npos) { return 0; }
-        p += k.size();
-        return std::atoi(j.c_str() + p);
+    json parsed = json::parse(j, nullptr, false);
+    if (parsed.is_discarded()) {
+        return false;
+    }
+
+    auto getInt = [](const json& node, const char* key) -> int {
+        auto it = node.find(key);
+        if (it == node.end()) { return 0; }
+        if (it->is_number_integer()) { return it->get<int>(); }
+        if (it->is_number_unsigned()) { return static_cast<int>(it->get<uint32_t>()); }
+        if (it->is_number_float()) { return static_cast<int>(it->get<float>()); }
+        return 0;
     };
-    pxSize_     = findNum("pxSize");
-    spread_     = findNum("spread");
-    atlasW_     = findNum("atlasW");
-    atlasH_     = findNum("atlasH");
-    ascent_     = findNum("ascent");
-    descent_    = findNum("descent");
-    lineAdvance_= findNum("lineAdvance");
+
+    type_ = Type::SDF;
+    auto typeIt = parsed.find("type");
+    if (typeIt != parsed.end() && typeIt->is_string()) {
+        std::string typeStr = typeIt->get<std::string>();
+        std::string lowered;
+        lowered.reserve(typeStr.size());
+        for (unsigned char c : typeStr) {
+            lowered.push_back(static_cast<char>(std::tolower(static_cast<int>(c))));
+        }
+        if (lowered == "coverage") {
+            type_ = Type::Coverage;
+        }
+    }
+
+    pxSize_      = getInt(parsed, "pxSize");
+    spread_      = getInt(parsed, "spread");
+    if (type_ == Type::Coverage) {
+        spread_ = 0;
+    }
+    atlasW_      = getInt(parsed, "atlasW");
+    atlasH_      = getInt(parsed, "atlasH");
+    ascent_      = getInt(parsed, "ascent");
+    descent_     = getInt(parsed, "descent");
+    lineAdvance_ = getInt(parsed, "lineAdvance");
 
     // glyphs
     glyphs_.clear();
     glyphRemap_.clear();
     glyphRemapBase_ = 0;
-    {
-        size_t p = j.find("\"glyphs\":[");
-        if (p != std::string::npos) {
-            p = j.find('[', p);
-            size_t e = j.find(']', p);
-            std::string arr = j.substr(p + 1, e - p - 1);
-            size_t i = 0;
-            while (i < arr.size()) {
-                size_t b = arr.find('{', i);
-                if (b == std::string::npos) { break; }
-                size_t c = arr.find('}', b);
-                std::string obj = arr.substr(b + 1, c - b - 1);
-                auto get = [&](const char* k) -> int {
-                    std::string kk = std::string("\"") + k + "\":";
-                    size_t pp = obj.find(kk);
-                    if (pp == std::string::npos) { return 0; }
-                    pp += kk.size();
-                    return std::atoi(obj.c_str() + pp);
-                };
-                FontGlyph g{};
-                g.cp = (uint32_t)get("cp");
-                g.x = get("x");
-                g.y = get("y");
-                g.w = get("w");
-                g.h = get("h");
-                g.xoff = get("xoff");
-                g.yoff = get("yoff");
-                g.xadv = get("xadv");
-                if (g.w > 0 && g.h > 0) {
-                    const float invW = 1.0f / float(atlasW_);
-                    const float invH = 1.0f / float(atlasH_);
-                    const float padU = 0.5f;
-                    const float padV = 0.5f;
+    if (parsed.contains("glyphs") && parsed["glyphs"].is_array()) {
+        for (const auto& entry : parsed["glyphs"]) {
+            if (!entry.is_object()) { continue; }
+            FontGlyph g{};
+            const int cp = getInt(entry, "cp");
+            if (cp < 0) { continue; }
+            g.cp = static_cast<uint32_t>(cp);
+            g.x = getInt(entry, "x");
+            g.y = getInt(entry, "y");
+            g.w = getInt(entry, "w");
+            g.h = getInt(entry, "h");
+            g.xoff = getInt(entry, "xoff");
+            g.yoff = getInt(entry, "yoff");
+            g.xadv = getInt(entry, "xadv");
+            if (g.w > 0 && g.h > 0 && atlasW_ > 0 && atlasH_ > 0) {
+                const float invW = 1.0f / float(atlasW_);
+                const float invH = 1.0f / float(atlasH_);
+                const float padU = 0.5f;
+                const float padV = 0.5f;
 
-                    g.u0 = (g.x + padU) * invW;
-                    g.v0 = (g.y + padV) * invH;
-                    g.u1 = (g.x + g.w - padU) * invW;
-                    g.v1 = (g.y + g.h - padV) * invH;
-                }
-                else {
-                    g.u0 = g.v0 = g.u1 = g.v1 = 0.0f;
-                }
-                glyphs_.push_back(g);
-                i = c + 1;
+                g.u0 = (g.x + padU) * invW;
+                g.v0 = (g.y + padV) * invH;
+                g.u1 = (g.x + g.w - padU) * invW;
+                g.v1 = (g.y + g.h - padV) * invH;
             }
+            else {
+                g.u0 = g.v0 = g.u1 = g.v1 = 0.0f;
+            }
+            glyphs_.push_back(g);
         }
     }
 
     // kern
     kerning_.clear();
-    {
-        size_t p = j.find("\"kern\":[");
-        if (p != std::string::npos) {
-            p = j.find('[', p);
-            size_t e = j.find(']', p);
-            std::string arr = j.substr(p + 1, e - p - 1);
-            size_t i = 0;
-            while (i < arr.size()) {
-                size_t b = arr.find('{', i);
-                if (b == std::string::npos) { break; }
-                size_t c = arr.find('}', b);
-                std::string obj = arr.substr(b + 1, c - b - 1);
-                auto get = [&](const char* k) -> int {
-                    std::string kk = std::string("\"") + k + "\":";
-                    size_t pp = obj.find(kk);
-                    if (pp == std::string::npos) { return 0; }
-                    pp += kk.size();
-                    return std::atoi(obj.c_str() + pp);
-                };
-                uint32_t a = (uint32_t)get("a");
-                uint32_t b2 = (uint32_t)get("b");
-                int k = get("k");
-                KerningPair pair{};
-                pair.key = ((uint64_t)a << 32) | (uint64_t)b2;
-                pair.value = k;
-                kerning_.push_back(pair);
-                i = c + 1;
-            }
+    if (parsed.contains("kern") && parsed["kern"].is_array()) {
+        for (const auto& entry : parsed["kern"]) {
+            if (!entry.is_object()) { continue; }
+            const int a = getInt(entry, "a");
+            const int b = getInt(entry, "b");
+            KerningPair pair{};
+            if (a < 0 || b < 0) { continue; }
+            pair.key = (static_cast<uint64_t>(static_cast<uint32_t>(a)) << 32) |
+                       static_cast<uint64_t>(static_cast<uint32_t>(b));
+            pair.value = getInt(entry, "k");
+            kerning_.push_back(pair);
         }
     }
 

--- a/FontAtlas.h
+++ b/FontAtlas.h
@@ -15,6 +15,8 @@ struct FontGlyph {
 
 class FontAtlas {
 public:
+    enum class Type : uint8_t { SDF, Coverage };
+
     bool Load(Renderer* r, ID3D12GraphicsCommandList* uploadCl, std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive,
               const std::wstring& jsonPath, const std::wstring& tgaPath);
 
@@ -26,12 +28,15 @@ public:
     int PxSize() const { return pxSize_; }
     int Spread() const { return spread_; }
     bool HasKerning() const { return kerning_.size() > 0; }
+    Type GetType() const { return type_; }
+    bool IsCoverage() const { return type_ == Type::Coverage; }
 
     D3D12_CPU_DESCRIPTOR_HANDLE GetSRVCPU() const { return tex_.GetSRVCPU(); }
 
 private:
     Texture2D tex_;
     int pxSize_=0, spread_=0, atlasW_=0, atlasH_=0, ascent_=0, descent_=0, lineAdvance_=0;
+    Type type_ = Type::SDF;
     std::vector<FontGlyph> glyphs_;
     std::vector<uint32_t> glyphRemap_;
     uint32_t glyphRemapBase_ = 0;

--- a/FontGenerator.cpp
+++ b/FontGenerator.cpp
@@ -1,0 +1,501 @@
+#include "FontGenerator.h"
+
+#include <windows.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <numeric>
+#include <unordered_set>
+#include <vector>
+
+#pragma warning(push)
+#pragma warning(disable: 26819)
+#include "third_party/json/json.hpp"
+#pragma warning(pop)
+
+using nlohmann::json;
+
+namespace {
+std::wstring JoinPath(const std::wstring& folder, const std::wstring& name) {
+    if (folder.empty()) {
+        return name;
+    }
+    if (folder.back() == L'/' || folder.back() == L'\\') {
+        return folder + name;
+    }
+    return folder + L"\\" + name;
+}
+
+struct GlyphBitmap {
+    uint32_t codepoint = 0;
+    uint16_t glyphIndex = 0;
+    int advance = 0;
+    int bearingX = 0;
+    int bearingY = 0;
+    int boxW = 0;
+    int boxH = 0;
+    std::vector<uint8_t> coverage;
+};
+
+struct PackedGlyph {
+    GlyphBitmap glyph;
+    int atlasX = 0;
+    int atlasY = 0;
+    int width = 0;
+    int height = 0;
+};
+
+constexpr float kInf = 1e12f;
+
+void EDT1D(const float* f, int n, float* d) {
+    std::vector<int> v(n);
+    std::vector<float> z(n + 1);
+    int k = 0;
+    v[0] = 0;
+    z[0] = -std::numeric_limits<float>::infinity();
+    z[1] = std::numeric_limits<float>::infinity();
+    for (int q = 1; q < n; ++q) {
+        float s = 0.0f;
+        while (true) {
+            const int vk = v[k];
+            const float num = (f[q] + float(q * q)) - (f[vk] + float(vk * vk));
+            const float den = 2.0f * float(q - vk);
+            s = (den != 0.0f) ? (num / den) : std::numeric_limits<float>::infinity();
+            if (s <= z[k]) {
+                if (k == 0) {
+                    break;
+                }
+                --k;
+            } else {
+                break;
+            }
+        }
+        ++k;
+        v[k] = q;
+        z[k] = s;
+        z[k + 1] = std::numeric_limits<float>::infinity();
+    }
+    k = 0;
+    for (int q = 0; q < n; ++q) {
+        while (z[k + 1] < q) {
+            ++k;
+        }
+        const int vk = v[k];
+        const float diff = float(q - vk);
+        d[q] = diff * diff + f[vk];
+    }
+}
+
+void EDT2D(const std::vector<float>& f, int w, int h, std::vector<float>& d) {
+    std::vector<float> tmp((size_t)w * (size_t)h);
+    std::vector<float> column(h);
+    std::vector<float> columnOut(h);
+
+    for (int y = 0; y < h; ++y) {
+        EDT1D(f.data() + (size_t)y * (size_t)w, w, tmp.data() + (size_t)y * (size_t)w);
+    }
+    for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+            column[y] = tmp[(size_t)y * (size_t)w + (size_t)x];
+        }
+        EDT1D(column.data(), h, columnOut.data());
+        for (int y = 0; y < h; ++y) {
+            d[(size_t)y * (size_t)w + (size_t)x] = columnOut[y];
+        }
+    }
+}
+
+void ComputeSDF(const std::vector<uint8_t>& coverage, int w, int h, int spread, std::vector<uint8_t>& out) {
+    const size_t pixelCount = (size_t)w * (size_t)h;
+    std::vector<float> inside(pixelCount, kInf);
+    std::vector<float> outside(pixelCount, kInf);
+
+    for (size_t i = 0; i < pixelCount; ++i) {
+        const float alpha = float(coverage[i]) / 255.0f;
+        if (alpha >= 0.5f) {
+            inside[i] = 0.0f;
+        } else {
+            outside[i] = 0.0f;
+        }
+    }
+
+    std::vector<float> distInside(pixelCount, kInf);
+    std::vector<float> distOutside(pixelCount, kInf);
+    EDT2D(inside, w, h, distInside);
+    EDT2D(outside, w, h, distOutside);
+
+    out.resize(pixelCount);
+    const float spreadF = std::max(1, spread);
+    for (size_t i = 0; i < pixelCount; ++i) {
+        const float di = std::sqrt(distInside[i]);
+        const float do_ = std::sqrt(distOutside[i]);
+        const float signedDist = do_ - di;
+        float value = 0.5f + signedDist / (2.0f * spreadF);
+        value = std::clamp(value, 0.0f, 1.0f);
+        out[i] = static_cast<uint8_t>(std::round(value * 255.0f));
+    }
+}
+
+bool WriteTGA8(const std::wstring& path, int w, int h, const std::vector<uint8_t>& data) {
+    if ((int)data.size() != w * h) {
+        return false;
+    }
+    std::ofstream f(path, std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    unsigned char header[18]{};
+    header[2] = 3; // grayscale
+    header[12] = static_cast<unsigned char>(w & 0xFF);
+    header[13] = static_cast<unsigned char>((w >> 8) & 0xFF);
+    header[14] = static_cast<unsigned char>(h & 0xFF);
+    header[15] = static_cast<unsigned char>((h >> 8) & 0xFF);
+    header[16] = 8;
+    header[17] = 0; // bottom-left origin
+    f.write(reinterpret_cast<char*>(header), sizeof(header));
+    for (int y = 0; y < h; ++y) {
+        const int srcY = h - 1 - y;
+        const uint8_t* row = data.data() + (size_t)srcY * (size_t)w;
+        f.write(reinterpret_cast<const char*>(row), (std::streamsize)w);
+    }
+    return static_cast<bool>(f);
+}
+
+std::vector<uint32_t> BuildCodepointList() {
+    std::vector<uint32_t> cps;
+    cps.reserve(512);
+    for (uint32_t cp = 32; cp <= 126; ++cp) {
+        cps.push_back(cp);
+    }
+    // basic Cyrillic range
+    for (uint32_t cp = 0x400; cp <= 0x45F; ++cp) {
+        cps.push_back(cp);
+    }
+    cps.push_back(0x451); // ё
+    cps.push_back(0x401); // Ё
+    std::sort(cps.begin(), cps.end());
+    cps.erase(std::unique(cps.begin(), cps.end()), cps.end());
+    return cps;
+}
+
+bool WriteJson(const std::wstring& path,
+               const json& j) {
+    std::ofstream out(path);
+    if (!out) {
+        return false;
+    }
+    out << j.dump(2);
+    return static_cast<bool>(out);
+}
+
+} // namespace
+
+bool FontGenerator::Generate(const Params& params) {
+    if (params.fontFamily.empty() || params.pixelHeight <= 0) {
+        return false;
+    }
+
+    const bool isSdf = (params.type == OutputType::Sdf);
+    const std::wstring baseName = L"cons_" + std::to_wstring(params.pixelHeight);
+    const std::wstring jsonPath = JoinPath(params.fontsFolder, isSdf ? baseName + L".json" : baseName + L"_coverage.json");
+    const std::wstring texturePath = JoinPath(params.fontsFolder, isSdf ? baseName + L".tga" : baseName + L"_coverage.tga");
+
+    HDC hdc = CreateCompatibleDC(nullptr);
+    if (!hdc) {
+        return false;
+    }
+
+    const int fontHeight = -params.pixelHeight;
+    HFONT font = CreateFontW(fontHeight, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
+                              DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+                              ANTIALIASED_QUALITY, FF_DONTCARE | FIXED_PITCH,
+                              params.fontFamily.c_str());
+    if (!font) {
+        DeleteDC(hdc);
+        return false;
+    }
+
+    HFONT oldFont = (HFONT)SelectObject(hdc, font);
+    SetMapMode(hdc, MM_TEXT);
+
+    TEXTMETRICW tm{};
+    if (!GetTextMetricsW(hdc, &tm)) {
+        SelectObject(hdc, oldFont);
+        DeleteObject(font);
+        DeleteDC(hdc);
+        return false;
+    }
+
+    const std::vector<uint32_t> codepoints = BuildCodepointList();
+    std::vector<WCHAR> wcharBuffer;
+    wcharBuffer.reserve(codepoints.size());
+    for (uint32_t cp : codepoints) {
+        if (cp <= 0xFFFFu) {
+            wcharBuffer.push_back(static_cast<WCHAR>(cp));
+        }
+    }
+
+    std::vector<WORD> glyphIndices(wcharBuffer.size(), 0);
+    if (!wcharBuffer.empty()) {
+        if (GetGlyphIndicesW(hdc, wcharBuffer.data(), static_cast<int>(wcharBuffer.size()),
+                             reinterpret_cast<LPWORD>(glyphIndices.data()), GGI_MARK_NONEXISTING_GLYPHS) == GDI_ERROR) {
+            SelectObject(hdc, oldFont);
+            DeleteObject(font);
+            DeleteDC(hdc);
+            return false;
+        }
+    }
+
+    MAT2 mat2{ {0,1}, {0,0}, {0,0}, {0,1} };
+
+    std::vector<GlyphBitmap> glyphs;
+    glyphs.reserve(codepoints.size());
+    size_t glyphCursor = 0;
+    for (size_t i = 0; i < codepoints.size(); ++i) {
+        const uint32_t cp = codepoints[i];
+        if (cp > 0xFFFFu) {
+            continue;
+        }
+        if (glyphCursor >= glyphIndices.size()) {
+            break;
+        }
+        const WORD glyphIdx = glyphIndices[glyphCursor++];
+        if (glyphIdx == 0xFFFFu) {
+            continue;
+        }
+        GLYPHMETRICS gm{};
+        const DWORD bufferSize = GetGlyphOutlineW(hdc, glyphIdx, GGO_GRAY8_BITMAP | GGO_GLYPH_INDEX,
+                                                  &gm, 0, nullptr, &mat2);
+        if (bufferSize == GDI_ERROR) {
+            continue;
+        }
+
+        GlyphBitmap bmp{};
+        bmp.codepoint = cp;
+        bmp.glyphIndex = static_cast<uint16_t>(glyphIdx);
+        bmp.advance = gm.gmCellIncX;
+        bmp.bearingX = gm.gmptGlyphOrigin.x;
+        bmp.bearingY = gm.gmptGlyphOrigin.y;
+        bmp.boxW = gm.gmBlackBoxX;
+        bmp.boxH = gm.gmBlackBoxY;
+
+        if (bufferSize > 0 && gm.gmBlackBoxX > 0 && gm.gmBlackBoxY > 0) {
+            std::vector<uint8_t> raw(bufferSize);
+            if (GetGlyphOutlineW(hdc, glyphIdx, GGO_GRAY8_BITMAP | GGO_GLYPH_INDEX,
+                                 &gm, bufferSize, raw.data(), &mat2) == GDI_ERROR) {
+                continue;
+            }
+            const size_t stride = ((size_t)gm.gmBlackBoxX + 3u) & ~3u;
+            bmp.coverage.resize((size_t)gm.gmBlackBoxX * (size_t)gm.gmBlackBoxY);
+            for (int y = 0; y < gm.gmBlackBoxY; ++y) {
+                for (int x = 0; x < gm.gmBlackBoxX; ++x) {
+                    const uint8_t v = raw[(size_t)y * stride + (size_t)x];
+                    const int scaled = (int(v) * 255 + 32) / 64;
+                    bmp.coverage[(size_t)y * (size_t)gm.gmBlackBoxX + (size_t)x] = static_cast<uint8_t>(std::clamp(scaled, 0, 255));
+                }
+            }
+        }
+
+        glyphs.push_back(std::move(bmp));
+    }
+
+    SelectObject(hdc, oldFont);
+    DeleteObject(font);
+    DeleteDC(hdc);
+
+    if (glyphs.empty()) {
+        return false;
+    }
+
+    std::sort(glyphs.begin(), glyphs.end(), [](const GlyphBitmap& a, const GlyphBitmap& b) {
+        return a.boxH > b.boxH;
+    });
+
+    const int spread = (params.type == OutputType::Sdf) ? std::max(8, params.pixelHeight / 2 + 2) : 0;
+    const int padding = (params.type == OutputType::Sdf) ? spread + 2 : 1;
+
+    std::vector<PackedGlyph> packed;
+    packed.reserve(glyphs.size());
+    for (const GlyphBitmap& g : glyphs) {
+        PackedGlyph pg;
+        pg.glyph = g;
+        if (g.boxW > 0 && g.boxH > 0) {
+            pg.width = g.boxW + padding * 2;
+            pg.height = g.boxH + padding * 2;
+        } else {
+            pg.width = 0;
+            pg.height = 0;
+        }
+        packed.push_back(std::move(pg));
+    }
+
+    auto tryPack = [&](int atlasW, int atlasH) -> bool {
+        int penX = padding;
+        int penY = padding;
+        int rowH = 0;
+        for (auto& pg : packed) {
+            if (pg.width == 0 || pg.height == 0) {
+                pg.atlasX = 0;
+                pg.atlasY = 0;
+                continue;
+            }
+            if (penX + pg.width > atlasW) {
+                penX = padding;
+                penY += rowH + padding;
+                rowH = 0;
+            }
+            if (penY + pg.height > atlasH) {
+                return false;
+            }
+            pg.atlasX = penX;
+            pg.atlasY = penY;
+            penX += pg.width + padding;
+            rowH = std::max(rowH, pg.height);
+        }
+        return true;
+    };
+
+    int atlasW = 256;
+    int atlasH = 256;
+    bool packedOk = false;
+    for (int size = 256; size <= 2048; size *= 2) {
+        atlasW = size;
+        atlasH = size;
+        if (tryPack(atlasW, atlasH)) {
+            packedOk = true;
+            break;
+        }
+    }
+    if (!packedOk) {
+        return false;
+    }
+
+    std::vector<uint8_t> atlas((size_t)atlasW * (size_t)atlasH, 0);
+    struct GlyphJsonEntry {
+        uint32_t cp = 0;
+        int x = 0;
+        int y = 0;
+        int w = 0;
+        int h = 0;
+        int xoff = 0;
+        int yoff = 0;
+        int xadv = 0;
+    };
+    std::vector<GlyphJsonEntry> glyphEntries;
+    glyphEntries.reserve(packed.size());
+
+    for (const PackedGlyph& pg : packed) {
+        GlyphJsonEntry entry{};
+        entry.cp = pg.glyph.codepoint;
+        entry.xadv = pg.glyph.advance;
+        if (pg.width > 0 && pg.height > 0) {
+            std::vector<uint8_t> padded((size_t)pg.width * (size_t)pg.height, 0);
+            for (int y = 0; y < pg.glyph.boxH; ++y) {
+                uint8_t* dst = padded.data() + (size_t)(y + padding) * (size_t)pg.width + padding;
+                const uint8_t* src = pg.glyph.coverage.data() + (size_t)y * (size_t)pg.glyph.boxW;
+                std::copy(src, src + pg.glyph.boxW, dst);
+            }
+            if (params.type == OutputType::Sdf) {
+                std::vector<uint8_t> sdf;
+                ComputeSDF(padded, pg.width, pg.height, spread, sdf);
+                padded.swap(sdf);
+            }
+            for (int y = 0; y < pg.height; ++y) {
+                uint8_t* dst = atlas.data() + (size_t)(pg.atlasY + y) * (size_t)atlasW + (size_t)pg.atlasX;
+                const uint8_t* src = padded.data() + (size_t)y * (size_t)pg.width;
+                std::copy(src, src + pg.width, dst);
+            }
+            entry.x = pg.atlasX;
+            entry.y = pg.atlasY;
+            entry.w = pg.width;
+            entry.h = pg.height;
+            entry.xoff = pg.glyph.bearingX - padding;
+            entry.yoff = -pg.glyph.bearingY - padding;
+        }
+        glyphEntries.push_back(entry);
+    }
+
+    std::sort(glyphEntries.begin(), glyphEntries.end(), [](const GlyphJsonEntry& a, const GlyphJsonEntry& b) {
+        return a.cp < b.cp;
+    });
+
+    std::unordered_set<uint32_t> glyphSet;
+    glyphSet.reserve(glyphEntries.size());
+    for (const auto& ge : glyphEntries) {
+        glyphSet.insert(ge.cp);
+    }
+
+    // kerning pairs
+    std::vector<json> kernEntries;
+    {
+        HDC kernDC = CreateCompatibleDC(nullptr);
+        if (kernDC) {
+            HFONT kernFont = CreateFontW(fontHeight, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
+                                         DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+                                         ANTIALIASED_QUALITY, FF_DONTCARE | FIXED_PITCH,
+                                         params.fontFamily.c_str());
+            if (kernFont) {
+                HFONT old = (HFONT)SelectObject(kernDC, kernFont);
+                DWORD pairCount = GetKerningPairsW(kernDC, 0, nullptr);
+                if (pairCount > 0) {
+                    std::vector<KERNINGPAIR> pairs(pairCount);
+                    pairCount = GetKerningPairsW(kernDC, pairCount, pairs.data());
+                    for (DWORD i = 0; i < pairCount; ++i) {
+                        const auto& kp = pairs[i];
+                        const uint32_t a = kp.wFirst;
+                        const uint32_t b = kp.wSecond;
+                        if (glyphSet.find(a) == glyphSet.end() || glyphSet.find(b) == glyphSet.end()) {
+                            continue;
+                        }
+                        if (kp.iKernAmount == 0) {
+                            continue;
+                        }
+                        json jk;
+                        jk["a"] = static_cast<int>(a);
+                        jk["b"] = static_cast<int>(b);
+                        jk["k"] = kp.iKernAmount;
+                        kernEntries.push_back(std::move(jk));
+                    }
+                }
+                SelectObject(kernDC, old);
+                DeleteObject(kernFont);
+            }
+            DeleteDC(kernDC);
+        }
+    }
+
+    json root;
+    root["type"] = (params.type == OutputType::Sdf) ? "sdf" : "coverage";
+    root["pxSize"] = params.pixelHeight;
+    root["spread"] = (params.type == OutputType::Sdf) ? spread : 0;
+    root["atlasW"] = atlasW;
+    root["atlasH"] = atlasH;
+    root["ascent"] = tm.tmAscent;
+    root["descent"] = -tm.tmDescent;
+    root["lineAdvance"] = tm.tmHeight + tm.tmExternalLeading;
+
+    json glyphArray = json::array();
+    glyphArray.reserve(glyphEntries.size());
+    for (const auto& ge : glyphEntries) {
+        json jg;
+        jg["cp"] = static_cast<int>(ge.cp);
+        jg["x"] = ge.x;
+        jg["y"] = ge.y;
+        jg["w"] = ge.w;
+        jg["h"] = ge.h;
+        jg["xoff"] = ge.xoff;
+        jg["yoff"] = ge.yoff;
+        jg["xadv"] = ge.xadv;
+        glyphArray.push_back(std::move(jg));
+    }
+    root["glyphs"] = std::move(glyphArray);
+    if (!kernEntries.empty()) {
+        root["kern"] = std::move(kernEntries);
+    }
+
+    const bool okTga = WriteTGA8(texturePath, atlasW, atlasH, atlas);
+    const bool okJson = WriteJson(jsonPath, root);
+    return okTga && okJson;
+}

--- a/FontGenerator.h
+++ b/FontGenerator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+class FontGenerator {
+public:
+    enum class OutputType { Sdf, Coverage };
+
+    struct Params {
+        std::wstring fontFamily;
+        int pixelHeight = 32;
+        OutputType type = OutputType::Coverage;
+        std::wstring fontsFolder;
+    };
+
+    bool Generate(const Params& params);
+};

--- a/FontManager.cpp
+++ b/FontManager.cpp
@@ -57,9 +57,15 @@ void FontManager::LoadFromFolder(Renderer* r,
 
         auto atlas = std::make_unique<FontAtlas>();
         if (atlas->Load(r, uploadCl, uploadKeepAlive, json, tga)) {
+            const FontAtlas::Type atlasType = atlas->GetType();
             fonts_[base] = std::move(atlas);
             if (defaultName_.empty()) {
                 defaultName_ = base;
+            } else if (atlasType == FontAtlas::Type::SDF) {
+                auto itDefault = fonts_.find(defaultName_);
+                if (itDefault == fonts_.end() || itDefault->second->GetType() != FontAtlas::Type::SDF) {
+                    defaultName_ = base;
+                }
             }
         }
     } while (FindNextFileW(h, &fd));

--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -28,10 +28,9 @@ std::wstring TextManager::UTF8toW(std::string_view s) {
 }
 
 void TextManager::Init(Renderer* r) {
-    // текст (SDF)
-    {
+    auto createTextMaterial = [&](const wchar_t* shaderPath) -> std::shared_ptr<Material> {
         Material::GraphicsDesc gd;
-        gd.shaderFile = L"shaders/font_sdf.hlsl";
+        gd.shaderFile = shaderPath;
         gd.inputLayoutKey = "PosColorUV";
         gd.topologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
         gd.depth.DepthEnable = FALSE;
@@ -46,8 +45,11 @@ void TextManager::Init(Renderer* r) {
         b.DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
         b.BlendOpAlpha = D3D12_BLEND_OP_ADD;
         b.RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
-        matText_ = r->GetMaterialManager()->GetOrCreateGraphics(r, gd);
-    }
+        return r->GetMaterialManager()->GetOrCreateGraphics(r, gd);
+    };
+
+    matTextSdf_ = createTextMaterial(L"shaders/font_sdf.hlsl");
+    matTextCoverage_ = createTextMaterial(L"shaders/font_pixelperfect.hlsl");
     // прямоугольник (фон)
     {
         Material::GraphicsDesc gd;
@@ -293,7 +295,7 @@ void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
     }
 
     // 2) текст
-    if (!verts_.empty() && !idx_.empty() && matText_) {
+    if (!verts_.empty() && !idx_.empty() && font_) {
         auto h = r->GetRenderContextPool()->Acquire();
         auto& rc = h.ref();
 
@@ -308,10 +310,16 @@ void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
         k[5] = f2u((float)font_->PxSize());
         rc.constants[1] = { k.begin(), k.end() };
 
-        const auto samplerDescs = std::array{ SamplerManager::LinearClamp() };
-        rc.samplerTable[0] = r->GetSamplerManager()->GetTable(r, samplerDescs);
+        const bool useCoverage = font_->IsCoverage();
+        const D3D12_SAMPLER_DESC samplerDesc = useCoverage ? SamplerManager::PointClamp() : SamplerManager::LinearClamp();
+        rc.samplerTable[0] = r->GetSamplerManager()->GetTable(r, samplerDesc);
 
-        matText_->Bind(cl, rc);
+        const std::shared_ptr<Material>& mat = useCoverage ? matTextCoverage_ : matTextSdf_;
+        if (!mat) {
+            return;
+        }
+
+        mat->Bind(cl, rc);
         cl->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
         cl->IASetVertexBuffers(0, 1, &vbv_);
         cl->IASetIndexBuffer(&ibv_);
@@ -320,7 +328,9 @@ void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
 }
 
 void TextManager::Clear() {
-    matText_.reset(); matRect_.reset();
+    matTextSdf_.reset();
+    matTextCoverage_.reset();
+    matRect_.reset();
     verts_.clear(); idx_.clear();
     rectVerts_.clear(); rectIdx_.clear();
     RecycleRegionLines();

--- a/TextManager.h
+++ b/TextManager.h
@@ -193,7 +193,8 @@ private:
 private:
     FontAtlas* font_ = nullptr;
 
-    std::shared_ptr<Material> matText_;
+    std::shared_ptr<Material> matTextSdf_;
+    std::shared_ptr<Material> matTextCoverage_;
     std::shared_ptr<Material> matRect_;
 
     GrowOnlyArray<Vertex>    verts_;

--- a/shaders/font_pixelperfect.hlsl
+++ b/shaders/font_pixelperfect.hlsl
@@ -1,0 +1,30 @@
+// RootSignature: CONSTANTS(b1,count=8) TABLE(SRV(t0)) TABLE(SAMPLER(s0))
+
+struct VSIn { float3 pos:POSITION; float4 col:COLOR; float2 uv:TEXCOORD; };
+struct VSOut{ float4 pos:SV_Position; float4 col:COLOR;  float2 uv:TEXCOORD; };
+
+cbuffer PC : register(b1)
+{
+    float2 viewport; float2 _pad0;
+    float spread; float pxSize; float2 _pad1;
+};
+
+VSOut VSMain(VSIn i) {
+    VSOut o;
+    float2 p = float2(i.pos.x + 0.5, i.pos.y + 0.5);
+    float2 ndc = float2((p.x / viewport.x) * 2.0 - 1.0,
+                         1.0 - (p.y / viewport.y) * 2.0);
+    o.pos = float4(ndc, 0.0, 1.0);
+    o.col = i.col;
+    o.uv = i.uv;
+    return o;
+}
+
+Texture2D tex0 : register(t0);
+SamplerState samp0 : register(s0);
+
+float4 PSMain(VSOut i) : SV_Target {
+    float coverage = tex0.Sample(samp0, i.uv).r;
+    float alpha = coverage >= 0.5 ? 1.0 : 0.0;
+    return float4(i.col.rgb, i.col.a * alpha);
+}

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -89,6 +89,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -103,6 +104,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -120,7 +122,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>mimalloc.lib;tbb12_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mimalloc.lib;tbb12_debug.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)third_party\tbb\lib;$(ProjectDir)third_party\mimalloc\lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
@@ -146,7 +148,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(ProjectDir)third_party\tbb\lib;$(ProjectDir)third_party\mimalloc\lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>mimalloc.lib;tbb12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mimalloc.lib;tbb12.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -155,6 +157,7 @@
     <ClCompile Include="Camera.cpp" />
     <ClCompile Include="DebugGrid.cpp" />
     <ClCompile Include="FontAtlas.cpp" />
+    <ClCompile Include="FontGenerator.cpp" />
     <ClCompile Include="FontManager.cpp" />
     <ClCompile Include="FrameResource.cpp" />
     <ClCompile Include="GBufferRenderable.cpp" />
@@ -198,6 +201,7 @@
     <ClInclude Include="DescriptorAllocator.h" />
     <ClInclude Include="DescriptorHeapGPU.h" />
     <ClInclude Include="FontAtlas.h" />
+    <ClInclude Include="FontGenerator.h" />
     <ClInclude Include="FontManager.h" />
     <ClInclude Include="FrameResource.h" />
     <ClInclude Include="GBufferRenderable.h" />
@@ -249,6 +253,9 @@
       <FileType>Document</FileType>
     </Text>
     <Text Include="shaders\font_sdf.hlsl">
+      <FileType>Document</FileType>
+    </Text>
+    <Text Include="shaders\font_pixelperfect.hlsl">
       <FileType>Document</FileType>
     </Text>
     <Text Include="shaders\gbuffer.hlsl">

--- a/test_cube.vcxproj.filters
+++ b/test_cube.vcxproj.filters
@@ -84,6 +84,9 @@
     <ClCompile Include="FontAtlas.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="FontGenerator.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="FrameResource.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -248,6 +251,9 @@
     <ClInclude Include="FontAtlas.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FontGenerator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="FontManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -293,6 +299,9 @@
       <Filter>Shaders</Filter>
     </Text>
     <Text Include="shaders\font_sdf.hlsl">
+      <Filter>Shaders</Filter>
+    </Text>
+    <Text Include="shaders\font_pixelperfect.hlsl">
       <Filter>Shaders</Filter>
     </Text>
     <Text Include="shaders\gbuffer.hlsl">


### PR DESCRIPTION
## Summary
- derive the JSON and texture output paths inside FontGenerator using the configured fonts folder
- simplify the F8 hook so it only supplies the font family, size, type, and output directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbbc0701388329ae494ae91e4d2ca8