### PR TITLE
Wrap app system helpers in Systems namespace

### DIFF
--- a/input/bindings.json
+++ b/input/bindings.json
@@ -13,6 +13,8 @@
 
     { "name": "Wireframe", "keys": ["F3"] },
     { "name": "DebugTex", "keys": ["F4"] },
-    { "name": "ToggleProfiler", "keys": ["F9"] }
+    { "name": "ToggleProfiler", "keys": ["F9"] },
+    { "name": "CaptureTrace", "keys": ["F11"] },
+    { "name": "GenerateFont", "keys": ["F8"] }
   ]
 }

--- a/sources/app/App.cpp
+++ b/sources/app/App.cpp
@@ -1,7 +1,6 @@
 #include "app/App.h"
 #include "core/profiling/Profiler.h"
 #include "core/profiling/ProfilerScopes.h"
-#include "text/FontGenerator.h"
 #include <algorithm>
 #include <cassert>
 
@@ -100,14 +99,11 @@ void App::InitScene()
     assert(systems_);
 
     auto& renderer = systems_->renderer;
-    auto& actions = systems_->actions;
     auto& scene = systems_->scene;
     auto& input = systems_->input;
 
     std::vector<ComPtr<ID3D12Resource>> pendingUploads;
-    scene.SetInput(&input);
-    scene.SetActions(&actions);
-    if (!actions.LoadFromJsonFile(L"input/bindings.json"))
+    if (!input.LoadActions(L"input/bindings.json"))
     {
         assert(false && "No bindings.json found!");
     }
@@ -134,7 +130,8 @@ void App::InitScene()
 }
 
 void App::Run(HINSTANCE hInstance, int nCmdShow) {
-    systems_ = std::make_unique<Systems>();
+    systems_ = std::make_unique<Systems::AppSystems>();
+    Systems::Set(systems_.get());
 
     {
         auto& renderer = systems_->renderer;
@@ -175,31 +172,7 @@ void App::Run(HINSTANCE hInstance, int nCmdShow) {
                     }
                 }
 
-                if (input.WasKeyPressed(VK_F11)) {
-                    constexpr uint32_t kTraceFrames = 120;
-                    Profiler::Get().RequestTraceCapture(kTraceFrames);
-                }
-
-                if (input.WasKeyPressed(VK_F8)) {
-                    const bool generateSdf = input.IsKeyDown(VK_SHIFT);
-                    const FontGenerator::OutputType type = generateSdf ? FontGenerator::OutputType::Sdf : FontGenerator::OutputType::Coverage;
-
-                    FontGenerator generator;
-                    FontGenerator::Params params;
-                    params.fontFile = L"fonts/Consolas.ttf";
-                    params.pixelHeight = 32;
-                    params.type = type;
-                    params.fontsFolder = L"fonts";
-                    if (generateSdf) {
-                        params.spread = std::max(8, params.pixelHeight / 2 + 2);
-                    } else {
-                        params.spread = 6;
-                    }
-
-                    if (!generator.Generate(params)) {
-                        OutputDebugStringA("Font generation failed\n");
-                    }
-                }
+                Profiler::Get().Tick();
 
                 double now = GetTimeSeconds();
                 float deltaTime = static_cast<float>(now - lastTime);
@@ -220,6 +193,8 @@ void App::Run(HINSTANCE hInstance, int nCmdShow) {
         scene.Clear();
         renderer.Shutdown();
     }
+
+    Systems::Set(nullptr);
 
     systems_.reset();
 }

--- a/sources/app/App.h
+++ b/sources/app/App.h
@@ -12,25 +12,15 @@
 
 #include "core/Helpers.h"
 #include "app/Camera.h"
-#include "rendering/core/Renderer.h"
-#include "app/Scene.h"
+#include "app/Systems.h"
 #include "core/task/TaskSystem.h"
-#include "input/InputManager.h"
-#include "input/ActionMap.h"
 
 class App {
 public:
-    struct Systems {
-        Renderer renderer;
-        ActionMap actions;
-        Scene scene;
-        InputManager input;
-    };
-
     void Run(HINSTANCE hInstance, int nCmdShow);
 
 private:
-    std::unique_ptr<Systems> systems_;
+    std::unique_ptr<Systems::AppSystems> systems_;
     bool isRunning_ = true;
 
     static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);

--- a/sources/app/Camera.cpp
+++ b/sources/app/Camera.cpp
@@ -1,16 +1,17 @@
 #include "app/Camera.h"
+#include "app/Systems.h"
 #include "input/InputManager.h"
-#include "input/ActionMap.h"
 
-void Camera::UpdateFromActions(InputManager& input, const ActionMap& map, float dt) {
+void Camera::UpdateFromInput(float dt) {
+    auto& input = GetInput();
     // Toggle camera rotation via the action
-    const bool lookHeld = map.IsActionDown("LookToggle", input) && !input.IsKeyDown(VK_MENU);
+    const bool lookHeld = input.IsActionDown("LookToggle") && !input.IsKeyDown(VK_MENU);
     if (lookHeld) {
         if (!input.IsMouseCaptured()) {
             input.SetMouseCapture(true);
         }
-        const float dx = map.GetAxis("LookX", input);
-        const float dy = map.GetAxis("LookY", input);
+        const float dx = input.GetActionAxis("LookX");
+        const float dy = input.GetActionAxis("LookY");
         if (dx != 0.0f || dy != 0.0f) {
             // Scale already includes sensitivity/invert
             AddYaw(dx);
@@ -36,12 +37,12 @@ void Camera::UpdateFromActions(InputManager& input, const ActionMap& map, float 
 
     // Movement
     float speed = moveSpeed_ * moveSpeedMultiplier_;
-    if (map.IsActionDown("Sprint", input)) {
+    if (input.IsActionDown("Sprint")) {
         speed *= sprintMultiplier_;
     }
-    const float mx = map.GetAxis("MoveX", input);
-    const float my = map.GetAxis("MoveY", input);
-    const float mz = map.GetAxis("MoveZ", input);
+    const float mx = input.GetActionAxis("MoveX");
+    const float my = input.GetActionAxis("MoveY");
+    const float mz = input.GetActionAxis("MoveZ");
 
     if (mx != 0.0f) { MoveRight(mx * speed * dt); }
     if (my != 0.0f) { MoveUp(my * speed * dt); }

--- a/sources/app/Camera.h
+++ b/sources/app/Camera.h
@@ -3,8 +3,6 @@
 #include "core/Math.h"
 
 using namespace DirectX;
-class ActionMap;  // forward
-class InputManager;
 
 class Camera {
 public:
@@ -14,7 +12,7 @@ public:
         : position_(pos), pitch_(pitch), yaw_(yaw)
     {}
 
-    void UpdateFromActions(InputManager& input, const ActionMap& map, float dt);
+    void UpdateFromInput(float dt);
 
     // Camera movement helpers
     void MoveForward(float d)   { MoveRelative(0, 0, d); }

--- a/sources/app/Scene.cpp
+++ b/sources/app/Scene.cpp
@@ -4,8 +4,9 @@
 #include <algorithm>
 #include <array>
 
-#include "input/ActionMap.h"
+#include "input/InputManager.h"
 #include "app/Camera.h"
+#include "app/Systems.h"
 #include "rendering/debug/DebugGrid.h"
 #include "rendering/meshes/GpuInstancedModels.h"
 #include "core/Helpers.h"
@@ -325,18 +326,16 @@ void Scene::AddObject(std::unique_ptr<RenderableObjectBase> obj) {
 void Scene::Tick(float deltaTime) {
     CPU_SCOPE(ProfilerScopes::kSceneTick);
 
-    if (input_ != nullptr && actions_ != nullptr)
-    {
-        camera_.UpdateFromActions(*input_, *actions_, deltaTime);
+    auto& input = GetInput();
+    camera_.UpdateFromInput(deltaTime);
 
-        if (actions_->WasActionPressed("DebugTex", *input_))
-        {
-            debugTexMode_ = !debugTexMode_;
-        }
-        if (actions_->WasActionPressed("ToggleProfiler", *input_))
-        {
-            showProfiler_ = !showProfiler_;
-        }
+    if (input.WasActionPressed("DebugTex"))
+    {
+        debugTexMode_ = !debugTexMode_;
+    }
+    if (input.WasActionPressed("ToggleProfiler"))
+    {
+        showProfiler_ = !showProfiler_;
     }
 #if TASKSYSTEM_ENABLE_PARALLEL_EXECUTION
     size_t batchSize = 32;
@@ -374,7 +373,7 @@ void Scene::Render(Renderer* renderer) {
     }
     CPU_SCOPE(ProfilerScopes::kSceneRender);
 
-    if (actions_->WasActionPressed("Wireframe", *input_)) {
+    if (GetInput().WasActionPressed("Wireframe")) {
         renderer->SetWireframeMode(!renderer->GetWireframeMode());
     }
 

--- a/sources/app/Scene.h
+++ b/sources/app/Scene.h
@@ -7,7 +7,6 @@
 
 #include "rendering/renderables/RenderableObject.h"
 #include "app/Camera.h"
-#include "input/InputManager.h"
 #include "rendering/lighting/Skybox.h"
 #include "rendering/lighting/PointLight.h"
 
@@ -15,8 +14,6 @@ class Renderer;
 
 class Scene {
 public:
-    void SetInput(InputManager* input) { input_ = input; }
-    void SetActions(ActionMap* a) { actions_ = a; }
     Camera& CameraRef() { return camera_; }
     const Camera& CameraRef() const { return camera_; }
 
@@ -146,9 +143,6 @@ private:
     std::vector<PointLight> pointLights_;
 
     ObjectBuckets renderBuckets_;
-
-    InputManager* input_ = nullptr;
-    ActionMap* actions_ = nullptr;
     Camera camera_;
 
     bool debugTexMode_ = false;

--- a/sources/app/Systems.cpp
+++ b/sources/app/Systems.cpp
@@ -1,0 +1,32 @@
+#include "app/Systems.h"
+
+#include <cassert>
+
+namespace Systems {
+
+namespace {
+AppSystems* gSystems = nullptr;
+}
+
+void Set(AppSystems* systems) {
+    gSystems = systems;
+}
+
+AppSystems& Get() {
+    assert(gSystems != nullptr);
+    return *gSystems;
+}
+
+Renderer& GetRenderer() {
+    return Get().renderer;
+}
+
+Scene& GetScene() {
+    return Get().scene;
+}
+
+InputManager& GetInput() {
+    return Get().input;
+}
+
+} // namespace Systems

--- a/sources/app/Systems.h
+++ b/sources/app/Systems.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "rendering/core/Renderer.h"
+#include "app/Scene.h"
+#include "input/InputManager.h"
+
+namespace Systems {
+
+struct AppSystems {
+    Renderer renderer;
+    Scene scene;
+    InputManager input;
+};
+
+void Set(AppSystems* systems);
+AppSystems& Get();
+Renderer& GetRenderer();
+Scene& GetScene();
+InputManager& GetInput();
+
+} // namespace Systems

--- a/sources/core/profiling/Profiler.cpp
+++ b/sources/core/profiling/Profiler.cpp
@@ -12,6 +12,8 @@
 #include <limits>
 #include "third_party/robin_hood.h"
 #include "text/TextManager.h"
+#include "input/InputManager.h"
+#include "app/Systems.h"
 
 namespace {
 
@@ -1166,6 +1168,17 @@ void Profiler::RequestTraceCapture(uint32_t frameCount) {
     traceRequestFrameCount_ = frameCount;
     traceStopRequested_ = false;
     std::printf("Profiler trace capture requested: %u frames\n", frameCount);
+}
+
+void Profiler::Tick()
+{
+#if PROF_ENABLED
+    auto& input = Systems::GetInput();
+    if (input.WasActionPressed("CaptureTrace")) {
+        constexpr uint32_t kTraceFrames = 120;
+        RequestTraceCapture(kTraceFrames);
+    }
+#endif
 }
 
 void Profiler::SetThreadName(const std::string& name) {

--- a/sources/core/profiling/Profiler.h
+++ b/sources/core/profiling/Profiler.h
@@ -28,7 +28,6 @@
 #endif
 
 class TextManager; // forward
-
 // CPU profiler: scopes, EMA averaging, cooldown for resetting maxima,
 // overlay preparation in EndFrame (double-buffered) and infrequent sorting by average.
 class Profiler {
@@ -211,6 +210,7 @@ public:
     // while a capture is pending or active will stop/cancel it.
 #endif
     void RequestTraceCapture(uint32_t frameCount);
+    void Tick();
     void SetThreadName(const std::string& name);
 
     // Cooldown for resetting maxima
@@ -408,6 +408,7 @@ inline void Profiler::SetMaxCooldownSeconds(double) {}
 inline double Profiler::GetMaxCooldownSeconds() const { return 0.0; }
 inline void Profiler::ResetMaxNow() {}
 inline void Profiler::RequestTraceCapture(uint32_t) {}
+inline void Profiler::Tick() {}
 inline void Profiler::SetThreadName(const std::string&) {}
 #if PROF_GPU_ENABLED
 inline void Profiler::BeginGpuFrame(ID3D12GraphicsCommandList*) {}

--- a/sources/input/InputManager.cpp
+++ b/sources/input/InputManager.cpp
@@ -123,3 +123,23 @@ void InputManager::OnWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) 
         }
     }
 }
+
+bool InputManager::LoadActions(const std::wstring& path) {
+    return actions_.LoadFromJsonFile(path);
+}
+
+bool InputManager::IsActionDown(const std::string& name) const {
+    return actions_.IsActionDown(name, *this);
+}
+
+bool InputManager::WasActionPressed(const std::string& name) const {
+    return actions_.WasActionPressed(name, *this);
+}
+
+bool InputManager::WasActionReleased(const std::string& name) const {
+    return actions_.WasActionReleased(name, *this);
+}
+
+float InputManager::GetActionAxis(const std::string& name) const {
+    return actions_.GetAxis(name, *this);
+}

--- a/sources/input/InputManager.h
+++ b/sources/input/InputManager.h
@@ -3,6 +3,9 @@
 #include <windows.h>
 #include <array>
 #include <cstdint>
+#include <string>
+
+#include "input/ActionMap.h"
 
 class InputManager {
 public:
@@ -11,6 +14,13 @@ public:
 
     // Forward WndProc messages from App::WndProc
     void OnWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+    bool LoadActions(const std::wstring& path);
+
+    bool  IsActionDown(const std::string& name) const;
+    bool  WasActionPressed(const std::string& name) const;
+    bool  WasActionReleased(const std::string& name) const;
+    float GetActionAxis(const std::string& name) const;
 
     // Keyboard
     bool IsKeyDown(int vk) const {
@@ -40,6 +50,8 @@ private:
 
 private:
     HWND hwnd_ = nullptr;
+
+    ActionMap actions_;
 
     std::array<uint8_t, 256> keyDown_{};     // Current state
     std::array<uint8_t, 256> keyPressed_{};  // Triggered during this frame

--- a/sources/rendering/core/Renderer.cpp
+++ b/sources/rendering/core/Renderer.cpp
@@ -8,6 +8,7 @@
 #include <mimalloc.h>
 #include "core/profiling/Profiler.h"
 #include "core/profiling/ProfilerScopes.h"
+#include "app/Systems.h"
 
 thread_local uint32_t Renderer::tlLaneIndex_ = UINT32_MAX;
 thread_local Renderer::CLStateEntry* Renderer::tlCurrentEntry_ = nullptr;
@@ -417,6 +418,8 @@ void Renderer::ReportLiveObjects()
 
 void Renderer::Tick(float dt)
 {
+    fontManager_.Tick();
+
     if (fps_ <= 0.0f)
     {
         fps_ = 1.0f / dt;

--- a/sources/text/FontManager.cpp
+++ b/sources/text/FontManager.cpp
@@ -1,5 +1,9 @@
 #include "text/FontManager.h"
 #include "rendering/core/Renderer.h"
+#include "text/FontGenerator.h"
+#include "input/InputManager.h"
+#include "app/Systems.h"
+#include <algorithm>
 
 using Microsoft::WRL::ComPtr;
 
@@ -8,12 +12,32 @@ static bool FileExistsW_(const std::wstring& path) {
     return (a != INVALID_FILE_ATTRIBUTES) && ((a & FILE_ATTRIBUTE_DIRECTORY) == 0);
 }
 
+namespace {
+std::wstring JoinPath(const std::wstring& base, const std::wstring& leaf)
+{
+    if (leaf.empty()) {
+        return base;
+    }
+
+    std::wstring result = base;
+    if (!result.empty()) {
+        const wchar_t back = result.back();
+        if (back != L'\\' && back != L'/') {
+            result += L'\\';
+        }
+    }
+    result += leaf;
+    return result;
+}
+}
+
 void FontManager::LoadFromFolder(Renderer* r,
                                  ID3D12GraphicsCommandList* uploadCl,
                                  std::vector<ComPtr<ID3D12Resource>>* uploadKeepAlive,
                                  const std::wstring& folder)
 {
     renderer_ = r;
+    fontsFolder_ = folder;
 
     std::wstring pattern = folder;
     if (!pattern.empty() && pattern.back() != L'\\' && pattern.back() != L'/') {
@@ -100,4 +124,40 @@ std::vector<std::wstring> FontManager::List() const {
 void FontManager::Clear()
 {
     fonts_.clear();
+    defaultName_.clear();
+    fontsFolder_.clear();
+    renderer_ = nullptr;
+}
+
+void FontManager::Tick()
+{
+    if (fontsFolder_.empty()) {
+        return;
+    }
+
+    auto& input = Systems::GetInput();
+
+    if (!input.WasActionPressed("GenerateFont")) {
+        return;
+    }
+
+    const bool generateSdf = input.IsKeyDown(VK_SHIFT);
+    const FontGenerator::OutputType type = generateSdf ? FontGenerator::OutputType::Sdf : FontGenerator::OutputType::Coverage;
+
+    FontGenerator generator;
+    FontGenerator::Params params;
+    params.fontFile = JoinPath(fontsFolder_, L"Consolas.ttf");
+    params.pixelHeight = 32;
+    params.type = type;
+    params.fontsFolder = fontsFolder_;
+    if (generateSdf) {
+        params.spread = std::max(8, params.pixelHeight / 2 + 2);
+    }
+    else {
+        params.spread = 6;
+    }
+
+    if (!generator.Generate(params)) {
+        OutputDebugStringA("Font generation failed\n");
+    }
 }

--- a/sources/text/FontManager.h
+++ b/sources/text/FontManager.h
@@ -7,7 +7,6 @@
 #include "text/FontAtlas.h"
 
 class Renderer;
-
 class FontManager {
 public:
     void Init(Renderer* r) {
@@ -31,8 +30,11 @@ public:
 
     void Clear();
 
+    void Tick();
+
 private:
     Renderer* renderer_ = nullptr;
     robin_hood::unordered_map<std::wstring, std::unique_ptr<FontAtlas>> fonts_;
     std::wstring defaultName_;
+    std::wstring fontsFolder_;
 };

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="sources/app/App.cpp" />
     <ClCompile Include="sources/app/Camera.cpp" />
     <ClCompile Include="sources/app/Scene.cpp" />
+    <ClCompile Include="sources/app/Systems.cpp" />
     <ClCompile Include="sources/app/main.cpp" />
     <ClCompile Include="sources/core/profiling/Profiler.cpp" />
     <ClCompile Include="sources/core/profiling/ProfilerScopes.cpp" />
@@ -200,6 +201,7 @@
     <ClInclude Include="sources/app/App.h" />
     <ClInclude Include="sources/app/Camera.h" />
     <ClInclude Include="sources/app/Scene.h" />
+    <ClInclude Include="sources/app/Systems.h" />
     <ClInclude Include="sources/core/Helpers.h" />
     <ClInclude Include="sources/core/Math.h" />
     <ClInclude Include="sources/core/profiling/Profiler.h" />

--- a/test_cube.vcxproj.filters
+++ b/test_cube.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="sources/app/Scene.cpp">
       <Filter>sources\app</Filter>
     </ClCompile>
+    <ClCompile Include="sources/app/Systems.cpp">
+      <Filter>sources\app</Filter>
+    </ClCompile>
     <ClCompile Include="sources/app/main.cpp">
       <Filter>sources\app</Filter>
     </ClCompile>
@@ -198,6 +201,9 @@
       <Filter>sources\app</Filter>
     </ClInclude>
     <ClInclude Include="sources/app/Scene.h">
+      <Filter>sources\app</Filter>
+    </ClInclude>
+    <ClInclude Include="sources/app/Systems.h">
       <Filter>sources\app</Filter>
     </ClInclude>
     <ClInclude Include="sources/core/Helpers.h">


### PR DESCRIPTION
## Summary
- wrap the app system accessors in a `Systems` namespace and update the app bootstrap to use it
- have `Profiler::Tick` and `FontManager::Tick` pull the shared input manager directly
- adjust the renderer tick and related headers for the new signatures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e389580b44832980e102b86cd3b5e6