### PR TITLE
Prebake sampler descriptors and streamline CB handles

### DIFF
--- a/GpuInstancedModels.cpp
+++ b/GpuInstancedModels.cpp
@@ -91,8 +91,8 @@ void GpuInstancedModels::PopulateContext(Renderer* renderer, ID3D12GraphicsComma
     auto tbl = renderer->StageSrvUavTable(srvs);
     ctx.table[0] = tbl.gpu;
 
-    auto aniso = SamplerManager::AnisoWrap(16);
-    ctx.samplerTable[0] = renderer->GetSamplerManager()->Get(renderer, aniso);
+    const D3D12_SAMPLER_DESC* aniso = SamplerManager::AnisoWrap(16);
+    ctx.samplerTable[0] = renderer->GetSamplerManager()->Get(renderer, *aniso);
 }
 
 void GpuInstancedModels::RecordGraphics(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx)

--- a/Material.cpp
+++ b/Material.cpp
@@ -951,19 +951,27 @@ bool Material::GetCBFieldOffset(UINT bRegister, const std::string& name, UINT& o
 Material::CBFieldHandle Material::ComputeCBFieldHandle(UINT bRegister, const std::string& name) const
 {
     CBFieldHandle handle{};
-    handle.destCBSizeBytes = GetCBSizeBytes(bRegister);
-    if (handle.destCBSizeBytes == 0) {
+    const CBufferInfo* cbInfo = GetCBInfo(bRegister);
+    if (!cbInfo) {
+        handle.destCBSizeBytes = 0;
         assert(false && "Bad constant buffer register!");
         return handle;
     }
 
-    if (!GetCBFieldInfo(bRegister, name, handle.field)) {
-        //assert(false && "Bad uniform name!");
+    handle.destCBSizeBytes = cbInfo->sizeBytes;
+    auto it = cbInfo->fieldsByName.find(name);
+    if (it == cbInfo->fieldsByName.end()) {
         handle.destCBSizeBytes = 0;
         return handle;
     }
 
-    handle.isValid = true;
+    CBufferField& field = it->second;
+    if (field.elementStride == 0) {
+        field.elementStride = (field.size > 0 ? field.size : 16);
+        field.elementCount = 1;
+    }
+
+    handle.field = &field;
     return handle;
 }
 

--- a/Material.h
+++ b/Material.h
@@ -133,9 +133,8 @@ public:
     };
 
     struct CBFieldHandle {
-        CBufferField field{};
+        const CBufferField* field = nullptr;
         UINT destCBSizeBytes = 0;
-        bool isValid = false;
     };
 
     const CBufferInfo* GetCBInfo(UINT bRegister) const;
@@ -173,9 +172,9 @@ public:
         std::optional<UINT> arrayIdxParam = std::nullopt)
     {
         if (!destCB) { return false; }
-        if (!handle.isValid) { return false; }
+        if (!handle.field) { return false; }
 
-        return CopyData(handle.field, value, destCB, handle.destCBSizeBytes, arrayIdxParam ? *arrayIdxParam : 0);
+        return CopyData(*handle.field, value, destCB, handle.destCBSizeBytes, arrayIdxParam ? *arrayIdxParam : 0);
     }
 
 private:

--- a/MaterialData.cpp
+++ b/MaterialData.cpp
@@ -84,6 +84,6 @@ void MaterialData::StageGBufferBindings(Renderer* r, RenderContext& ctx,
             gbufferSrvCache_.gpu = tbl.gpu;
         }
     }
-    auto aniso = SamplerManager::AnisoWrap(16);
-    ctx.samplerTable[samplerTableRegister] = r->GetSamplerManager()->Get(r, aniso);
+    const D3D12_SAMPLER_DESC* aniso = SamplerManager::AnisoWrap(16);
+    ctx.samplerTable[samplerTableRegister] = r->GetSamplerManager()->Get(r, *aniso);
 }

--- a/OceanRenderable.cpp
+++ b/OceanRenderable.cpp
@@ -362,7 +362,7 @@ void OceanRenderable::PopulateContext(Renderer* renderer, ID3D12GraphicsCommandL
     auto tbl = renderer->StageSrvUavTable({ simulation_->GetDisplacementSRV() });
     ctx.table[0] = tbl.gpu;
 
-    const auto samplers = std::array{ SamplerManager::LinearWrap() };
+    const auto samplers = std::array{ *SamplerManager::LinearWrap() };
     ctx.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplers);
 }
 

--- a/PointLight.cpp
+++ b/PointLight.cpp
@@ -174,7 +174,7 @@ void PointLight::RenderColor(Renderer* r, ID3D12GraphicsCommandList* cl,
     rc.cbv[0] = cb0.gpu;
     rc.cbv[1] = cb1.gpu;
     rc.table[0] = tbl;
-    const auto samplerDescs = std::array{ SamplerManager::LinearClamp(), SamplerManager::PointClamp() };
+    const auto samplerDescs = std::array{ *SamplerManager::LinearClamp(), *SamplerManager::PointClamp() };
     rc.samplerTable[0] = r->GetSamplerManager()->GetTable(r, samplerDescs);
 
     cl->OMSetStencilRef(0);

--- a/RenderableObject.h
+++ b/RenderableObject.h
@@ -80,7 +80,7 @@ protected:
     {
         if (!cbData) { return false; }
         if (!material) { return false; }
-        if (!handle.isValid) { return false; }
+        if (!handle.field) { return false; }
         return material->UpdateCBField(handle, value, cbData);
     }
 

--- a/SamplerManager.cpp
+++ b/SamplerManager.cpp
@@ -2,6 +2,8 @@
 #include "Renderer.h"
 #include "DescriptorAllocator.h" // для DescriptorAllocatorSampler
 
+#include <array>
+
 using Microsoft::WRL::ComPtr;
 
 void SamplerManager::Init(ID3D12Device* device, UINT capacity) {
@@ -92,65 +94,140 @@ void SamplerManager::Clear()
     cpuHeap_.Reset();
 }
 
+namespace {
+
+enum class SamplerPresetIndex : size_t {
+    LinearWrap = 0,
+    LinearClamp,
+    PointClamp,
+    FontMinPointMagLinearClamp,
+    ComparisonLinearClamp,
+    AnisoWrap4,
+    AnisoWrap8,
+    AnisoWrap16,
+    Count
+};
+
+struct PrebakedSamplers {
+    std::array<D3D12_SAMPLER_DESC,
+               static_cast<size_t>(SamplerPresetIndex::Count)> descs{};
+
+    PrebakedSamplers() {
+        auto makeLinear = [](D3D12_TEXTURE_ADDRESS_MODE mode) {
+            D3D12_SAMPLER_DESC s{};
+            s.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+            s.AddressU = s.AddressV = s.AddressW = mode;
+            s.MinLOD = 0.0f;
+            s.MaxLOD = D3D12_FLOAT32_MAX;
+            s.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+            s.MaxAnisotropy = 1;
+            return s;
+        };
+
+        auto makePointClamp = []() {
+            D3D12_SAMPLER_DESC s{};
+            s.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+            s.AddressU = s.AddressV = s.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+            s.MinLOD = 0.0f;
+            s.MaxLOD = D3D12_FLOAT32_MAX;
+            s.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+            s.MaxAnisotropy = 1;
+            return s;
+        };
+
+        auto makeFont = []() {
+            D3D12_SAMPLER_DESC d{};
+            d.Filter = D3D12_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
+            d.AddressU = d.AddressV = d.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+            d.MipLODBias = 0.0f;
+            d.MaxAnisotropy = 1;
+            d.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+            d.MinLOD = 0.0f;
+            d.MaxLOD = D3D12_FLOAT32_MAX;
+            return d;
+        };
+
+        auto makeComparisonLinearClamp = []() {
+            D3D12_SAMPLER_DESC d{};
+            d.Filter = D3D12_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
+            d.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+            d.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+            d.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+            d.ComparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
+            d.MipLODBias = 0.0f;
+            d.MaxAnisotropy = 1;
+            d.MinLOD = 0.0f;
+            d.MaxLOD = 0.0f;
+            d.BorderColor[0] = d.BorderColor[1] = d.BorderColor[2] = d.BorderColor[3] = 1.0f;
+            return d;
+        };
+
+        auto makeAnisoWrap = [](UINT aniso) {
+            D3D12_SAMPLER_DESC s{};
+            s.Filter = D3D12_FILTER_ANISOTROPIC;
+            s.AddressU = s.AddressV = s.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+            s.MinLOD = 0.0f;
+            s.MaxLOD = D3D12_FLOAT32_MAX;
+            s.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+            s.MaxAnisotropy = aniso;
+            return s;
+        };
+
+        descs[static_cast<size_t>(SamplerPresetIndex::LinearWrap)] =
+            makeLinear(D3D12_TEXTURE_ADDRESS_MODE_WRAP);
+        descs[static_cast<size_t>(SamplerPresetIndex::LinearClamp)] =
+            makeLinear(D3D12_TEXTURE_ADDRESS_MODE_CLAMP);
+        descs[static_cast<size_t>(SamplerPresetIndex::PointClamp)] = makePointClamp();
+        descs[static_cast<size_t>(SamplerPresetIndex::FontMinPointMagLinearClamp)] = makeFont();
+        descs[static_cast<size_t>(SamplerPresetIndex::ComparisonLinearClamp)] =
+            makeComparisonLinearClamp();
+
+        descs[static_cast<size_t>(SamplerPresetIndex::AnisoWrap4)] = makeAnisoWrap(4);
+        descs[static_cast<size_t>(SamplerPresetIndex::AnisoWrap8)] = makeAnisoWrap(8);
+        descs[static_cast<size_t>(SamplerPresetIndex::AnisoWrap16)] = makeAnisoWrap(16);
+    }
+};
+
+const PrebakedSamplers& GetPrebakedSamplers() {
+    static const PrebakedSamplers samplers;
+    return samplers;
+}
+
+const D3D12_SAMPLER_DESC* ResolveSampler(SamplerPresetIndex preset) {
+    const auto& samplers = GetPrebakedSamplers().descs;
+    return &samplers[static_cast<size_t>(preset)];
+}
+
+} // namespace
+
 // Presets
-D3D12_SAMPLER_DESC SamplerManager::LinearWrap() {
-    D3D12_SAMPLER_DESC s{};
-    s.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-    s.AddressU = s.AddressV = s.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-    s.MinLOD = 0.0f; s.MaxLOD = D3D12_FLOAT32_MAX;
-    s.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-    s.MaxAnisotropy = 1;
-    return s;
+const D3D12_SAMPLER_DESC* SamplerManager::LinearWrap() {
+    return ResolveSampler(SamplerPresetIndex::LinearWrap);
 }
-D3D12_SAMPLER_DESC SamplerManager::LinearClamp() {
-    D3D12_SAMPLER_DESC s{};
-    s.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-    s.AddressU = s.AddressV = s.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    s.MinLOD = 0.0f; s.MaxLOD = D3D12_FLOAT32_MAX;
-    s.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-    s.MaxAnisotropy = 1;
-    return s;
+
+const D3D12_SAMPLER_DESC* SamplerManager::LinearClamp() {
+    return ResolveSampler(SamplerPresetIndex::LinearClamp);
 }
-D3D12_SAMPLER_DESC SamplerManager::PointClamp() {
-    D3D12_SAMPLER_DESC s{};
-    s.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-    s.AddressU = s.AddressV = s.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    s.MinLOD = 0.0f; s.MaxLOD = D3D12_FLOAT32_MAX;
-    s.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-    s.MaxAnisotropy = 1;
-    return s;
+
+const D3D12_SAMPLER_DESC* SamplerManager::PointClamp() {
+    return ResolveSampler(SamplerPresetIndex::PointClamp);
 }
-D3D12_SAMPLER_DESC SamplerManager::AnisoWrap(UINT aniso) {
-    D3D12_SAMPLER_DESC s{};
-    s.Filter = D3D12_FILTER_ANISOTROPIC;
-    s.AddressU = s.AddressV = s.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-    s.MinLOD = 0.0f; s.MaxLOD = D3D12_FLOAT32_MAX;
-    s.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-    s.MaxAnisotropy = aniso ? aniso : 8;
-    return s;
+
+const D3D12_SAMPLER_DESC* SamplerManager::AnisoWrap(UINT aniso) {
+    const UINT requested = aniso == 0 ? 8u : aniso;
+    if (requested <= 4) {
+        return ResolveSampler(SamplerPresetIndex::AnisoWrap4);
+    }
+    if (requested <= 8) {
+        return ResolveSampler(SamplerPresetIndex::AnisoWrap8);
+    }
+    return ResolveSampler(SamplerPresetIndex::AnisoWrap16);
 }
-D3D12_SAMPLER_DESC SamplerManager::FontMinPointMagLinearClamp() {
-    D3D12_SAMPLER_DESC d = {};
-    d.Filter = D3D12_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
-    d.AddressU = d.AddressV = d.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    d.MipLODBias = 0.0f;
-    d.MaxAnisotropy = 1;
-    d.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-    d.MinLOD = 0.0f;
-    d.MaxLOD = D3D12_FLOAT32_MAX;
-    return d;
+
+const D3D12_SAMPLER_DESC* SamplerManager::FontMinPointMagLinearClamp() {
+    return ResolveSampler(SamplerPresetIndex::FontMinPointMagLinearClamp);
 }
-D3D12_SAMPLER_DESC SamplerManager::ComparisonLinearClamp() {
-    D3D12_SAMPLER_DESC d{};
-    d.Filter = D3D12_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT; // или POINT
-    d.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    d.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    d.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    d.ComparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
-    d.MipLODBias = 0.0f;
-    d.MaxAnisotropy = 1;
-    d.MinLOD = 0.0f;
-    d.MaxLOD = 0.0f;   // будем звать SampleCmpLevelZero
-    d.BorderColor[0] = d.BorderColor[1] = d.BorderColor[2] = d.BorderColor[3] = 1.0f;
-    return d;
+
+const D3D12_SAMPLER_DESC* SamplerManager::ComparisonLinearClamp() {
+    return ResolveSampler(SamplerPresetIndex::ComparisonLinearClamp);
 }

--- a/SamplerManager.h
+++ b/SamplerManager.h
@@ -54,12 +54,12 @@ public:
     void Clear();
 
     // Быстрые пресеты
-    static D3D12_SAMPLER_DESC LinearWrap();
-    static D3D12_SAMPLER_DESC LinearClamp();
-    static D3D12_SAMPLER_DESC PointClamp();
-    static D3D12_SAMPLER_DESC FontMinPointMagLinearClamp();
-    static D3D12_SAMPLER_DESC AnisoWrap(UINT aniso = 8);
-    static D3D12_SAMPLER_DESC ComparisonLinearClamp();
+    static const D3D12_SAMPLER_DESC* LinearWrap();
+    static const D3D12_SAMPLER_DESC* LinearClamp();
+    static const D3D12_SAMPLER_DESC* PointClamp();
+    static const D3D12_SAMPLER_DESC* FontMinPointMagLinearClamp();
+    static const D3D12_SAMPLER_DESC* AnisoWrap(UINT aniso = 8);
+    static const D3D12_SAMPLER_DESC* ComparisonLinearClamp();
 
 private:
     struct Entry {

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -853,7 +853,7 @@ void Scene::Pass_Lighting(Renderer* renderer, RenderGraph::PassContext ctx,
         srvs.push_back(D.gbSRV[3]);
         srvs.push_back(D.shadowSRV); // NEW
         rc.table[0] = renderer->StageSrvUavTable(srvs).gpu;
-        const auto samplerDescs = std::array{ SamplerManager::PointClamp(), SamplerManager::ComparisonLinearClamp() };
+        const auto samplerDescs = std::array{ *SamplerManager::PointClamp(), *SamplerManager::ComparisonLinearClamp() };
         rc.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplerDescs);
 
         matLighting_->Bind(t.cl, rc);
@@ -959,7 +959,7 @@ void Scene::Pass_SSR(Renderer* renderer, RenderGraph::PassContext ctx,
 
         rc.cbv[0] = cb.gpu;
         rc.table[0] = renderer->StageSrvUavTable({ D.lightSRV, D.gbSRV[1], D.gbSRV[3] }).gpu; // t0 Light, t1 GB1, t2 Depth
-        const auto samplerDescs = std::array{ SamplerManager::LinearClamp(), SamplerManager::PointClamp() };
+        const auto samplerDescs = std::array{ *SamplerManager::LinearClamp(), *SamplerManager::PointClamp() };
         rc.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplerDescs);
 
         matSSR_->Bind(t.cl, rc);
@@ -992,7 +992,7 @@ void Scene::Pass_SSR_Blur(Renderer* renderer, RenderGraph::PassContext ctx)
 
         rc.cbv[0] = cb.gpu;
         rc.table[0] = renderer->StageSrvUavTable({ D.ssrSRV }).gpu;
-        const auto samplerDescsX = std::array{ SamplerManager::LinearClamp() };
+        const auto samplerDescsX = std::array{ *SamplerManager::LinearClamp() };
         rc.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplerDescsX);
 
         matBlur_->Bind(t.cl, rc);
@@ -1012,7 +1012,7 @@ void Scene::Pass_SSR_Blur(Renderer* renderer, RenderGraph::PassContext ctx)
 
         rc.cbv[0] = cb.gpu;
         rc.table[0] = renderer->StageSrvUavTable({ D.ssrBlurSRV }).gpu;
-        const auto samplerDescsY = std::array{ SamplerManager::LinearClamp() };
+        const auto samplerDescsY = std::array{ *SamplerManager::LinearClamp() };
         rc.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplerDescsY);
 
         matBlur_->Bind(t.cl, rc);
@@ -1067,7 +1067,7 @@ void Scene::Pass_Compose(Renderer* renderer, RenderGraph::PassContext ctx,
 
         rc.cbv[0] = cb.gpu; // b0
         rc.table[0] = renderer->StageSrvUavTable(srvs).gpu;
-        const auto samplerDescs = std::array{ SamplerManager::LinearClamp(), SamplerManager::PointClamp() };
+        const auto samplerDescs = std::array{ *SamplerManager::LinearClamp(), *SamplerManager::PointClamp() };
         rc.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplerDescs);
 
         matCompose_->Bind(t.cl, rc);
@@ -1130,7 +1130,7 @@ void Scene::Pass_Tonemap(Renderer* renderer, RenderGraph::PassContext ctx)
         auto& rc = h.ref();
 
         rc.table[0] = renderer->StageTonemapSrvTable(); // t0
-        const auto tonemapSamplers = std::array{ SamplerManager::LinearClamp() };
+        const auto tonemapSamplers = std::array{ *SamplerManager::LinearClamp() };
         rc.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, tonemapSamplers);
 
         matTonemap_->Bind(t.cl, rc);
@@ -1158,7 +1158,7 @@ void Scene::Pass_Debug(Renderer* renderer, RenderGraph::PassContext ctx)
         auto& rc = h.ref();
 
         rc.table[0] = renderer->StageSrvUavTable({ D.shadowSRV }).gpu; // t0
-        const auto debugSamplers = std::array{ SamplerManager::LinearClamp() };
+        const auto debugSamplers = std::array{ *SamplerManager::LinearClamp() };
         rc.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, debugSamplers);
 
         matDebug_->Bind(t.cl, rc);

--- a/Skybox.cpp
+++ b/Skybox.cpp
@@ -81,7 +81,7 @@ void Skybox::Init(Renderer* renderer,
 void Skybox::PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx)
 {
     ctx.table[0] = cube_.GetSRVForFrame(renderer);
-    ctx.samplerTable[0] = renderer->GetSamplerManager()->Get(renderer, SamplerManager::LinearClamp());
+    ctx.samplerTable[0] = renderer->GetSamplerManager()->Get(renderer, *SamplerManager::LinearClamp());
 }
 
 void Skybox::BuildCubeMesh_(Renderer* r,

--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -355,7 +355,7 @@ void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
         rc.constants[1] = { k.begin(), k.end() };
 
         const bool useCoverage = font_->IsCoverage();
-        const D3D12_SAMPLER_DESC samplerDesc = useCoverage ? SamplerManager::PointClamp() : SamplerManager::LinearClamp();
+        const D3D12_SAMPLER_DESC samplerDesc = useCoverage ? *SamplerManager::PointClamp() : *SamplerManager::LinearClamp();
         rc.samplerTable[0] = r->GetSamplerManager()->GetTable(r, samplerDesc);
 
         const std::shared_ptr<Material>& mat = useCoverage ? matTextCoverage_ : matTextSdf_;


### PR DESCRIPTION
## Summary
- pre-generate commonly used sampler descriptors and expose them through pointer-returning helpers
- update call sites to consume the shared sampler presets
- shrink constant buffer field handles to reference cached metadata instead of copying it
- limit prebaked anisotropic sampler presets to 4x/8x/16x variants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc28620a1083299a2a0a750c019066