### PR TITLE
Synchronize backbuffer state tracking

### DIFF
--- a/sources/rendering/core/Renderer.cpp
+++ b/sources/rendering/core/Renderer.cpp
@@ -283,6 +283,7 @@ void Renderer::CreateSwapChainAndRTVs(UINT width, UINT height) {
 
         device_->CreateRenderTargetView(renderTargets_[i].Get(), &rtvFmt, rtv);
         rtv.ptr += rtvDescriptorSize_;
+        SetResourceState(renderTargets_[i].Get(), D3D12_RESOURCE_STATE_PRESENT);
     }
 }
 
@@ -693,6 +694,7 @@ void Renderer::ExecuteTimelineAndPresent() {
         b.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 
         cl->ResourceBarrier(1, &b);
+        SetResourceState(renderTargets_[currentFrameIndex_].Get(), D3D12_RESOURCE_STATE_PRESENT);
 #if PROF_GPU_ENABLED
         Profiler::Get().EndGpuFrame(cl);
 #endif
@@ -868,6 +870,7 @@ void Renderer::RecordBindAndClear(ID3D12GraphicsCommandList* cl) {
     b.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
     b.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
     cl->ResourceBarrier(1, &b);
+    SetResourceState(renderTargets_[currentFrameIndex_].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
 
     // RTV/DSV
     D3D12_CPU_DESCRIPTOR_HANDLE rtv = rtvHeap_->GetCPUDescriptorHandleForHeapStart();


### PR DESCRIPTION
## Summary
- keep the resource-state tracker in sync with manual backbuffer barriers
- seed swapchain images with a PRESENT state so the tracker starts from a known value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3f798b7008329880eca8d72a31370