### PR TITLE
Normalize float packing across ocean and instancing

### DIFF
--- a/GpuInstancedModels.cpp
+++ b/GpuInstancedModels.cpp
@@ -7,6 +7,7 @@
 #include "Renderer.h"
 #include "Helpers.h"
 #include "SamplerManager.h"
+#include "Math.h"
 
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;
@@ -63,9 +64,8 @@ void GpuInstancedModels::RecordCompute(Renderer* renderer, ID3D12GraphicsCommand
     auto& ctx = h.ref();
 
     // constants(b0) для CS
-    uint32_t dtBits = 0, angBits = 0;
-    memcpy(&dtBits, &deltaTime_, sizeof(float));
-    memcpy(&angBits, &angularSpeed_, sizeof(float));
+    const uint32_t dtBits = Math::FloatToUint32(deltaTime_);
+    const uint32_t angBits = Math::FloatToUint32(angularSpeed_);
     ctx.constants[0] = { dtBits, angBits, instanceCount_ };
 
     // таблица UAV/SRV для CS: u0 = instanceBuffer UAV

--- a/Math.h
+++ b/Math.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <DirectXMath.h>
 
 namespace Math
@@ -37,6 +38,13 @@ namespace Math
         if (t >= 1.0f) { return b; }
         const float x = t * t * (3.0f - 2.0f * t);
         return a + (b - a) * x;
+    }
+
+    inline uint32_t FloatToUint32(float value) {
+        static_assert(sizeof(uint32_t) == sizeof(float), "FloatToUint32 requires 32-bit float");
+        uint32_t result;
+        std::memcpy(&result, &value, sizeof(result));
+        return result;
     }
 
     inline float Step(float edge, float x) { return x < edge ? 0.0f : 1.0f; }

--- a/OceanSimulation.cpp
+++ b/OceanSimulation.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 #include <random>
 
 #include "Helpers.h"
@@ -297,13 +296,6 @@ float OceanSimulation::ComputeCascadeContribution(float kLength, UINT cascade) c
     }
 
     return 1.0f / total;
-}
-
-uint32_t OceanSimulation::FloatToBits(float value)
-{
-    uint32_t bits = 0u;
-    std::memcpy(&bits, &value, sizeof(uint32_t));
-    return bits;
 }
 
 void OceanSimulation::Initialize(Renderer* renderer,
@@ -696,7 +688,7 @@ void OceanSimulation::DispatchSpectrum(Renderer* renderer, ID3D12GraphicsCommand
     ctx.constants[0] = {
         resolution_,
         cascadeCount_,
-        FloatToBits(timeSeconds),
+        Math::FloatToUint32(timeSeconds),
         resolution_ * resolution_
     };
 

--- a/OceanSimulation.h
+++ b/OceanSimulation.h
@@ -65,8 +65,6 @@ private:
     void InitializeDefaultAssets();
     void ReleaseCpuData();
 
-    static uint32_t FloatToBits(float value);
-
 private:
     bool initialized_ = false;
 

--- a/TextManager.cpp
+++ b/TextManager.cpp
@@ -316,9 +316,8 @@ void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
         auto& rc = h.ref();
 
         std::array<uint32_t, 8> k{};
-        auto f2u = [](float f)->uint32_t { uint32_t u; std::memcpy(&u, &f, 4u); return u; };
-        k[0] = f2u((float)vpW_);
-        k[1] = f2u((float)vpH_);
+        k[0] = static_cast<uint32_t>(vpW_);
+        k[1] = static_cast<uint32_t>(vpH_);
         rc.constants[1] = { k.begin(), k.end() };
 
         matRect_->Bind(cl, rc);
@@ -349,16 +348,15 @@ void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
         cl->IASetVertexBuffers(0, 1, &vbv_);
         cl->IASetIndexBuffer(&ibv_);
 
-        auto f2u = [](float f)->uint32_t { uint32_t u; std::memcpy(&u, &f, 4u); return u; };
         std::array<uint32_t, 8> k{};
-        k[0] = f2u((float)vpW_);
-        k[1] = f2u((float)vpH_);
+        k[0] = static_cast<uint32_t>(vpW_);
+        k[1] = static_cast<uint32_t>(vpH_);
         const float invAtlasW = (font_->AtlasWidth() > 0) ? (1.0f / float(font_->AtlasWidth())) : 0.0f;
         const float invAtlasH = (font_->AtlasHeight() > 0) ? (1.0f / float(font_->AtlasHeight())) : 0.0f;
-        k[2] = f2u(invAtlasW);
-        k[3] = f2u(invAtlasH);
-        k[4] = f2u((float)font_->Spread());
-        k[5] = f2u((float)font_->PxSize());
+        k[2] = Math::FloatToUint32(invAtlasW);
+        k[3] = Math::FloatToUint32(invAtlasH);
+        k[4] = static_cast<uint32_t>(font_->Spread());
+        k[5] = static_cast<uint32_t>(font_->PxSize());
         rc.constants[1] = { k.begin(), k.end() };
 
         mat->Bind(cl, rc);


### PR DESCRIPTION
## Summary
- reuse the Math::FloatToUint32 helper when populating ocean spectrum constants
- switch instanced models to use the helper instead of manual memcpy
- avoid routing integer values through float conversion when filling text constants

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd48e41bc88329b70b31a7496fd924