### PR TITLE
Remove SSR texture size override controls

### DIFF
--- a/shaders/ssr_cs.hlsl
+++ b/shaders/ssr_cs.hlsl
@@ -222,16 +222,21 @@ SSRHit TraceSSR_Lettier(float3 Pv, float3 Nv)
 [numthreads(8, 8, 1)]
 void CSMain(uint3 dispatchThreadId : SV_DispatchThreadID)
 {
-    uint width, height;
-    LightTarget.GetDimensions(width, height);
+    uint renderWidth, renderHeight;
+    LightTarget.GetDimensions(renderWidth, renderHeight);
+    uint ssrWidth, ssrHeight;
+    SsrOut.GetDimensions(ssrWidth, ssrHeight);
 
-    if (dispatchThreadId.x >= width || dispatchThreadId.y >= height)
+    if (dispatchThreadId.x >= ssrWidth || dispatchThreadId.y >= ssrHeight)
     {
         return;
     }
 
-    float2 pixel = float2(dispatchThreadId.xy);
-    float2 uv = (pixel + 0.5f) / screenSize;
+    float2 fullRes = float2(renderWidth, renderHeight);
+    float2 ssrRes = float2(max(ssrWidth, 1u), max(ssrHeight, 1u));
+    float2 pixelScale = fullRes / ssrRes;
+    float2 pixel = (float2(dispatchThreadId.xy) + 0.5f) * pixelScale;
+    float2 uv = pixel / fullRes;
 
     float depth = ReadDepth(uv);
     float4 result = float4(0, 0, 0, 0);
@@ -245,8 +250,8 @@ void CSMain(uint3 dispatchThreadId : SV_DispatchThreadID)
         SSRHit ssr = TraceSSR_Lettier(Pv, Nv);
         if (ssr.hit != 0)
         {
-            int2 ip = int2(ssr.uv * screenSize + 0.5);
-            ip = clamp(ip, int2(0, 0), int2(width - 1, height - 1));
+            int2 ip = int2(ssr.uv * float2(renderWidth, renderHeight) + 0.5);
+            ip = clamp(ip, int2(0, 0), int2(int(renderWidth) - 1, int(renderHeight) - 1));
             float3 c = LightTarget.Load(int3(ip, 0)).rgb;
             float vis = ssr.visibility;
             result = float4(c * vis, vis);

--- a/sources/app/Scene.cpp
+++ b/sources/app/Scene.cpp
@@ -1301,8 +1301,10 @@ void Scene::Pass_SSR(Renderer* renderer, RenderGraph::PassContext ctx,
 
         matSSR_->Bind(t.cl, rc);
         constexpr UINT kGroupSize = 8;
-        const UINT groupsX = (renderer->GetWidth() + kGroupSize - 1u) / kGroupSize;
-        const UINT groupsY = (renderer->GetHeight() + kGroupSize - 1u) / kGroupSize;
+        const UINT ssrWidth = renderer->GetSsrTextureWidth();
+        const UINT ssrHeight = renderer->GetSsrTextureHeight();
+        const UINT groupsX = (ssrWidth + kGroupSize - 1u) / kGroupSize;
+        const UINT groupsY = (ssrHeight + kGroupSize - 1u) / kGroupSize;
         t.cl->Dispatch(groupsX, groupsY, 1);
         renderer->UAVBarrier(t.cl, D.ssr.Get());
     }
@@ -1318,15 +1320,18 @@ void Scene::Pass_SSR_Blur(Renderer* renderer, RenderGraph::PassContext ctx)
         GPU_SCOPE(t.cl, ProfilerScopes::kPassSSRBlur);
         const auto& D = renderer->GetDeferredForFrame();
         constexpr UINT kGroupSize = 8;
-        const UINT groupsX = (renderer->GetWidth() + kGroupSize - 1u) / kGroupSize;
-        const UINT groupsY = (renderer->GetHeight() + kGroupSize - 1u) / kGroupSize;
+        const UINT ssrWidth = renderer->GetSsrTextureWidth();
+        const UINT ssrHeight = renderer->GetSsrTextureHeight();
+        const UINT groupsX = (ssrWidth + kGroupSize - 1u) / kGroupSize;
+        const UINT groupsY = (ssrHeight + kGroupSize - 1u) / kGroupSize;
 
         // Horizontal pass
         renderer->Transition(t.cl, D.ssr.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
         renderer->Transition(t.cl, D.ssrBlur.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
         auto cb = renderer->GetFrameResource()->AllocDynamic(matBlur_->GetCBSizeBytesAligned(0, 256), 256);
-        float2 dir = float2(1.0f / renderer->GetWidth(), 0.0f);
+        const float invSsrWidth = ssrWidth > 0 ? (1.0f / static_cast<float>(ssrWidth)) : 0.0f;
+        float2 dir = float2(invSsrWidth, 0.0f);
         matBlur_->UpdateCBField(cbHandles_.blur.dir, dir, (uint8_t*)cb.cpu);
         matBlur_->UpdateCBField(cbHandles_.blur.radius, 1.0f, (uint8_t*)cb.cpu);
 
@@ -1348,7 +1353,8 @@ void Scene::Pass_SSR_Blur(Renderer* renderer, RenderGraph::PassContext ctx)
         renderer->Transition(t.cl, D.ssr.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
         cb = renderer->GetFrameResource()->AllocDynamic(matBlur_->GetCBSizeBytesAligned(0, 256), 256);
-        dir = float2(0.0f, 1.0f / renderer->GetHeight());
+        const float invSsrHeight = ssrHeight > 0 ? (1.0f / static_cast<float>(ssrHeight)) : 0.0f;
+        dir = float2(0.0f, invSsrHeight);
         matBlur_->UpdateCBField(cbHandles_.blur.dir, dir, (uint8_t*)cb.cpu);
         matBlur_->UpdateCBField(cbHandles_.blur.radius, 1.0f, (uint8_t*)cb.cpu);
 

--- a/sources/rendering/core/Renderer.cpp
+++ b/sources/rendering/core/Renderer.cpp
@@ -2,6 +2,7 @@
 #include "core/Helpers.h"
 #include <cassert>
 #include <vector>
+#include <utility>
 #include <dxgidebug.h>
 #pragma comment(lib, "dxguid.lib")
 #include <d3d12sdklayers.h> // ID3D12Debug*, ID3D12InfoQueue
@@ -1082,9 +1083,13 @@ void Renderer::CreateDeferredTargets(UINT width, UINT height)
         UINT f,
         ComPtr<ID3D12Resource>& outRes,
         D3D12_CPU_DESCRIPTOR_HANDLE& outSRV,
-        D3D12_CPU_DESCRIPTOR_HANDLE& outUAV)
+        D3D12_CPU_DESCRIPTOR_HANDLE& outUAV,
+        UINT overrideWidth,
+        UINT overrideHeight)
         {
             D3D12_RESOURCE_DESC rd = MakeTex2DDesc(fmt, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+            if (overrideWidth > 0) { rd.Width = overrideWidth; }
+            if (overrideHeight > 0) { rd.Height = overrideHeight; }
 
             ThrowIfFailed(dev->CreateCommittedResource(
                 &heapProps, D3D12_HEAP_FLAG_NONE, &rd,
@@ -1125,6 +1130,10 @@ void Renderer::CreateDeferredTargets(UINT width, UINT height)
 
             SetResourceState(outRes.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
         };
+
+    const auto ssrSize = ComputeSsrTextureSize(width, height);
+    ssrTextureWidth_ = ssrSize.first > 0 ? ssrSize.first : 1;
+    ssrTextureHeight_ = ssrSize.second > 0 ? ssrSize.second : 1;
 
     auto CreateDepth = [&](DXGI_FORMAT dsvFmt,
         UINT f,
@@ -1285,9 +1294,9 @@ void Renderer::CreateDeferredTargets(UINT width, UINT height)
 
         CreateRT(kLightTargetFormat, DeferredRtvSlot::Light, DeferredSrvSlot::Light, DeferredSrvSlot::LightUAV, f, D.light, D.lightRTV, D.lightSRV);
         CreateRT(kSceneColorFormat, DeferredRtvSlot::Scene, DeferredSrvSlot::Scene, DeferredSrvSlot::SceneUAV, f, D.scene, D.sceneRTV, D.sceneSRV);
-        CreateSrvUavTexture(kSsrFormat, DeferredSrvSlot::SSR, DeferredSrvSlot::SSRUAV, f, D.ssr, D.ssrSRV, D.ssrUAV);
-        CreateSrvUavTexture(kSsrBlurFormat, DeferredSrvSlot::SSRBlur, DeferredSrvSlot::SSRBlurUAV, f, D.ssrBlur, D.ssrBlurSRV, D.ssrBlurUAV);
-        CreateSrvUavTexture(kBackbufferResourceFormat, DeferredSrvSlot::Tonemap, DeferredSrvSlot::TonemapUAV, f, D.tonemap, D.tonemapSRV, D.tonemapUAV);
+        CreateSrvUavTexture(kSsrFormat, DeferredSrvSlot::SSR, DeferredSrvSlot::SSRUAV, f, D.ssr, D.ssrSRV, D.ssrUAV, ssrTextureWidth_, ssrTextureHeight_);
+        CreateSrvUavTexture(kSsrBlurFormat, DeferredSrvSlot::SSRBlur, DeferredSrvSlot::SSRBlurUAV, f, D.ssrBlur, D.ssrBlurSRV, D.ssrBlurUAV, ssrTextureWidth_, ssrTextureHeight_);
+        CreateSrvUavTexture(kBackbufferResourceFormat, DeferredSrvSlot::Tonemap, DeferredSrvSlot::TonemapUAV, f, D.tonemap, D.tonemapSRV, D.tonemapUAV, width, height);
     }
 }
 
@@ -1324,6 +1333,71 @@ void Renderer::DestroyDeferredTargets() {
             knownStates_.erase(res);
         }
     }
+
+    ssrTextureWidth_ = 1;
+    ssrTextureHeight_ = 1;
+}
+
+std::pair<UINT, UINT> Renderer::ComputeSsrTextureSize(UINT baseWidth, UINT baseHeight) const
+{
+    const UINT refWidth = std::max(baseWidth, 1u);
+    const UINT refHeight = std::max(baseHeight, 1u);
+
+    auto computeDim = [](UINT dim, float scale) -> UINT
+    {
+        if (scale <= 0.0f)
+        {
+            return 1u;
+        }
+        const float scaled = static_cast<float>(dim) * scale;
+        const UINT value = static_cast<UINT>(scaled + 0.5f);
+        return std::max(1u, value);
+    };
+
+    const UINT ssrWidth = computeDim(refWidth, ssrTextureScale_.x);
+    const UINT ssrHeight = computeDim(refHeight, ssrTextureScale_.y);
+    return { ssrWidth, ssrHeight };
+}
+
+void Renderer::RecreateDeferredTargets()
+{
+    if (!device_ || width_ == 0 || height_ == 0)
+    {
+        return;
+    }
+
+    WaitForPreviousFrame();
+    DestroyDeferredTargets();
+    CreateDeferredTargets(width_, height_);
+}
+
+void Renderer::SetSsrTextureScale(Math::float2 scale)
+{
+    Math::float2 sanitized{ scale.x, scale.y };
+    if (sanitized.x < 0.0f) { sanitized.x = 0.0f; }
+    if (sanitized.y < 0.0f) { sanitized.y = 0.0f; }
+
+    if (sanitized.x == ssrTextureScale_.x && sanitized.y == ssrTextureScale_.y)
+    {
+        return;
+    }
+
+    ssrTextureScale_ = sanitized;
+
+    if (deferredRtvHeap_)
+    {
+        RecreateDeferredTargets();
+    }
+}
+
+UINT Renderer::GetSsrTextureWidth() const
+{
+    return std::max(1u, ssrTextureWidth_);
+}
+
+UINT Renderer::GetSsrTextureHeight() const
+{
+    return std::max(1u, ssrTextureHeight_);
 }
 
 void Renderer::BindGBuffer(ID3D12GraphicsCommandList* cl, ClearMode mode) {

--- a/sources/rendering/core/Renderer.h
+++ b/sources/rendering/core/Renderer.h
@@ -5,7 +5,9 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <utility>
 
+#include "core/Math.h"
 #include "rendering/descriptors/DescriptorAllocator.h"
 #include "rendering/core/FrameResource.h"
 #include "third_party/robin_hood.h"
@@ -171,6 +173,12 @@ public:
     void Transition(ID3D12GraphicsCommandList* cl, ID3D12Resource* res, D3D12_RESOURCE_STATES after);
     void UAVBarrier(ID3D12GraphicsCommandList* cl, ID3D12Resource* res);
 
+    void SetSsrTextureScale(Math::float2 scale);
+    void SetSsrTextureScale(float scale) { SetSsrTextureScale(Math::float2(scale, scale)); }
+    Math::float2 GetSsrTextureScale() const { return ssrTextureScale_; }
+    UINT GetSsrTextureWidth() const;
+    UINT GetSsrTextureHeight() const;
+
     template<class Alloc, class It>
     inline GpuDescHandle StageDescriptorTableRange(
         Alloc& alloc,
@@ -243,6 +251,8 @@ private:
     void WaitForFrame(UINT frameIndex);   // wait for a specific frame (by that frame's fence value)
     void SignalFrame(UINT frameIndex);    // signal the fence for a frame
     void RefreshCurrentFrameCaches();
+    std::pair<UINT, UINT> ComputeSsrTextureSize(UINT baseWidth, UINT baseHeight) const;
+    void RecreateDeferredTargets();
 
     D3D12_CPU_DESCRIPTOR_HANDLE DeferredRtvAt(UINT idx) const;
     D3D12_CPU_DESCRIPTOR_HANDLE DeferredDsvAt(UINT idx) const;
@@ -293,6 +303,10 @@ private:
     HWND  hWnd_ = nullptr;
     UINT  width_ = 1600;
     UINT  height_ = 900;
+
+    Math::float2 ssrTextureScale_ = Math::float2(0.5f, 0.5f);
+    UINT ssrTextureWidth_ = 1;
+    UINT ssrTextureHeight_ = 1;
 
     bool wireframeMode_ = false;
 


### PR DESCRIPTION
## Summary
- add renderer controls to scale SSR texture dimensions with a half-resolution default
- size SSR render targets and blur resources based on the configured resolution
- update SSR compute shader and dispatch parameters to operate on the reduced-resolution textures safely
- remove the SSR texture size override API to rely solely on scaling controls

## Testing
- Not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e4f58b849c8329a02811d85f7aa8cc