### PR TITLE
Release profiler GPU resources during renderer shutdown

### DIFF
--- a/Profiler.cpp
+++ b/Profiler.cpp
@@ -990,6 +990,30 @@ void Profiler::EndGpuSample(ID3D12GraphicsCommandList* cl, size_t idx) {
     (void)cl; (void)idx;
 #endif
 }
+
+void Profiler::ShutdownGpu() {
+#if PROF_ENABLED
+    if (!gpuInitialized_) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(gpuMtx_);
+        gpuPending_.clear();
+        gpuResolved_.clear();
+    }
+
+    gpuFrameSampleIdx_.store(SIZE_MAX, std::memory_order_relaxed);
+    gpuQueryHeap_.Reset();
+    gpuReadback_.Reset();
+    gpuQueue_ = nullptr;
+    gpuFreq_ = 0;
+    maxGpuQueries_ = 0;
+    nextGpuQuery_ = 0;
+    lastGpuQueryCount_ = 0;
+    gpuInitialized_ = false;
+#endif
+}
 #endif // PROF_GPU_ENABLED
 
 void Profiler::EmitOverlay(TextManager* tm, int x, int y, int maxLines) {

--- a/Profiler.h
+++ b/Profiler.h
@@ -243,6 +243,7 @@ private:
     void PushGpuSample(const ScopeNameKey& key, double ms);
     size_t BeginGpuSample(ID3D12GraphicsCommandList* cl, const ScopeNameKey& key);
     void EndGpuSample(ID3D12GraphicsCommandList* cl, size_t idx);
+    void ShutdownGpu();
 #endif
 
 #if PROF_ENABLED

--- a/Renderer.cpp
+++ b/Renderer.cpp
@@ -49,6 +49,10 @@ void Renderer::Shutdown()
         WaitForPreviousFrame(); // твой метод полной синхронизации :contentReference[oaicite:2]{index=2}
     }
 
+#if PROF_GPU_ENABLED
+    Profiler::Get().ShutdownGpu();
+#endif
+
     materialManager_.Clear();
     materialDataManager_.ClearAll();
     meshManager_.Clear();


### PR DESCRIPTION
## Summary
- add a Profiler::ShutdownGpu helper to release timestamp query resources
- invoke the helper during Renderer shutdown to drop live D3D12 objects before destroying the device

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd744216ac8329b8e16c8963854f1c