### PR TITLE
Adjust PostTick scheduling and StaticMesh rotation API

### DIFF
--- a/sources/app/Scene.cpp
+++ b/sources/app/Scene.cpp
@@ -338,21 +338,32 @@ void Scene::Tick(float deltaTime) {
             showProfiler_ = !showProfiler_;
         }
     }
-    auto& tasks = TaskSystem::Get();
-
 #if TASKSYSTEM_ENABLE_PARALLEL_EXECUTION
     size_t batchSize = 32;
     TaskSystem::ParallelFor(objects_.size(),
         [this, deltaTime](size_t index) {
             if (index >= objects_.size()) {
                 return;
-			}
+            }
             objects_[index]->Tick(deltaTime);
-		}, batchSize);
+        }, batchSize);
+
+    TaskSystem::ParallelFor(objects_.size(),
+        [this, deltaTime](size_t index) {
+            if (index >= objects_.size()) {
+                return;
+            }
+            objects_[index]->PostTick(deltaTime);
+        }, batchSize);
 #else
     for (auto& obj : objects_)
     {
         obj->Tick(deltaTime);
+    }
+
+    for (auto& obj : objects_)
+    {
+        obj->PostTick(deltaTime);
     }
 #endif
 }

--- a/sources/rendering/meshes/StaticMesh.cpp
+++ b/sources/rendering/meshes/StaticMesh.cpp
@@ -1,6 +1,14 @@
-﻿#include "rendering/meshes/StaticMesh.h"
+#include "rendering/meshes/StaticMesh.h"
 
 using namespace Math;
+
+namespace
+{
+    bool NearlyEqualFloat3(const float3& a, const float3& b)
+    {
+        return Math::NearlyEqual(a.x, b.x) && Math::NearlyEqual(a.y, b.y) && Math::NearlyEqual(a.z, b.z);
+    }
+}
 
 StaticMesh::StaticMesh(const std::string& modelName,
     const std::string& matPreset,
@@ -10,9 +18,9 @@ StaticMesh::StaticMesh(const std::string& modelName,
     modelName_(modelName)
 {
     pos_ = float3(0.0f, 0.0f, 0.0f);
-    rot_ = mat4::Identity();
+    rotEuler_ = float3(0.0f, 0.0f, 0.0f);
     scale_ = float3(1);
-    RebuildModel();
+    transformDirty_ = true;
 }
 
 void StaticMesh::Init(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList, std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive)
@@ -26,20 +34,32 @@ void StaticMesh::Init(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdLi
 
 void StaticMesh::SetPosition(const float3& p)
 {
+    if (NearlyEqualFloat3(pos_, p))
+    {
+        return;
+    }
     pos_ = p;
-    RebuildModel();
+    MarkTransformDirty();
 }
 
 void StaticMesh::SetScale(const float3& s)
 {
+    if (NearlyEqualFloat3(scale_, s))
+    {
+        return;
+    }
     scale_ = s;
-    RebuildModel();
+    MarkTransformDirty();
 }
 
 void StaticMesh::SetRotationEulerRad(const float3& eulerXYZ)
 {
-    rot_ = mat4::RotationFromEulerXYZRad(eulerXYZ); // Rx * Ry * Rz
-    RebuildModel();
+    if (NearlyEqualFloat3(rotEuler_, eulerXYZ))
+    {
+        return;
+    }
+    rotEuler_ = eulerXYZ;
+    MarkTransformDirty();
 }
 
 void StaticMesh::SetRotationEulerDeg(const float3& eulerDegXYZ)
@@ -48,16 +68,27 @@ void StaticMesh::SetRotationEulerDeg(const float3& eulerDegXYZ)
     SetRotationEulerRad(float3(eulerDegXYZ.x * k, eulerDegXYZ.y * k, eulerDegXYZ.z * k));
 }
 
-void StaticMesh::SetOrientationMatrix(const mat4& rotation3x3In4x4)
+void StaticMesh::PostTick(float /*deltaTime*/)
 {
-    rot_ = rotation3x3In4x4;
+    if (!transformDirty_)
+    {
+        return;
+    }
+
     RebuildModel();
+    transformDirty_ = false;
 }
 
 void StaticMesh::RebuildModel()
 {
     mat4 T = mat4::Translation(pos_);
     mat4 S = mat4::Scaling(scale_);
-    mat4 M = S * rot_ * T;
+    mat4 R = mat4::RotationFromEulerXYZRad(rotEuler_);
+    mat4 M = S * R * T;
     SetModelMatrix(M);
+}
+
+void StaticMesh::MarkTransformDirty()
+{
+    transformDirty_ = true;
 }

--- a/sources/rendering/meshes/StaticMesh.h
+++ b/sources/rendering/meshes/StaticMesh.h
@@ -11,28 +11,31 @@ public:
         const std::wstring& graphicsShader);
 
     virtual void Init(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList, std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive) override;
+    void PostTick(float deltaTime) override;
 
     // --- Transforms ---
     void SetPosition(const float3& p);
     void SetScale(const float3& s);
     void SetRotationEulerRad(const float3& eulerXYZ);   // (pitch=X, yaw=Y, roll=Z), radians
     void SetRotationEulerDeg(const float3& eulerDegXYZ);
-    void SetOrientationMatrix(const mat4& rotation3x3In4x4);
 
     float3 GetPosition() const { return pos_; }
     float3 GetScale() const { return scale_; }
-    const mat4& GetOrientationMatrix() const { return rot_; }
+    mat4 GetOrientationMatrix() const { return mat4::RotationFromEulerXYZRad(rotEuler_); }
+    float3 GetRotationEulerRad() const { return rotEuler_; }
 
     bool IsSimpleRender() const { return true; }
     bool CastsShadow() const override { return true; }
 
 private:
     void RebuildModel(); // M = R * T (for the row-vector convention)
+    void MarkTransformDirty();
 
 private:
-    mat4   rot_;   // Orthonormal 3x3 in the upper-left block
+    float3 rotEuler_;
     float3 pos_;
     float3 scale_;
+    bool transformDirty_ = true;
 
     std::string modelName_;
 };

--- a/sources/rendering/renderables/RenderableObject.h
+++ b/sources/rendering/renderables/RenderableObject.h
@@ -40,6 +40,7 @@ public:
     // Lifecycle
     virtual void Init(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList, std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive);
     virtual void Tick(float /*dt*/) {}
+    virtual void PostTick(float /*dt*/) override {}
 
     // Base renderer: Compute -> Graphics (Bind/IssueDraw)
     virtual void Render(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& view, const mat4& proj);

--- a/sources/rendering/renderables/RenderableObjectBase.h
+++ b/sources/rendering/renderables/RenderableObjectBase.h
@@ -12,6 +12,7 @@ public:
     virtual ~RenderableObjectBase() noexcept = default;
     virtual void Init(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList, std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive) = 0;
     virtual void Tick(float /*dt*/) = 0;
+    virtual void PostTick(float /*dt*/) = 0;
     virtual void Render(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& view, const mat4& proj) = 0;
     virtual void RenderShadow(Renderer* renderer, ID3D12GraphicsCommandList* cl, const mat4& lightView, const mat4& lightProj) = 0;
     virtual bool IsTransparent() const = 0;


### PR DESCRIPTION
## Summary
- remove the unused orientation-matrix setter from StaticMesh and its quaternion helper
- run StaticMesh transform rebuilds during PostTick while keeping the dirty flag flow intact
- invoke PostTick on renderables via ParallelFor when the task system is enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e381d4cdc48329b0978b2bd97c8396