### PR TITLE
Define renderer RT formats as shared constants

### DIFF
--- a/sources/app/Scene.cpp
+++ b/sources/app/Scene.cpp
@@ -217,7 +217,7 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
         Material::GraphicsDesc gd{};
         gd.shaderFile = L"shaders/ssr_ps.hlsl";
         gd.vsEntry = "VSMain"; gd.psEntry = "PSMain";
-        gd.numRT = 1; gd.rtvFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;// renderer->GetSceneColorFormat();
+        gd.numRT = 1; gd.rtvFormats[0] = renderer->GetSsrFormat();
         gd.depth.DepthEnable = FALSE;
         matSSR_ = renderer->GetMaterialManager()->GetOrCreateGraphics(renderer, gd);
     }
@@ -226,7 +226,7 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
         Material::GraphicsDesc gd{};
         gd.shaderFile = L"shaders/blur_ps.hlsl";
         gd.vsEntry = "VSMain"; gd.psEntry = "PSMain";
-        gd.numRT = 1; gd.rtvFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;// renderer->GetSceneColorFormat();
+        gd.numRT = 1; gd.rtvFormats[0] = renderer->GetSsrBlurFormat();
         gd.depth.DepthEnable = FALSE;
         matBlur_ = renderer->GetMaterialManager()->GetOrCreateGraphics(renderer, gd);
     }

--- a/sources/rendering/core/Renderer.cpp
+++ b/sources/rendering/core/Renderer.cpp
@@ -249,7 +249,7 @@ void Renderer::CreateSwapChainAndRTVs(UINT width, UINT height) {
     scd.BufferCount = kFrameCount;
     scd.Width = width;
     scd.Height = height;
-    scd.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    scd.Format = GetBackbufferResourceFormat();
     scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
     scd.SampleDesc.Count = 1;
@@ -276,7 +276,7 @@ void Renderer::CreateSwapChainAndRTVs(UINT width, UINT height) {
         ThrowIfFailed(swapChain_->GetBuffer(i, IID_PPV_ARGS(&renderTargets_[i])));
 
         D3D12_RENDER_TARGET_VIEW_DESC rtvFmt{};
-        rtvFmt.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;        // <- key
+        rtvFmt.Format = GetBackbufferFormat();        // <- key
         rtvFmt.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
         rtvFmt.Texture2D.MipSlice   = 0;
         rtvFmt.Texture2D.PlaneSlice = 0;
@@ -303,7 +303,7 @@ void Renderer::CreateDepthResources(UINT width, UINT height) {
     depthDesc.Height = height;
     depthDesc.DepthOrArraySize = 1;
     depthDesc.MipLevels = 1;
-    depthDesc.Format = DXGI_FORMAT_D32_FLOAT;
+    depthDesc.Format = kDepthBufferResourceFormat;
     depthDesc.SampleDesc.Count = 1;
     depthDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
     depthDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
@@ -312,7 +312,7 @@ void Renderer::CreateDepthResources(UINT width, UINT height) {
     heap.Type = D3D12_HEAP_TYPE_DEFAULT;
 
     D3D12_CLEAR_VALUE cv{};
-    cv.Format = DXGI_FORMAT_D32_FLOAT;
+    cv.Format = kDepthBufferViewFormat;
     cv.DepthStencil.Depth = 1.0f;
     cv.DepthStencil.Stencil = 0;
 
@@ -1073,7 +1073,7 @@ void Renderer::CreateDeferredTargets(UINT width, UINT height)
 
             // Create an SRV for depth as R32_FLOAT
             D3D12_SHADER_RESOURCE_VIEW_DESC sd{};
-            sd.Format = DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS;
+            sd.Format = GetDepthSrvFormat();
             sd.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
             sd.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
             sd.Texture2D.MipLevels = 1;
@@ -1134,19 +1134,19 @@ void Renderer::CreateDeferredTargets(UINT width, UINT height)
     {
         auto& D = deferred_[f];
 
-        CreateRT(DXGI_FORMAT_R8G8B8A8_UNORM, DeferredRtvSlot::GB0, DeferredSrvSlot::GB0, f, D.gb0, D.gbRTV[0], D.gbSRV[0]);
-        CreateRT(DXGI_FORMAT_R10G10B10A2_UNORM, DeferredRtvSlot::GB1, DeferredSrvSlot::GB1, f, D.gb1, D.gbRTV[1], D.gbSRV[1]);
-        CreateRT(DXGI_FORMAT_R11G11B10_FLOAT, DeferredRtvSlot::GB2, DeferredSrvSlot::GB2, f, D.gb2, D.gbRTV[2], D.gbSRV[2]);
+        CreateRT(kGBuffer0Format, DeferredRtvSlot::GB0, DeferredSrvSlot::GB0, f, D.gb0, D.gbRTV[0], D.gbSRV[0]);
+        CreateRT(kGBuffer1Format, DeferredRtvSlot::GB1, DeferredSrvSlot::GB1, f, D.gb1, D.gbRTV[1], D.gbSRV[1]);
+        CreateRT(kGBuffer2Format, DeferredRtvSlot::GB2, DeferredSrvSlot::GB2, f, D.gb2, D.gbRTV[2], D.gbSRV[2]);
 
-        CreateDepth(DXGI_FORMAT_D32_FLOAT_S8X24_UINT, f, D.depth, D.dsv, /*outDepthSRV*/ D.gbSRV[3]);
+        CreateDepth(kDeferredDepthFormat, f, D.depth, D.dsv, /*outDepthSRV*/ D.gbSRV[3]);
 
         D.shadowRes = 4096; // could be driven by config/parameter
         CreateShadow(f, D.shadow, D.shadowDSV, D.shadowSRV, D.shadowRes);
 
-        CreateRT(DXGI_FORMAT_R16G16B16A16_FLOAT, DeferredRtvSlot::Light, DeferredSrvSlot::Light, f, D.light, D.lightRTV, D.lightSRV);
-        CreateRT(DXGI_FORMAT_R16G16B16A16_FLOAT, DeferredRtvSlot::Scene, DeferredSrvSlot::Scene, f, D.scene, D.sceneRTV, D.sceneSRV);
-        CreateRT(DXGI_FORMAT_R8G8B8A8_UNORM, DeferredRtvSlot::SSR, DeferredSrvSlot::SSR, f, D.ssr, D.ssrRTV, D.ssrSRV);
-        CreateRT(DXGI_FORMAT_R8G8B8A8_UNORM, DeferredRtvSlot::SSRBlur, DeferredSrvSlot::SSRBlur, f, D.ssrBlur, D.ssrBlurRTV, D.ssrBlurSRV);
+        CreateRT(kLightTargetFormat, DeferredRtvSlot::Light, DeferredSrvSlot::Light, f, D.light, D.lightRTV, D.lightSRV);
+        CreateRT(kSceneColorFormat, DeferredRtvSlot::Scene, DeferredSrvSlot::Scene, f, D.scene, D.sceneRTV, D.sceneSRV);
+        CreateRT(kSsrFormat, DeferredRtvSlot::SSR, DeferredSrvSlot::SSR, f, D.ssr, D.ssrRTV, D.ssrSRV);
+        CreateRT(kSsrBlurFormat, DeferredRtvSlot::SSRBlur, DeferredSrvSlot::SSRBlur, f, D.ssrBlur, D.ssrBlurRTV, D.ssrBlurSRV);
     }
 }
 

--- a/sources/rendering/core/Renderer.h
+++ b/sources/rendering/core/Renderer.h
@@ -28,14 +28,14 @@ public:
     enum class ClearMode { None, Color, ColorDepth };
     struct DeferredTargets {
         // Resources
-        ComPtr<ID3D12Resource> gb0;   // R8G8B8A8 (albedo+metal)
-        ComPtr<ID3D12Resource> gb1;   // R10G10G10A2 (normalOcta+rough)
-        ComPtr<ID3D12Resource> gb2;   // R11G11B10 (emissive)
-        ComPtr<ID3D12Resource> depth; // D32
-        ComPtr<ID3D12Resource> light; // R16G16B16A16F
-        ComPtr<ID3D12Resource> scene; // R16G16B16A16F
-        ComPtr<ID3D12Resource> ssr;     // R16G16B16A16F premultiplied
-        ComPtr<ID3D12Resource> ssrBlur; // R16G16B16A16F
+        ComPtr<ID3D12Resource> gb0;   // Renderer::kGBuffer0Format (albedo+metal)
+        ComPtr<ID3D12Resource> gb1;   // Renderer::kGBuffer1Format (normalOcta+rough)
+        ComPtr<ID3D12Resource> gb2;   // Renderer::kGBuffer2Format (emissive)
+        ComPtr<ID3D12Resource> depth; // Renderer::kDeferredDepthFormat
+        ComPtr<ID3D12Resource> light; // Renderer::kLightTargetFormat
+        ComPtr<ID3D12Resource> scene; // Renderer::kSceneColorFormat
+        ComPtr<ID3D12Resource> ssr;     // Renderer::kSsrFormat (premultiplied)
+        ComPtr<ID3D12Resource> ssrBlur; // Renderer::kSsrBlurFormat
         ComPtr<ID3D12Resource> shadow; // R32_TYPELESS (DSV=D32F, SRV=R32F)
 
         // CPU descriptors
@@ -83,10 +83,29 @@ public:
     D3D12_GPU_DESCRIPTOR_HANDLE StageTonemapSrvTable(); // t0     : Scene
 
     // Formats
-    DXGI_FORMAT GetLightTargetFormat() const { return DXGI_FORMAT_R16G16B16A16_FLOAT; }
-    DXGI_FORMAT GetSceneColorFormat() const { return DXGI_FORMAT_R16G16B16A16_FLOAT; }
-    DXGI_FORMAT GetBackbufferFormat() const { return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB; }
-    DXGI_FORMAT GetDsvFormat() const { return DXGI_FORMAT_D32_FLOAT_S8X24_UINT; }
+    static constexpr DXGI_FORMAT kBackbufferResourceFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
+    static constexpr DXGI_FORMAT kBackbufferFormat = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    static constexpr DXGI_FORMAT kDepthBufferResourceFormat = DXGI_FORMAT_D32_FLOAT;
+    static constexpr DXGI_FORMAT kDepthBufferViewFormat = DXGI_FORMAT_D32_FLOAT;
+    static constexpr DXGI_FORMAT kDeferredDepthFormat = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+    static constexpr DXGI_FORMAT kDeferredDepthSrvFormat = DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS;
+    static constexpr DXGI_FORMAT kGBuffer0Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    static constexpr DXGI_FORMAT kGBuffer1Format = DXGI_FORMAT_R10G10B10A2_UNORM;
+    static constexpr DXGI_FORMAT kGBuffer2Format = DXGI_FORMAT_R11G11B10_FLOAT;
+    static constexpr DXGI_FORMAT kLightTargetFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    static constexpr DXGI_FORMAT kSceneColorFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    static constexpr DXGI_FORMAT kSsrFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
+    static constexpr DXGI_FORMAT kSsrBlurFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+    // Formats
+    DXGI_FORMAT GetLightTargetFormat() const { return kLightTargetFormat; }
+    DXGI_FORMAT GetSceneColorFormat() const { return kSceneColorFormat; }
+    DXGI_FORMAT GetBackbufferFormat() const { return kBackbufferFormat; }
+    DXGI_FORMAT GetBackbufferResourceFormat() const { return kBackbufferResourceFormat; }
+    DXGI_FORMAT GetDsvFormat() const { return kDeferredDepthFormat; }
+    DXGI_FORMAT GetDepthSrvFormat() const { return kDeferredDepthSrvFormat; }
+    DXGI_FORMAT GetSsrFormat() const { return kSsrFormat; }
+    DXGI_FORMAT GetSsrBlurFormat() const { return kSsrBlurFormat; }
 
     const DeferredTargets& GetDeferredForFrame() const { return deferred_[currentFrameIndex_]; }
 

--- a/sources/rendering/renderables/GBufferRenderable.cpp
+++ b/sources/rendering/renderables/GBufferRenderable.cpp
@@ -91,10 +91,10 @@ GBufferRenderable::GBufferRenderable(const std::string& matPreset,
 {
     auto& gd = GetGraphicsDesc();
     gd.numRT = 3;
-    gd.rtvFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-    gd.rtvFormats[1] = DXGI_FORMAT_R10G10B10A2_UNORM;
-    gd.rtvFormats[2] = DXGI_FORMAT_R11G11B10_FLOAT;
-    gd.dsvFormat = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+    gd.rtvFormats[0] = Renderer::kGBuffer0Format;
+    gd.rtvFormats[1] = Renderer::kGBuffer1Format;
+    gd.rtvFormats[2] = Renderer::kGBuffer2Format;
+    gd.dsvFormat = Renderer::kDeferredDepthFormat;
 
     SetUniformBinder(std::make_unique<GBufferUniformBinder>(matParams_));
 }


### PR DESCRIPTION
## Summary
- expose shared Renderer constants for all render/depth target formats
- update deferred target creation and swapchain setup to consume the shared constants
- switch material descriptor setup for SSR/blur and the G-buffer renderable to the shared formats

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e39dcbf9c88329b9df0524d7284962