### PR TITLE
Optimize text glyph emission by reducing shadow data

### DIFF
--- a/shaders/font_pixelperfect.hlsl
+++ b/shaders/font_pixelperfect.hlsl
@@ -1,36 +1,35 @@
-// RootSignature: CONSTANTS(b1,count=4) TABLE(SRV(t0)) TABLE(SAMPLER(s0))
+// RootSignature: CONSTANTS(b1,count=12) TABLE(SRV(t0)) TABLE(SAMPLER(s0))
 
 struct VSIn {
-    float3 pos : POSITION;
+    float2 pos : POSITION;
     float4 col : COLOR0;
     float2 uv  : TEXCOORD0;
-    float2 shadowOffset : TEXCOORD1;
-    float4 shadowColor  : COLOR1;
+    float2 shadowParams : TEXCOORD1; // x = offset scale, y = final alpha
 };
 struct VSOut {
     float4 pos : SV_Position;
     float4 col : COLOR0;
     float2 uv  : TEXCOORD0;
-    float2 shadowOffset : TEXCOORD1;
-    float4 shadowColor  : COLOR1;
+    float2 shadowParams : TEXCOORD1;
 };
 
 cbuffer TextParams : register(b1)
 {
-    float2 viewport;
-    float2 atlasTexelSize;
+    float4 viewportAtlas;    // xy = viewport size, zw = atlas texel size
+    float4 shadowOffsetBase; // xy = base shadow offset, zw unused
+    float4 shadowColorRgb;   // xyz = shadow color rgb
 };
 
 VSOut VSMain(VSIn i) {
     VSOut o;
-    float2 p = float2(i.pos.x + 0.5, i.pos.y + 0.5);
+    float2 viewport = viewportAtlas.xy;
+    float2 p = i.pos + 0.5;
     float2 ndc = float2((p.x / viewport.x) * 2.0 - 1.0,
                          1.0 - (p.y / viewport.y) * 2.0);
     o.pos = float4(ndc, 0.0, 1.0);
     o.col = i.col;
     o.uv = i.uv;
-    o.shadowOffset = i.shadowOffset;
-    o.shadowColor = i.shadowColor;
+    o.shadowParams = i.shadowParams;
     return o;
 }
 
@@ -38,20 +37,18 @@ Texture2D tex0 : register(t0);
 SamplerState samp0 : register(s0);
 
 float4 PSMain(VSOut i) : SV_Target {
+    const float2 atlasTexelSize = viewportAtlas.zw;
     float coverage = saturate(tex0.Sample(samp0, i.uv).r);
     float4 textColor = float4(i.col.rgb, i.col.a * coverage);
 
-    float shadowCoverage = 0.0f;
-    float4 shadowColor = float4(i.shadowColor.rgb, 0.0f);
-    if (i.shadowColor.a > 0.0f) {
-        float2 shadowUv = i.uv - i.shadowOffset * atlasTexelSize;
-        shadowCoverage = saturate(tex0.Sample(samp0, shadowUv).r);
-        shadowColor.a = saturate(i.shadowColor.a * shadowCoverage);
-        
+    float shadowAlpha = i.shadowParams.y;
+    if (shadowAlpha > 0.0f) {
+        float2 baseOffset = shadowOffsetBase.xy;
+        float2 shadowUv = i.uv - baseOffset * i.shadowParams.x * atlasTexelSize;
+        float shadowCoverage = saturate(tex0.Sample(samp0, shadowUv).r);
+        float finalAlpha = saturate(shadowAlpha * shadowCoverage);
+        float4 shadowColor = float4(shadowColorRgb.xyz, finalAlpha);
         return lerp(shadowColor, textColor, saturate(coverage * 2.0f));
     }
-    else
-    {
-        return textColor;
-    }
+    return textColor;
 }

--- a/shaders/font_sdf.hlsl
+++ b/shaders/font_sdf.hlsl
@@ -1,36 +1,35 @@
-// RootSignature: CONSTANTS(b1,count=4) TABLE(SRV(t0)) TABLE(SAMPLER(s0))
+// RootSignature: CONSTANTS(b1,count=12) TABLE(SRV(t0)) TABLE(SAMPLER(s0))
 
 struct VSIn {
-    float3 pos : POSITION;
+    float2 pos : POSITION;
     float4 col : COLOR0;
     float2 uv  : TEXCOORD0;
-    float2 shadowOffset : TEXCOORD1;
-    float4 shadowColor  : COLOR1;
+    float2 shadowParams : TEXCOORD1; // x = offset scale, y = final alpha
 };
 struct VSOut {
     float4 pos : SV_Position;
     float4 col : COLOR0;
     float2 uv  : TEXCOORD0;
-    float2 shadowOffset : TEXCOORD1;
-    float4 shadowColor  : COLOR1;
+    float2 shadowParams : TEXCOORD1;
 };
 
 cbuffer TextParams : register(b1)
 {
-    float2 viewport;
-    float2 atlasTexelSize;
+    float4 viewportAtlas;    // xy = viewport size, zw = atlas texel size
+    float4 shadowOffsetBase; // xy = base shadow offset, zw unused
+    float4 shadowColorRgb;   // xyz = shadow color rgb
 };
 
 VSOut VSMain(VSIn i) {
     VSOut o;
-    float2 p = float2(i.pos.x + 0.5, i.pos.y + 0.5);
+    float2 viewport = viewportAtlas.xy;
+    float2 p = i.pos + 0.5;
     float2 ndc = float2((p.x / viewport.x) * 2.0 - 1.0,
                          1.0 - (p.y / viewport.y) * 2.0);
     o.pos = float4(ndc, 0.0, 1.0);
     o.col = i.col;
     o.uv = i.uv;
-    o.shadowOffset = i.shadowOffset;
-    o.shadowColor = i.shadowColor;
+    o.shadowParams = i.shadowParams;
     return o;
 }
 
@@ -41,31 +40,28 @@ float4 PSMain(VSOut i) : SV_Target {
     float d = tex0.Sample(samp0, i.uv).r;
 
     float w = fwidth(d);
-    float minw = 1.0 / max(viewport.x, viewport.y);
+    float minw = 1.0 / max(viewportAtlas.x, viewportAtlas.y);
     w = max(w, minw);
 
     float textCoverage = smoothstep(0.5 - w, 0.5 + w, d);
     float coverage = saturate(textCoverage);
     float4 textColor = float4(i.col.rgb, i.col.a * coverage);
 
-    float shadowCoverage = 0.0f;
-    float4 shadowColor = float4(i.shadowColor.rgb, 0.0f);
-    if (i.shadowColor.a > 0.0f) {
-        float2 shadowUv = i.uv - float2(i.shadowOffset.x * atlasTexelSize.x,
-                                        i.shadowOffset.y * atlasTexelSize.y);
+    float shadowAlpha = i.shadowParams.y;
+    if (shadowAlpha > 0.0f) {
+        float4 shadowColor = float4(shadowColorRgb.xyz, 0.0f);
+        float2 atlasTexelSize = viewportAtlas.zw;
+        float2 shadowUv = i.uv - shadowOffsetBase.xy * i.shadowParams.x * atlasTexelSize;
         float shadowD = tex0.Sample(samp0, shadowUv).r;
 
         float shadowW = fwidth(shadowD);
         shadowW = max(shadowW, minw);
 
-        shadowCoverage = smoothstep(0.5 - shadowW, 0.5 + shadowW, shadowD);
+        float shadowCoverage = smoothstep(0.5 - shadowW, 0.5 + shadowW, shadowD);
         shadowCoverage = saturate(shadowCoverage);
-        shadowColor.a = saturate(i.shadowColor.a * shadowCoverage);
-        
+        shadowColor.a = saturate(shadowAlpha * shadowCoverage);
+
         return lerp(shadowColor, textColor, saturate(coverage * 3.0f));
     }
-    else
-    {
-        return textColor;
-    }
+    return textColor;
 }

--- a/shaders/ui_rect.hlsl
+++ b/shaders/ui_rect.hlsl
@@ -1,11 +1,10 @@
 // RootSignature: CONSTANTS(b1,count=4)
 struct VSIn
 {
-    float3 pos : POSITION;
+    float2 pos : POSITION;
     float4 col : COLOR0;
     float2 uv : TEXCOORD0;
-    float2 shadowOffset : TEXCOORD1;
-    float4 shadowColor : COLOR1;
+    float2 shadowParams : TEXCOORD1;
 };
 struct VSOut
 {
@@ -31,7 +30,7 @@ static float2 PixelToNDC(float2 p, float2 vp)
 VSOut VSMain(VSIn i)
 {
     VSOut o;
-    float2 ndc = PixelToNDC(i.pos.xy, uViewport);
+    float2 ndc = PixelToNDC(i.pos, uViewport);
     o.H = float4(ndc, 0.0, 1.0);
     o.col = i.col;
     return o;

--- a/sources/rendering/descriptors/InputLayoutManager.cpp
+++ b/sources/rendering/descriptors/InputLayoutManager.cpp
@@ -59,13 +59,12 @@ void InputLayoutManager::InitBuiltins() {
         .Add("TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0)
         .Build(*this, "PosNormTanUV");
 
-    // pos, color, uv, shadow offset/color
+    // pos(float2), color, uv, shadow params
     Builder()
-        .Add("POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0)
+        .Add("POSITION", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 0)
         .Add("COLOR",    0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0)
         .Add("TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0)
         .Add("TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0)
-        .Add("COLOR",    1, DXGI_FORMAT_R32G32B32A32_FLOAT, 0)
         .Build(*this, "PosColorUV");
 
     // pos only

--- a/sources/text/TextManager.cpp
+++ b/sources/text/TextManager.cpp
@@ -239,8 +239,8 @@ void TextManager::Build(Renderer* r, ID3D12GraphicsCommandList* /*cl*/) {
     }
 
     // 1) Reserve space for potential background rectangles
-    rectVerts_.reserve(rectVerts_.size() + regions_.size() * 4);
-    rectIdx_.reserve(rectIdx_.size() + regions_.size() * 6);
+    rectVerts_.ensureAdditional(regions_.size() * 4);
+    rectIdx_.ensureAdditional(regions_.size() * 6);
 
     // 2) Single pass over regions: backgrounds and lines
     for (const Region& rg : regions_) {
@@ -315,7 +315,7 @@ void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
         auto h = r->GetRenderContextPool()->Acquire();
         auto& rc = h.ref();
 
-        rc.constants[1] = { FloatToUint32((float)vpW_), FloatToUint32((float)vpH_) };
+        rc.constants[1] = { FloatToUint32((float)vpW_), FloatToUint32((float)vpH_), 0u, 0u };
 
         matRect_->Bind(cl, rc);
         cl->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
@@ -347,7 +347,22 @@ void TextManager::Draw(Renderer* r, ID3D12GraphicsCommandList* cl) {
 
         const float invAtlasW = (font_->AtlasWidth() > 0) ? (1.0f / float(font_->AtlasWidth())) : 0.0f;
         const float invAtlasH = (font_->AtlasHeight() > 0) ? (1.0f / float(font_->AtlasHeight())) : 0.0f;
-        rc.constants[1] = { FloatToUint32((float)vpW_), FloatToUint32((float)vpH_), FloatToUint32(invAtlasW), FloatToUint32(invAtlasH) };
+        float2 shadowBaseOffset = { 0.0f, 0.0f };
+        float3 shadowColorRgb = { 0.0f, 0.0f, 0.0f };
+        if (shadow_.has_value()) {
+            const ShadowDesc& desc = shadow_.value();
+            shadowBaseOffset = { desc.offsetX, desc.offsetY };
+            shadowColorRgb = { desc.color.x, desc.color.y, desc.color.z };
+        }
+
+        rc.constants[1] = {
+            FloatToUint32((float)vpW_), FloatToUint32((float)vpH_),
+            FloatToUint32(invAtlasW), FloatToUint32(invAtlasH),
+            FloatToUint32(shadowBaseOffset.x), FloatToUint32(shadowBaseOffset.y),
+            0u, 0u,
+            FloatToUint32(shadowColorRgb.x), FloatToUint32(shadowColorRgb.y),
+            FloatToUint32(shadowColorRgb.z), 0u
+        };
 
         mat->Bind(cl, rc);
 
@@ -534,31 +549,24 @@ void TextManager::EmitGlyphRun(int x, int y, float xOffset, const float4& color,
     Vertex* const vData = verts_.data() + baseVert;
     uint32_t* const iData = idx_.data() + baseIdx;
 
-    float2 shadowOffset = { 0.0f, 0.0f };
-    float4 shadowColor = { 0.0f, 0.0f, 0.0f, 0.0f };
+    float shadowScale = 0.0f;
+    float shadowAlpha = 0.0f;
 
     if (enableShadow && shadow_.has_value()) {
         const ShadowDesc& desc = shadow_.value();
-        float offsetX = desc.offsetX;
-        float offsetY = desc.offsetY;
-        if (desc.scaleWithTextSize) {
-            offsetX *= scale;
-            offsetY *= scale;
-        }
+        float offsetScale = (desc.scaleWithTextSize ? scale : 1.0f);
         if (desc.scaleWithDpi) {
-            offsetX *= dpi_;
-            offsetY *= dpi_;
+            offsetScale *= dpi_;
         }
         else {
-            offsetX = 0.0f;
-            offsetY = 0.0f;
+            offsetScale = 0.0f;
         }
 
         const float baseAlpha = desc.color.w * desc.alphaMultiplier * color.w;
         const float finalAlpha = std::clamp(baseAlpha, 0.0f, 1.0f);
         if (finalAlpha > 0.0f) {
-            shadowOffset = { offsetX, offsetY };
-            shadowColor = { desc.color.x, desc.color.y, desc.color.z, finalAlpha };
+            shadowScale = offsetScale;
+            shadowAlpha = finalAlpha;
         }
     }
 
@@ -574,25 +582,25 @@ void TextManager::EmitGlyphRun(int x, int y, float xOffset, const float4& color,
         const float gh = float(gph->h) * scale;
 
         Vertex* curV = vData + glyphCounter * 4;
-        Vertex v;
-        v.pos.x = gx; v.pos.y = gy; v.pos.z = 0.0f;
+        Vertex v{};
         v.col = color;
-        v.uv.x = gph->u0; v.uv.y = gph->v0;
-        v.shadowOffset = shadowOffset; v.shadowColor = shadowColor;
+        v.shadowParams = { shadowScale, shadowAlpha };
+
+        v.pos = { gx, gy };
+        v.uv = { gph->u0, gph->v0 };
         curV[0] = v;
-        //curV[0] = { {gx,      gy,      0.0f}, color, {gph->u0, gph->v0}, shadowOffset, shadowColor };
-        v.pos.x = gx + gw; v.pos.y = gy;
-        v.uv.x = gph->u1; v.uv.y = gph->v0;
+
+        v.pos = { gx + gw, gy };
+        v.uv = { gph->u1, gph->v0 };
         curV[1] = v;
-        //curV[1] = { {gx + gw, gy,      0.0f}, color, {gph->u1, gph->v0}, shadowOffset, shadowColor };
-        v.pos.x = gx + gw; v.pos.y = gy + gh;
-        v.uv.x = gph->u1; v.uv.y = gph->v1;
+
+        v.pos = { gx + gw, gy + gh };
+        v.uv = { gph->u1, gph->v1 };
         curV[2] = v;
-        //curV[2] = { {gx + gw, gy + gh, 0.0f}, color, {gph->u1, gph->v1}, shadowOffset, shadowColor };
-        v.pos.x = gx; v.pos.y = gy + gh;
-        v.uv.x = gph->u0; v.uv.y = gph->v1;
+
+        v.pos = { gx, gy + gh };
+        v.uv = { gph->u0, gph->v1 };
         curV[3] = v;
-        //curV[3] = { {gx,      gy + gh, 0.0f}, color, {gph->u0, gph->v1}, shadowOffset, shadowColor };
 
         uint32_t* curI = iData + glyphCounter * 6;
         const uint32_t base = static_cast<uint32_t>(baseVert + glyphCounter * 4);
@@ -616,13 +624,29 @@ void TextManager::EmitTextImmediate(int x, int y, float px, const float4& color,
 void TextManager::EmitRect(int x, int y, float w, float h, const float4& color) {
     const float gx = (float)x, gy = (float)y;
     const float gw = w, gh = h;
-    const uint32_t base = (uint32_t)rectVerts_.size();
-    const float2 zeroOffset{ 0.0f, 0.0f };
-    const float4 zeroShadow{ 0.0f, 0.0f, 0.0f, 0.0f };
-    rectVerts_.push_back({ {gx,      gy,      0}, color, {0,0}, zeroOffset, zeroShadow });
-    rectVerts_.push_back({ {gx + gw, gy,      0}, color, {0,0}, zeroOffset, zeroShadow });
-    rectVerts_.push_back({ {gx + gw, gy + gh, 0}, color, {0,0}, zeroOffset, zeroShadow });
-    rectVerts_.push_back({ {gx,      gy + gh, 0}, color, {0,0}, zeroOffset, zeroShadow });
-    rectIdx_.push_back(base + 0u); rectIdx_.push_back(base + 1u); rectIdx_.push_back(base + 2u);
-    rectIdx_.push_back(base + 0u); rectIdx_.push_back(base + 2u); rectIdx_.push_back(base + 3u);
+    const size_t baseVert = rectVerts_.appendUninitialized(4);
+    Vertex* vData = rectVerts_.data() + baseVert;
+
+    Vertex v{};
+    v.col = color;
+    v.uv = { 0.0f, 0.0f };
+    v.shadowParams = { 0.0f, 0.0f };
+
+    v.pos = { gx, gy };
+    vData[0] = v;
+
+    v.pos = { gx + gw, gy };
+    vData[1] = v;
+
+    v.pos = { gx + gw, gy + gh };
+    vData[2] = v;
+
+    v.pos = { gx, gy + gh };
+    vData[3] = v;
+
+    const size_t baseIdx = rectIdx_.appendUninitialized(6);
+    uint32_t* iData = rectIdx_.data() + baseIdx;
+    const uint32_t base = static_cast<uint32_t>(baseVert);
+    iData[0] = base + 0u; iData[1] = base + 1u; iData[2] = base + 2u;
+    iData[3] = base + 0u; iData[4] = base + 2u; iData[5] = base + 3u;
 }

--- a/sources/text/TextManager.h
+++ b/sources/text/TextManager.h
@@ -73,11 +73,10 @@ public:
 
 private:
     struct Vertex {
-        float3 pos;
+        float2 pos;
         float4 col;
         float2 uv;
-        float2 shadowOffset;
-        float4 shadowColor;
+        float2 shadowParams; // x = offset scale factor, y = final shadow alpha
     };
 
     // Precomputed glyph run for a single line
@@ -227,8 +226,8 @@ private:
     D3D12_VERTEX_BUFFER_VIEW vbv_{};
     D3D12_INDEX_BUFFER_VIEW  ibv_{};
 
-    std::vector<Vertex>      rectVerts_;
-    std::vector<uint32_t>    rectIdx_;
+    GrowOnlyArray<Vertex>    rectVerts_;
+    GrowOnlyArray<uint32_t>  rectIdx_;
     D3D12_VERTEX_BUFFER_VIEW rectVBV_{};
     D3D12_INDEX_BUFFER_VIEW  rectIBV_{};
 


### PR DESCRIPTION
## Summary
- shrink the text vertex format further by keeping float2 positions alongside the compact shadow parameters
- update glyph emission to use stack-local vertex writes and convert rectangle buffers to grow-only arrays
- move static shadow data into renamed shader constants, drop the enabled flag, and refresh the text/UI shaders plus the PosColorUV input layout accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e191a27883299a0953f9b9f43214