### PR TITLE
Refactor glass cube renderable into dedicated files

### DIFF
--- a/docs/transparent_objects_lighting_report.md
+++ b/docs/transparent_objects_lighting_report.md
@@ -1,0 +1,106 @@
+# Transparent Objects Lighting and Shadowing in Modern Rendering Engines
+
+## Overview
+Transparent or translucent materials allow light to pass through while still interacting with illumination and shadowing cues. Rendering them convincingly is challenging because transparency breaks the single-depth assumption underpinning standard rasterization pipelines and shadow maps. Modern game and real-time engines therefore employ specialized data structures, shading models, and compositing passes to balance physical accuracy with performance.
+
+Key goals for transparent rendering include:
+
+* **Accurate depth ordering.** Ensuring fragments are blended in the correct back-to-front order so that lighting contributions accumulate properly.
+* **Consistent lighting response.** Supporting direct lighting, indirect lighting, and reflections in a way that matches opaque surfaces.
+* **Shadow integration.** Allowing transparent receivers to cast and receive shadows, including colored transmission and partial occlusion.
+* **Performance scalability.** Keeping algorithms tractable across consumer hardware by limiting per-pixel complexity.
+
+## Transparency Classification
+
+Modern engines differentiate between several transparency classes:
+
+1. **Binary transparency** (alpha-tested or masked) uses a hard cutoff and can remain in the opaque pass. It inherits all opaque lighting and shadow features because the geometry writes depth.
+2. **Additive or emissive transparency** (e.g., particles) is usually rendered in a forward+ or blended pass without shadow reception to reduce cost.
+3. **Physically based transmissive materials** (glass, water, thin film) require refraction, reflection, and partial shadowing. These assets typically use dedicated material domains or shading models with added lighting support.
+
+## Depth Ordering Techniques
+
+Because the GPU depth buffer stores only one surface per pixel, transparent fragments must be resolved in a separate pass. Engines choose between:
+
+* **Sorted draw calls:** Geometry is sorted back-to-front on the CPU. Simple and common for low overdraw scenes (Unity standard transparent queue, Unreal forward shading). Draw order becomes difficult for intersecting surfaces.
+* **Depth peeling:** Multiple passes peel successive layers using depth min/max tests. Accurate but expensive; often limited to tools or cinematics.
+* **Weighted blended order-independent transparency (WBOIT):** Uses per-pixel color and weight accumulation buffers to approximate sorted blending in a single pass. Supported in engines like Unity's Scriptable Render Pipeline and Unreal's Niagara for particles.
+* **Per-pixel linked lists (PPLL):** Records all fragments in GPU memory for sorting per pixel. Offers higher quality but is memory intensive; used selectively in custom rendering pipelines.
+
+## Lighting Models for Transparent Materials
+
+### Forward Shading Path
+
+Many engines evaluate lighting for transparent surfaces in a forward shading pass after opaque rendering. The material shader samples:
+
+* **Direct lighting:** Calculated per-light, respecting surface normal, Fresnel, and transmittance. Forward+ clustering or tiled lighting keeps light counts manageable.
+* **Specular reflections:** Sampled via reflection probes or screen-space reflections (SSR). Transparent materials often favor planar or cubemap probes because SSR can fail without a depth hit.
+* **Refraction:** Obtained from scene color buffers (grab pass) warped by the surface normal or using ray-marched signed distance fields for thick glass.
+* **Transmission and attenuation:** Beer-Lambert absorption models the tint picked up while light travels through the medium.
+
+### Deferred or Hybrid Approaches
+
+Classic deferred shading struggles with transparency because G-buffers cannot store multiple layers. Engines therefore mix deferred opaque passes with forward transparent passes (deferred+). Unreal Engine 5, Unity HDRP, and Frostbite all follow this hybrid pipeline, enabling transparent materials to reuse lighting data (e.g., light lists, shadow maps) computed for opaque geometry.
+
+## Shadow Reception Strategies
+
+Transparent receivers need soft, partial shadows to avoid looking detached. Techniques include:
+
+* **Shadow map sampling with alpha:** Transparent objects use the alpha of their material to modulate shadow map depth tests. Unreal's "Masked" materials and Unity's alpha-tested materials do this in the main shadow pass.
+* **Transmission in shadow maps:** For translucent surfaces, engines store opacity or thickness in shadow map texels. Unreal's "Per-Pixel Translucency Shadow" and Unity HDRP's "Thin Transmittance" allow directional lights to evaluate Beer-Lambert absorption during shadow lookups, creating colored lighting through stained glass.
+* **Screen-space contact shadows:** After the main shadow pass, a screen-space ray marching step (SSCS) refines contact shadows for thin geometry that missed in the coarse shadow map.
+* **Ray traced shadows:** With hardware ray tracing, transparent materials can participate in physically correct shadowing (transmission, caustics). Unreal's Lumen and Unity's HDRP ray-traced shadows provide options to include translucent geometry, although often at higher cost.
+
+## Engine-Specific Implementations
+
+### Unreal Engine (4 & 5)
+
+* Uses a deferred main pass for opaques and forward shading for translucency.
+* Translucent materials can enable **"Render After DOF"** and **"Lighting Mode"** options (Surface ForwardShading, Volumetric NonDirectional, etc.) to select lighting features.
+* Supports **Translucency Lighting Volume (TLV)** for indirect light and **Separate Translucency** for post-process effects.
+* Shadowing: directional lights offer **"Per-Pixel Translucency Shadows"**; local lights provide **"Contact Shadows"** or ray-traced translucency. Materials expose parameters for **"Transmission Color"** and **"Opacity"** to control tint.
+
+### Unity (Built-in & SRP)
+
+* Built-in pipeline sorts transparent objects and shades them in forward passes. Lights affecting transparent objects are limited to four per object unless using deferred + forward add.
+* High Definition Render Pipeline (HDRP) adds **"Lit"** and **"Unlit"** transparent material types with features like refraction models (Proxy, Box, Sphere) and screen-space refraction.
+* HDRP implements **"Density Volume"** and **"Fog"** for volumetric contributions, and allows transparent receivers to sample shadow maps via **shadow matte** options.
+* Universal Render Pipeline (URP) supports approximate WBOIT for particles and uses **"Transparent Receive Shadows"** toggle to opt-in per material.
+
+### Frostbite & Other AAA Engines
+
+* Employ cluster-based or tiled forward lighting for transparency.
+* Store transmittance or thickness in auxiliary buffers (e.g., "deep G-buffer") to feed into global illumination and shadowing.
+* Integrate volumetric fog and lighting to ensure transparent media participates in atmospheric scattering.
+
+## Volumetric and Participating Media
+
+Transparent rendering extends to volumetric effects (smoke, fog). Engines render these using 3D textures or voxel grids, accumulating lighting along view rays. Shadows are injected via light volumes or froxel grids. Techniques such as **epipolar sampling** and **temporal reprojection** keep volumetric lighting stable and performant.
+
+## Best Practices for Production
+
+1. **Limit overlap complexity:** Reduce self-intersecting transparent surfaces or use WBOIT to avoid sorting artifacts.
+2. **Use thickness maps:** Provide per-pixel thickness so absorption and shadowing behave consistently across the asset.
+3. **Leverage hybrid lighting:** Keep opaques in deferred passes and transparents in forward passes to share shadow data without duplicating work.
+4. **Adjust shadow quality per asset:** High-quality translucency shadows are expensive; reserve them for hero assets.
+5. **Balance post-processing:** Effects like bloom, depth of field, and TAA interact strongly with transparent passes; ensure they are configured to avoid ghosting.
+
+## Emerging Trends
+
+* **Hardware-accelerated ray tracing** enables more accurate refraction, caustics, and multi-bounce transmission for glass and water. Engines increasingly expose ray-traced translucency options for next-gen platforms.
+* **Stochastic transparency and reservoir sampling** apply Monte Carlo techniques to approximate multiple scattering and caustics in real time.
+* **Neural rendering** approaches (neural radiance fields, learned denoisers) aim to reduce the cost of multi-layer light transport and may eventually handle transparency with fewer hacks.
+
+## Suggested Next Steps for the Test Cube Renderer
+
+1. **Stabilize depth ordering in the transparent pass.** `Scene::Pass_Transparent` replays the `TransparentSimple` and `TransparentComplex` buckets without sorting them by eye-space depth or performing order-independent blending, so the draw order currently depends on how objects were inserted into the scene list. Introducing per-frame depth sorting (back-to-front for blending, front-to-back for weighted additive) or adopting a single-pass approximation such as weighted blended order-independent transparency (WBOIT) would keep overlapping glass, particle, and ocean layers consistent even as the camera moves or assets animate.
+2. **Disable depth writes when blending is enabled.** Transparency is detected through `RenderableObject::IsTransparent`, which checks whether `GraphicsDesc::blend.RenderTarget[0].BlendEnable` is set. However, `GraphicsDesc::FillDefaultsTriangle` still initializes every pipeline with `DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL`, meaning blended draws can still occlude later layers and break refraction or fog composition. For any material that enables blending, explicitly switch the depth write mask to zero (while keeping depth testing enabled) or provide a material flag that lets artists control depth writes per asset.
+3. **Add transmission inputs for forward-lit materials.** The forward shading path used by ocean and other transparent objects currently binds scene color and depth but does not expose per-pixel thickness or shadow-matte data beyond the opaque G-buffer (which stores only albedo, metalness, roughness, and normals). Adding lightweight transmission parameters—such as Beer-Lambert absorption coefficients, thickness maps, or dual-source color outputs—to the transparent shaders would let directional and punctual lights tint through glass, water, or volumetric layers instead of relying solely on additive highlights.
+
+## References & Further Reading
+
+* Unreal Engine Documentation – Translucency Overview
+* Unity HDRP Documentation – Transparent Surface Type
+* NVIDIA Developer – Advanced Order-Independent Transparency
+* SIGGRAPH Courses on Real-Time Rendering Techniques
+

--- a/shaders/glass.hlsl
+++ b/shaders/glass.hlsl
@@ -1,0 +1,333 @@
+// RootSignature: CBV(b0) TABLE(SRV(t0,t1,t2,t3)) TABLE(SRV(t4,t5)) TABLE(SAMPLER(s0,s1,s2))
+#pragma pack_matrix(row_major)
+#include "utils.hlsl"
+
+struct PointLightData
+{
+    float3 position;
+    float radius;
+    float3 color;
+    float intensity;
+};
+
+struct SpotLightData
+{
+    float4 positionRange;      // xyz = position, w = range
+    float4 directionCosOuter;  // xyz = direction, w = cos(outer)
+    float4 colorIntensity;     // xyz = color, w = intensity
+    float4 shadowParams;       // x = cos(inner), y = shadow index, z = invAngleRange, w = depth bias
+    float4 shadowParams2;      // x = normal bias (world units)
+    float4x4 viewProj;
+};
+
+cbuffer GlassParams : register(b0)
+{
+    float4x4 world;
+    float4x4 view;
+    float4x4 proj;
+    float4x4 invView;
+    float4x4 invProj;
+    float4 cameraPosIor;          // xyz = camera position, w = IOR
+    float4 absorptionThickness;   // xyz = absorption, w = thickness
+    float4 tintRoughness;         // xyz = tint color, w = roughness
+    float4 reflectionRefraction;  // x = reflection strength, y = refraction distortion, z = sky intensity, w = unused
+    float4 sunDirAmbient;         // xyz = sun direction, w = ambient intensity
+    float4 sunColorExposure;      // xyz = sun color, w = sun exposure
+    float4 camDirWS;              // xyz = camera forward, w unused
+    float4 screenSizeInv;         // xy = screen size, zw = inverse screen size
+    float4 shadowAtlasSizeInv;    // xy = atlas size, zw = inverse atlas size
+    float4 shadowBiasNDC;         // cascade depth bias
+    float4 normalBiasWS;          // cascade normal bias
+    float4 cascadeSplitsVS;       // cascade splits in view space
+    float4 cascadeScaleBias[4];   // xy = scale, zw = bias per cascade
+    float4 spotShadowInfo;        // xy = spot shadow size, zw = inverse size
+    float4 lightCounts;           // x = point lights, y = spot lights
+    float4x4 lightViewProj[4];
+};
+
+Texture2D SceneOpaque : register(t0);
+Texture2D ShadowAtlas : register(t1);
+Texture2DArray SpotShadowAtlas : register(t2);
+TextureCube SkyboxTex : register(t3);
+StructuredBuffer<PointLightData> PointLights : register(t4);
+StructuredBuffer<SpotLightData> SpotLights : register(t5);
+
+SamplerState LinearSampler : register(s0);
+SamplerComparisonState ShadowSampler : register(s1);
+SamplerState EnvSampler : register(s2);
+
+struct VSIn
+{
+    float3 P : POSITION;
+    float3 N : NORMAL;
+    float4 T : TANGENT;
+    float2 UV : TEXCOORD0;
+};
+
+struct VSOut
+{
+    float4 posH : SV_POSITION;
+    float3 posWS : TEXCOORD0;
+    float3 normalWS : TEXCOORD1;
+};
+
+VSOut VSMain(VSIn input)
+{
+    VSOut o;
+    float4 worldPos = mul(float4(input.P, 1.0f), world);
+    o.posWS = worldPos.xyz;
+    o.posH = mul(mul(worldPos, view), proj);
+    float3x3 w3 = (float3x3) world;
+    o.normalWS = NormalizeSafe(mul(input.N, w3), float3(0.0f, 1.0f, 0.0f));
+    return o;
+}
+
+int ChooseCascadeIndex(float3 Pws)
+{
+    float3 camPos = cameraPosIor.xyz;
+    float3 camDir = normalize(camDirWS.xyz);
+    float z = dot(Pws - camPos, camDir);
+    float3 gt = saturate(sign(z.xxx - cascadeSplitsVS.yzw));
+    return (int)(gt.x + gt.y + gt.z);
+}
+
+float ShadowPCF3x3Texture(Texture2D atlas, float2 uv, float depth, float2 texel)
+{
+    float s = 0.0f;
+    [unroll]
+    for (int y = -1; y <= 1; ++y)
+    {
+        [unroll]
+        for (int x = -1; x <= 1; ++x)
+        {
+            float2 offset = float2(x, y) * texel;
+            s += atlas.SampleCmpLevelZero(ShadowSampler, uv + offset, depth);
+        }
+    }
+    return s / 9.0f;
+}
+
+float SampleShadowCSM(float3 Pws, float3 Nws, float NdotL)
+{
+    int idx = ChooseCascadeIndex(Pws);
+    float4 sb = cascadeScaleBias[idx];
+    float2 scale = sb.xy;
+    float2 bias = sb.zw;
+
+    float normalBias = normalBiasWS[idx];
+    float depthBias = shadowBiasNDC[idx];
+
+    float3 Poff = Pws + Nws * normalBias;
+    float4 clip = mul(float4(Poff, 1.0f), lightViewProj[idx]);
+    float3 ndc = clip.xyz / max(clip.w, 1e-6f);
+    float2 uv = ndc.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
+    float z = ndc.z;
+
+    uv = uv * scale + bias;
+
+    if (any(uv < 0.0f) || any(uv > 1.0f))
+    {
+        return 1.0f;
+    }
+
+    float biasFactor = depthBias + (1.0f - NdotL) * depthBias;
+    float2 texel = shadowAtlasSizeInv.zw;
+    return ShadowPCF3x3Texture(ShadowAtlas, uv, z - biasFactor, texel);
+}
+
+float ShadowPCF3x3Array(Texture2DArray atlas, float3 uvw, float depth, float2 texel)
+{
+    float s = 0.0f;
+    [unroll]
+    for (int y = -1; y <= 1; ++y)
+    {
+        [unroll]
+        for (int x = -1; x <= 1; ++x)
+        {
+            float2 offset = float2(x, y) * texel;
+            s += atlas.SampleCmpLevelZero(ShadowSampler, float3(uvw.xy + offset, uvw.z), depth);
+        }
+    }
+    return s / 9.0f;
+}
+
+float SampleSpotShadow(const SpotLightData light, float3 P, float3 N, float NdotL)
+{
+    float normalBias = light.shadowParams2.x;
+    float depthBias = light.shadowParams.w;
+
+    float3 Poff = P + N * normalBias;
+    float4 clip = mul(float4(Poff, 1.0f), light.viewProj);
+    float3 ndc = clip.xyz / max(clip.w, 1e-6f);
+    float2 uv = ndc.xy * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
+    float depth = ndc.z;
+    if (any(uv < 0.0f) || any(uv > 1.0f) || depth <= 0.0f || depth >= 1.0f)
+    {
+        return 1.0f;
+    }
+
+    float3 uvw = float3(uv, light.shadowParams.y);
+    float2 texel = spotShadowInfo.zw;
+    return ShadowPCF3x3Array(SpotShadowAtlas, uvw, depth - depthBias, texel);
+}
+
+float4 PSMain(VSOut i) : SV_Target
+{
+    float3 N = normalize(i.normalWS);
+    float3 camPos = cameraPosIor.xyz;
+    float3 V = normalize(camPos - i.posWS);
+    float ior = max(cameraPosIor.w, 1.0f);
+    float3 absorption = max(absorptionThickness.xyz, 0.0f.xxx);
+    float thickness = max(absorptionThickness.w, 0.0f);
+    float3 tint = saturate(tintRoughness.xyz);
+    float rough = saturate(tintRoughness.w);
+    float reflectionStrength = max(reflectionRefraction.x, 0.0f);
+    float refractionDistortion = reflectionRefraction.y;
+    float skyIntensity = reflectionRefraction.z;
+
+    float3 sunDir = normalize(sunDirAmbient.xyz);
+    float ambientIntensity = sunDirAmbient.w;
+    float3 sunColor = sunColorExposure.xyz * sunColorExposure.w;
+
+    float3 diffuseAccum = tint * ambientIntensity;
+    float3 specAccum = 0.0f.xxx;
+
+    // Directional light
+    {
+        BRDFInput bi;
+        bi.albedo = tint;
+        bi.rough = rough;
+        bi.metal = 0.0f;
+        bi.N = N;
+        bi.V = V;
+        bi.L = normalize(-sunDir);
+
+        BRDFResult br = EvalBRDF(bi);
+        if (br.NdotL > 0.0f)
+        {
+            float shadow = SampleShadowCSM(i.posWS, N, br.NdotL);
+            float3 radiance = sunColor;
+            diffuseAccum += br.diffBRDF * br.NdotL * radiance * shadow;
+            specAccum += br.specBRDF * br.NdotL * radiance * shadow;
+        }
+    }
+
+    uint pointCount = (uint)lightCounts.x;
+    for (uint idx = 0; idx < pointCount; ++idx)
+    {
+        PointLightData light = PointLights[idx];
+        float3 Lvec = light.position - i.posWS;
+        float dist = length(Lvec);
+        if (dist > light.radius || light.radius <= kEpsilon)
+        {
+            continue;
+        }
+        float3 L = Lvec / max(dist, kEpsilon);
+        float atten = saturate(1.0f - dist / light.radius);
+        atten *= atten;
+
+        BRDFInput bi;
+        bi.albedo = tint;
+        bi.rough = rough;
+        bi.metal = 0.0f;
+        bi.N = N;
+        bi.V = V;
+        bi.L = L;
+
+        BRDFResult br = EvalBRDF(bi);
+        if (br.NdotL <= 0.0f)
+        {
+            continue;
+        }
+
+        float3 radiance = light.color * light.intensity * atten;
+        diffuseAccum += br.diffBRDF * br.NdotL * radiance;
+        specAccum += br.specBRDF * br.NdotL * radiance;
+    }
+
+    uint spotCount = (uint)lightCounts.y;
+    for (uint idx = 0; idx < spotCount; ++idx)
+    {
+        SpotLightData light = SpotLights[idx];
+        float3 Lvec = light.positionRange.xyz - i.posWS;
+        float dist = length(Lvec);
+        if (dist >= light.positionRange.w || light.positionRange.w <= kEpsilon)
+        {
+            continue;
+        }
+        float3 L = Lvec / max(dist, kEpsilon);
+
+        float spotCos = dot(-L, light.directionCosOuter.xyz);
+        if (spotCos <= light.directionCosOuter.w)
+        {
+            continue;
+        }
+
+        float angleAtten = saturate((spotCos - light.directionCosOuter.w) * light.shadowParams.z);
+        angleAtten *= angleAtten;
+
+        float distAtten = saturate(1.0f - dist / light.positionRange.w);
+        distAtten *= distAtten;
+
+        BRDFInput bi;
+        bi.albedo = tint;
+        bi.rough = rough;
+        bi.metal = 0.0f;
+        bi.N = N;
+        bi.V = V;
+        bi.L = L;
+
+        BRDFResult br = EvalBRDF(bi);
+        if (br.NdotL <= 0.0f)
+        {
+            continue;
+        }
+
+        float shadow = SampleSpotShadow(light, i.posWS, N, br.NdotL);
+        float3 radiance = light.colorIntensity.xyz * light.colorIntensity.w * distAtten * angleAtten;
+        diffuseAccum += br.diffBRDF * br.NdotL * radiance * shadow;
+        specAccum += br.specBRDF * br.NdotL * radiance * shadow;
+    }
+
+    float3 reflectionDir = reflect(-V, N);
+    float3 envRefl = SkyboxTex.SampleLevel(EnvSampler, reflectionDir, rough * 5.0f).rgb * skyIntensity;
+
+    float eta = 1.0f / ior;
+    float3 refrDir = refract(-V, N, eta);
+    bool totalInternal = dot(refrDir, refrDir) < 1e-6f;
+
+    float3 refrColor = 0.0f.xxx;
+    if (!totalInternal)
+    {
+        float3 refrPosWS = i.posWS + refrDir * thickness;
+        float4 clip = mul(mul(float4(refrPosWS, 1.0f), view), proj);
+        float2 uv = clip.xy / max(clip.w, 1e-6f);
+        uv = uv * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
+        uv += N.xy * refractionDistortion;
+        uv = saturate(uv);
+        refrColor = SceneOpaque.Sample(LinearSampler, uv).rgb;
+    }
+
+    float3 transmittance = exp(-absorption * thickness);
+    refrColor *= transmittance;
+
+    float cosTheta = saturate(dot(N, V));
+    float r0 = (ior - 1.0f) / (ior + 1.0f);
+    float3 F0 = float3(r0 * r0, r0 * r0, r0 * r0);
+    float3 F = F_Schlick(cosTheta, F0);
+    if (totalInternal)
+    {
+        F = 1.0f.xxx;
+    }
+
+    float3 lightingColor = diffuseAccum + specAccum;
+    float3 color = lightingColor + refrColor * (1.0f - F) + envRefl * (reflectionStrength * F);
+    color = max(color, 0.0f.xxx);
+
+    float transAvg = (transmittance.x + transmittance.y + transmittance.z) * (1.0f / 3.0f);
+    float Favg = (F.x + F.y + F.z) * (1.0f / 3.0f);
+    float alpha = saturate(1.0f - (1.0f - Favg) * transAvg);
+    alpha = saturate(alpha);
+
+    return float4(color, alpha);
+}

--- a/shaders/glass_csm.hlsl
+++ b/shaders/glass_csm.hlsl
@@ -1,0 +1,30 @@
+// RootSignature: CBV(b0)
+#pragma pack_matrix(row_major)
+#include "utils.hlsl"
+
+cbuffer PerObject : register(b0)
+{
+    float4x4 world;
+    float4x4 view;
+    float4x4 proj;
+};
+
+struct VSIn
+{
+    float3 P : POSITION;
+};
+
+struct VSOut
+{
+    float4 posH : SV_POSITION;
+};
+
+VSOut VSMain(VSIn input)
+{
+    VSOut o;
+    float4 worldPos = mul(float4(input.P, 1.0f), world);
+    o.posH = mul(mul(worldPos, view), proj);
+    return o;
+}
+
+void PSMain() {}

--- a/sources/app/Scene.cpp
+++ b/sources/app/Scene.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cassert>
 
 #include "input/InputManager.h"
 #include "app/Camera.h"
@@ -15,6 +16,7 @@
 #include "rendering/core/RenderGraph.h"
 #include "ocean/OceanRenderable.h"
 #include "rendering/meshes/StaticMesh.h"
+#include "rendering/renderables/GlassCube.h"
 #include "core/task/TaskSystem.h"
 #include "text/TextManager.h"
 #include "core/profiling/Profiler.h"
@@ -108,6 +110,42 @@ void Scene::CBHandleCache::ComposeHandles::Populate(Material* material)
     camPos = material->ComputeCB0FieldHandle("camPosWS");
     screenSize = material->ComputeCB0FieldHandle("screenSize");
     invScreenSize = material->ComputeCB0FieldHandle("invScreenSize");
+}
+
+const mat4& Scene::GetCascadeView(size_t index) const
+{
+    assert(index < static_cast<size_t>(kCascades));
+    return cachedLightView_[index];
+}
+
+const mat4& Scene::GetCascadeProj(size_t index) const
+{
+    assert(index < static_cast<size_t>(kCascades));
+    return cachedLightProj_[index];
+}
+
+float2 Scene::GetCascadeScale(size_t index) const
+{
+    assert(index < static_cast<size_t>(kCascades));
+    return cachedScale_[index];
+}
+
+float2 Scene::GetCascadeBias(size_t index) const
+{
+    assert(index < static_cast<size_t>(kCascades));
+    return cachedBias_[index];
+}
+
+float Scene::GetCascadeNormalBias(size_t index) const
+{
+    assert(index < static_cast<size_t>(kCascades));
+    return cachedNormalBiasWS_[index];
+}
+
+float Scene::GetCascadeDepthBias(size_t index) const
+{
+    assert(index < static_cast<size_t>(kCascades));
+    return cachedDepthBiasNDC_[index];
 }
 
 void Scene::RefreshCachedHandles(Renderer* renderer)
@@ -327,6 +365,18 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
     AddObject(std::make_unique<RotatingObject>("models/teapot.obj", "bronze", "PosNormTanUV", L"shaders/gbuffer.hlsl", float3(-1.0f, 0.5f, -1.0f), float3(1, 1, 1)));
     AddObject(std::make_unique<RotatingObject>("models/sphere.obj", "bronze", "PosNormTanUV", L"shaders/gbuffer.hlsl", float3(-3.0f, 0.5f, -1.0f), float3(1, 1, 1)));
     AddObject(std::make_unique<RotatingObject>("models/corgi.obj", "brick", "PosNormTanUV", L"shaders/gbuffer.hlsl", float3(3.0f, 0.5f, -1.0f), float3(1, 1, 1)));
+
+    {
+        auto glass = std::make_unique<GlassCube>(this, "models/box.obj", float3(2.0f, 0.9f, -3.0f), float3(1.6f, 1.6f, 1.6f), 0.35f);
+        glass->SetTint(float3(0.78f, 0.9f, 1.0f));
+        glass->SetAbsorption(float3(0.16f, 0.07f, 0.03f));
+        glass->SetThickness(0.65f);
+        glass->SetReflectionStrength(1.25f);
+        glass->SetRefractionDistortion(0.02f);
+        glass->SetRoughness(0.05f);
+        glass->SetIor(1.52f);
+        AddObject(std::move(glass));
+    }
 
     {
         auto floor = std::make_unique<StaticMesh>("models/box.obj", "sandstone_cracks", "PosNormTanUV", L"shaders/gbuffer.hlsl");
@@ -1457,6 +1507,13 @@ void Scene::Pass_Transparent(Renderer* renderer, RenderGraph::PassContext ctx,
         {
             GPU_SCOPE(driver.cl, ProfilerScopes::kTransparentDriver);
             const auto& D = renderer->GetDeferredForFrame();
+            if (D.sceneOpaque.Get())
+            {
+                renderer->Transition(driver.cl, D.scene.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE);
+                renderer->Transition(driver.cl, D.sceneOpaque.Get(), D3D12_RESOURCE_STATE_COPY_DEST);
+                driver.cl->CopyResource(D.sceneOpaque.Get(), D.scene.Get());
+                renderer->Transition(driver.cl, D.sceneOpaque.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+            }
             renderer->Transition(driver.cl, D.scene.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
             renderer->Transition(driver.cl, D.depth.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE);
             renderer->BindSceneColor(driver.cl, Renderer::ClearMode::None, true);

--- a/sources/app/Scene.h
+++ b/sources/app/Scene.h
@@ -18,6 +18,19 @@ public:
     Camera& CameraRef() { return camera_; }
     const Camera& CameraRef() const { return camera_; }
 
+    const DirectionalLight& GetDirectionalLight() const { return dirLight_; }
+    LightManager& GetLightManager() { return lightManager_; }
+    const LightManager& GetLightManager() const { return lightManager_; }
+    Skybox* GetSkybox() const { return skyBox_.get(); }
+
+    const mat4& GetCascadeView(size_t index) const;
+    const mat4& GetCascadeProj(size_t index) const;
+    float2 GetCascadeScale(size_t index) const;
+    float2 GetCascadeBias(size_t index) const;
+    float GetCascadeNormalBias(size_t index) const;
+    float GetCascadeDepthBias(size_t index) const;
+    const float* GetCascadeSplitsVS() const { return cachedSplitsVS_; }
+
     void InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList, std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive);
     void AddObject(std::unique_ptr<RenderableObjectBase> obj);
     void Tick(float deltaTime);

--- a/sources/rendering/core/Renderer.cpp
+++ b/sources/rendering/core/Renderer.cpp
@@ -972,7 +972,7 @@ void Renderer::CreateDeferredTargets(UINT width, UINT height)
     {
         D3D12_DESCRIPTOR_HEAP_DESC desc{};
         desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        desc.NumDescriptors = kFrameCount * kDeferredSrvPerFrame;  // GB0,GB1,GB2,Depth,Light,LightUAV,Scene,SceneUAV,SSR,SSRBlur,Shadow,SSRUAV,SSRBlurUAV,Tonemap,TonemapUAV
+        desc.NumDescriptors = kFrameCount * kDeferredSrvPerFrame;  // GB0,GB1,GB2,Depth,Light,LightUAV,Scene,SceneUAV,SceneOpaque,SSR,SSRBlur,Shadow,SpotShadow,SSRUAV,SSRBlurUAV,Tonemap,TonemapUAV
         desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE; // CPU-only staging
         ThrowIfFailed(dev->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&deferredSrvCpuHeap_)));
     }
@@ -1075,6 +1075,37 @@ void Renderer::CreateDeferredTargets(UINT width, UINT height)
             }
 
             SetResourceState(outRes.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET);
+        };
+
+    auto CreateSrvTexture = [&](DXGI_FORMAT fmt,
+        DeferredSrvSlot srvSlot,
+        UINT f,
+        ComPtr<ID3D12Resource>& outRes,
+        D3D12_CPU_DESCRIPTOR_HANDLE& outSRV)
+        {
+            D3D12_RESOURCE_DESC rd = MakeTex2DDesc(fmt, D3D12_RESOURCE_FLAG_NONE);
+
+            ThrowIfFailed(dev->CreateCommittedResource(
+                &heapProps, D3D12_HEAP_FLAG_NONE, &rd,
+                D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr, IID_PPV_ARGS(&outRes)));
+
+            D3D12_SHADER_RESOURCE_VIEW_DESC sd{};
+            sd.Format = fmt;
+            sd.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+            sd.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+            sd.Texture2D.MipLevels = 1;
+
+            outSRV = DeferredSrvCPU(f, srvSlot);
+            dev->CreateShaderResourceView(outRes.Get(), &sd, outSRV);
+
+            auto& D = deferred_[f];
+            if (srvSlot == DeferredSrvSlot::SceneOpaque)
+            {
+                D.sceneOpaque = outRes;
+                D.sceneOpaqueSRV = outSRV;
+            }
+
+            SetResourceState(outRes.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
         };
 
     auto CreateSrvUavTexture = [&](DXGI_FORMAT fmt,
@@ -1294,6 +1325,7 @@ void Renderer::CreateDeferredTargets(UINT width, UINT height)
 
         CreateRT(kLightTargetFormat, DeferredRtvSlot::Light, DeferredSrvSlot::Light, DeferredSrvSlot::LightUAV, f, D.light, D.lightRTV, D.lightSRV);
         CreateRT(kSceneColorFormat, DeferredRtvSlot::Scene, DeferredSrvSlot::Scene, DeferredSrvSlot::SceneUAV, f, D.scene, D.sceneRTV, D.sceneSRV);
+        CreateSrvTexture(kSceneColorFormat, DeferredSrvSlot::SceneOpaque, f, D.sceneOpaque, D.sceneOpaqueSRV);
         CreateSrvUavTexture(kSsrFormat, DeferredSrvSlot::SSR, DeferredSrvSlot::SSRUAV, f, D.ssr, D.ssrSRV, D.ssrUAV, ssrTextureWidth_, ssrTextureHeight_);
         CreateSrvUavTexture(kSsrBlurFormat, DeferredSrvSlot::SSRBlur, DeferredSrvSlot::SSRBlurUAV, f, D.ssrBlur, D.ssrBlurSRV, D.ssrBlurUAV, ssrTextureWidth_, ssrTextureHeight_);
         CreateSrvUavTexture(kBackbufferResourceFormat, DeferredSrvSlot::Tonemap, DeferredSrvSlot::TonemapUAV, f, D.tonemap, D.tonemapSRV, D.tonemapUAV, width, height);
@@ -1320,6 +1352,7 @@ void Renderer::DestroyDeferredTargets() {
         collect(D.depth);
         collect(D.light);
         collect(D.scene);
+        collect(D.sceneOpaque);
         collect(D.tonemap);
         collect(D.ssr);
         collect(D.ssrBlur);

--- a/sources/rendering/core/Renderer.h
+++ b/sources/rendering/core/Renderer.h
@@ -32,7 +32,7 @@ public:
     };
     enum class ClearMode { None, Color, ColorDepth };
     struct DeferredTargets {
-        static constexpr size_t kResourceCount = 11; // gb0,gb1,gb2,depth,light,scene,tonemap,ssr,ssrBlur,shadow,spotShadow
+        static constexpr size_t kResourceCount = 12; // gb0,gb1,gb2,depth,light,scene,sceneOpaque,tonemap,ssr,ssrBlur,shadow,spotShadow
         // Resources
         ComPtr<ID3D12Resource> gb0;   // Renderer::kGBuffer0Format (albedo+metal)
         ComPtr<ID3D12Resource> gb1;   // Renderer::kGBuffer1Format (normalOcta+rough)
@@ -40,6 +40,7 @@ public:
         ComPtr<ID3D12Resource> depth; // Renderer::kDeferredDepthFormat
         ComPtr<ID3D12Resource> light; // Renderer::kLightTargetFormat
         ComPtr<ID3D12Resource> scene; // Renderer::kSceneColorFormat
+        ComPtr<ID3D12Resource> sceneOpaque; // Copy of opaque scene color for refraction
         ComPtr<ID3D12Resource> tonemap; // Tonemap output (R8G8B8A8)
         ComPtr<ID3D12Resource> ssr;     // Renderer::kSsrFormat (premultiplied)
         ComPtr<ID3D12Resource> ssrBlur; // Renderer::kSsrBlurFormat
@@ -52,6 +53,7 @@ public:
         D3D12_CPU_DESCRIPTOR_HANDLE gbSRV[4]{}; // GB0,GB1,GB2,Depth(R32F)
         D3D12_CPU_DESCRIPTOR_HANDLE lightRTV{}, lightSRV{}, lightUAV{};
         D3D12_CPU_DESCRIPTOR_HANDLE sceneRTV{}, sceneSRV{}, sceneUAV{};
+        D3D12_CPU_DESCRIPTOR_HANDLE sceneOpaqueSRV{};
         D3D12_CPU_DESCRIPTOR_HANDLE tonemapSRV{}, tonemapUAV{};
         D3D12_CPU_DESCRIPTOR_HANDLE ssrSRV{}, ssrUAV{};
         D3D12_CPU_DESCRIPTOR_HANDLE ssrBlurSRV{}, ssrBlurUAV{};
@@ -262,7 +264,7 @@ private:
     static constexpr UINT kFrameCount = 2;
 
     enum class DeferredRtvSlot : UINT { GB0, GB1, GB2, Light, Scene, Count };
-    enum class DeferredSrvSlot : UINT { GB0, GB1, GB2, Depth, Light, LightUAV, Scene, SceneUAV, SSR, SSRBlur, Shadow, SpotShadow, SSRUAV, SSRBlurUAV, Tonemap, TonemapUAV, Count };
+    enum class DeferredSrvSlot : UINT { GB0, GB1, GB2, Depth, Light, LightUAV, Scene, SceneUAV, SceneOpaque, SSR, SSRBlur, Shadow, SpotShadow, SSRUAV, SSRBlurUAV, Tonemap, TonemapUAV, Count };
     enum class DeferredDsvSlot : UINT { Depth, Shadow, Count };
 
     static constexpr UINT kDeferredRtvPerFrame = (UINT)DeferredRtvSlot::Count;

--- a/sources/rendering/renderables/GlassCube.cpp
+++ b/sources/rendering/renderables/GlassCube.cpp
@@ -1,0 +1,327 @@
+#include "rendering/renderables/GlassCube.h"
+
+#include <algorithm>
+#include <array>
+
+#include "app/Scene.h"
+#include "rendering/core/Renderer.h"
+#include "rendering/descriptors/SamplerManager.h"
+#include "rendering/lighting/LightManager.h"
+#include "rendering/lighting/Skybox.h"
+#include "rendering/meshes/MeshManager.h"
+
+using namespace Math;
+
+namespace
+{
+    constexpr size_t kCascadeCount = 4;
+}
+
+class GlassCube::GlassUniformBinder final : public RenderableObject::UniformBinder
+{
+public:
+    GlassUniformBinder(Scene* scene, GlassCube* owner)
+        : scene_(scene)
+        , owner_(owner)
+    {
+    }
+
+    void RebuildHandles(RenderableObject& obj) override
+    {
+        cb_ = {};
+        shadowCb_ = {};
+        if (Material* material = obj.GetGraphicsMaterial())
+        {
+            cb_.world = material->ComputeCBFieldHandle(0, "world");
+            cb_.view = material->ComputeCBFieldHandle(0, "view");
+            cb_.proj = material->ComputeCBFieldHandle(0, "proj");
+            cb_.invView = material->ComputeCBFieldHandle(0, "invView");
+            cb_.invProj = material->ComputeCBFieldHandle(0, "invProj");
+            cb_.cameraPosIor = material->ComputeCBFieldHandle(0, "cameraPosIor");
+            cb_.absorptionThickness = material->ComputeCBFieldHandle(0, "absorptionThickness");
+            cb_.tintRoughness = material->ComputeCBFieldHandle(0, "tintRoughness");
+            cb_.reflectionRefraction = material->ComputeCBFieldHandle(0, "reflectionRefraction");
+            cb_.sunDirAmbient = material->ComputeCBFieldHandle(0, "sunDirAmbient");
+            cb_.sunColorExposure = material->ComputeCBFieldHandle(0, "sunColorExposure");
+            cb_.camDirWS = material->ComputeCBFieldHandle(0, "camDirWS");
+            cb_.screenSizeInv = material->ComputeCBFieldHandle(0, "screenSizeInv");
+            cb_.shadowAtlasSizeInv = material->ComputeCBFieldHandle(0, "shadowAtlasSizeInv");
+            cb_.shadowBiasNDC = material->ComputeCBFieldHandle(0, "shadowBiasNDC");
+            cb_.normalBiasWS = material->ComputeCBFieldHandle(0, "normalBiasWS");
+            cb_.cascadeSplitsVS = material->ComputeCBFieldHandle(0, "cascadeSplitsVS");
+            cb_.cascadeScaleBias = material->ComputeCBFieldHandle(0, "cascadeScaleBias");
+            cb_.spotShadowInfo = material->ComputeCBFieldHandle(0, "spotShadowInfo");
+            cb_.lightCounts = material->ComputeCBFieldHandle(0, "lightCounts");
+            cb_.lightViewProj = material->ComputeCBFieldHandle(0, "lightViewProj");
+        }
+
+        if (Material* shadowMaterial = obj.GetShadowMaterial())
+        {
+            shadowCb_.world = shadowMaterial->ComputeCBFieldHandle(0, "world");
+            shadowCb_.view = shadowMaterial->ComputeCBFieldHandle(0, "view");
+            shadowCb_.proj = shadowMaterial->ComputeCBFieldHandle(0, "proj");
+        }
+    }
+
+    void UpdateMainCB(RenderableObject& obj, Renderer* renderer, const mat4& view, const mat4& proj, uint8_t* cbData) override
+    {
+        if (!renderer || !scene_ || !owner_)
+        {
+            return;
+        }
+        Material* material = obj.GetGraphicsMaterial();
+        if (!material)
+        {
+            return;
+        }
+
+        const mat4 invView = mat4::Inverse(view);
+        const mat4 invProj = mat4::Inverse(proj);
+        const float3 camPos = scene_->CameraRef().GetPosition();
+        float3 camDir = invView.TransformDirection(float3(0.0f, 0.0f, 1.0f));
+        if (camDir.Length() > Math::EPS)
+        {
+            camDir = camDir.Normalized();
+        }
+        else
+        {
+            camDir = float3(0.0f, 0.0f, 1.0f);
+        }
+
+        UpdateUniform(obj, cb_.world, material, obj.GetModelMatrix(), cbData);
+        UpdateUniform(obj, cb_.view, material, view, cbData);
+        UpdateUniform(obj, cb_.proj, material, proj, cbData);
+        UpdateUniform(obj, cb_.invView, material, invView, cbData);
+        UpdateUniform(obj, cb_.invProj, material, invProj, cbData);
+
+        UpdateUniform(obj, cb_.cameraPosIor, material, float4(camPos, owner_->ior_), cbData);
+        UpdateUniform(obj, cb_.absorptionThickness, material, float4(owner_->absorption_, owner_->thickness_), cbData);
+        UpdateUniform(obj, cb_.tintRoughness, material, float4(owner_->tint_, owner_->roughness_), cbData);
+
+        float skyIntensity = 1.0f;
+        if (auto* sky = scene_->GetSkybox())
+        {
+            skyIntensity = sky->GetExposure();
+        }
+        UpdateUniform(obj, cb_.reflectionRefraction, material, float4(owner_->reflectionStrength_, owner_->refractionDistortion_, skyIntensity, 0.0f), cbData);
+
+        const auto& dirLight = scene_->GetDirectionalLight();
+        UpdateUniform(obj, cb_.sunDirAmbient, material, float4(dirLight.dir, dirLight.ambient), cbData);
+        UpdateUniform(obj, cb_.sunColorExposure, material, float4(dirLight.color, dirLight.exposure), cbData);
+        UpdateUniform(obj, cb_.camDirWS, material, float4(camDir, 0.0f), cbData);
+
+        const float width = static_cast<float>(std::max(renderer->GetWidth(), 1u));
+        const float height = static_cast<float>(std::max(renderer->GetHeight(), 1u));
+        const float invWidth = width > 0.0f ? 1.0f / width : 0.0f;
+        const float invHeight = height > 0.0f ? 1.0f / height : 0.0f;
+        UpdateUniform(obj, cb_.screenSizeInv, material, float4(width, height, invWidth, invHeight), cbData);
+
+        const auto& deferred = renderer->GetDeferredForFrame();
+        const float shadowRes = static_cast<float>(std::max(deferred.shadowRes, 1u));
+        const float invShadow = shadowRes > 0.0f ? 1.0f / shadowRes : 0.0f;
+        UpdateUniform(obj, cb_.shadowAtlasSizeInv, material, float4(shadowRes, shadowRes, invShadow, invShadow), cbData);
+
+        UpdateUniform(obj, cb_.shadowBiasNDC, material, float4(
+            scene_->GetCascadeDepthBias(0),
+            scene_->GetCascadeDepthBias(1),
+            scene_->GetCascadeDepthBias(2),
+            scene_->GetCascadeDepthBias(3)), cbData);
+
+        UpdateUniform(obj, cb_.normalBiasWS, material, float4(
+            scene_->GetCascadeNormalBias(0),
+            scene_->GetCascadeNormalBias(1),
+            scene_->GetCascadeNormalBias(2),
+            scene_->GetCascadeNormalBias(3)), cbData);
+
+        if (const float* splits = scene_->GetCascadeSplitsVS())
+        {
+            UpdateUniform(obj, cb_.cascadeSplitsVS, material, float4(splits[0], splits[1], splits[2], splits[3]), cbData);
+        }
+
+        for (size_t i = 0; i < kCascadeCount; ++i)
+        {
+            const mat4 viewProj = scene_->GetCascadeView(i) * scene_->GetCascadeProj(i);
+            UpdateUniform(obj, cb_.lightViewProj, material, viewProj, cbData, static_cast<uint32_t>(i));
+            const float2 scale = scene_->GetCascadeScale(i);
+            const float2 bias = scene_->GetCascadeBias(i);
+            UpdateUniform(obj, cb_.cascadeScaleBias, material, float4(scale.x, scale.y, bias.x, bias.y), cbData, static_cast<uint32_t>(i));
+        }
+
+        const float spotRes = static_cast<float>(std::max(deferred.spotShadowRes, 1u));
+        const float invSpot = spotRes > 0.0f ? 1.0f / spotRes : 0.0f;
+        UpdateUniform(obj, cb_.spotShadowInfo, material, float4(spotRes, spotRes, invSpot, invSpot), cbData);
+
+        auto& lightManager = scene_->GetLightManager();
+        const float pointCount = static_cast<float>(lightManager.PointLights().size());
+        const float spotCount = static_cast<float>(lightManager.GetSpotLightCount());
+        UpdateUniform(obj, cb_.lightCounts, material, float4(pointCount, spotCount, 0.0f, 0.0f), cbData);
+    }
+
+    void UpdateShadowCB(RenderableObject& obj, Renderer* /*renderer*/, const mat4& lightView, const mat4& lightProj, uint8_t* cbData) override
+    {
+        Material* shadowMaterial = obj.GetShadowMaterial();
+        if (!shadowMaterial)
+        {
+            return;
+        }
+
+        UpdateUniform(obj, shadowCb_.world, shadowMaterial, obj.GetModelMatrix(), cbData);
+        UpdateUniform(obj, shadowCb_.view, shadowMaterial, lightView, cbData);
+        UpdateUniform(obj, shadowCb_.proj, shadowMaterial, lightProj, cbData);
+    }
+
+private:
+    struct MainHandles
+    {
+        Material::CBFieldHandle world;
+        Material::CBFieldHandle view;
+        Material::CBFieldHandle proj;
+        Material::CBFieldHandle invView;
+        Material::CBFieldHandle invProj;
+        Material::CBFieldHandle cameraPosIor;
+        Material::CBFieldHandle absorptionThickness;
+        Material::CBFieldHandle tintRoughness;
+        Material::CBFieldHandle reflectionRefraction;
+        Material::CBFieldHandle sunDirAmbient;
+        Material::CBFieldHandle sunColorExposure;
+        Material::CBFieldHandle camDirWS;
+        Material::CBFieldHandle screenSizeInv;
+        Material::CBFieldHandle shadowAtlasSizeInv;
+        Material::CBFieldHandle shadowBiasNDC;
+        Material::CBFieldHandle normalBiasWS;
+        Material::CBFieldHandle cascadeSplitsVS;
+        Material::CBFieldHandle cascadeScaleBias;
+        Material::CBFieldHandle spotShadowInfo;
+        Material::CBFieldHandle lightCounts;
+        Material::CBFieldHandle lightViewProj;
+    } cb_{};
+
+    struct ShadowHandles
+    {
+        Material::CBFieldHandle world;
+        Material::CBFieldHandle view;
+        Material::CBFieldHandle proj;
+    } shadowCb_{};
+
+    Scene* scene_ = nullptr;
+    GlassCube* owner_ = nullptr;
+};
+
+GlassCube::GlassCube(Scene* scene,
+    const std::string& modelName,
+    float3 position,
+    float3 scale,
+    float rotationSpeedRad)
+    : RenderableObject("PosNormTanUV", L"shaders/glass.hlsl")
+    , scene_(scene)
+    , modelName_(modelName)
+    , rotationSpeed_(rotationSpeedRad)
+{
+    pos_ = position;
+    scale_ = scale;
+    rotEuler_ = float3(0.0f, 0.0f, 0.0f);
+    transformDirty_ = true;
+
+    auto& gd = GetGraphicsDesc();
+    gd.numRT = 1;
+    gd.rtvFormats[0] = Renderer::kSceneColorFormat;
+    gd.dsvFormat = Renderer::kDeferredDepthFormat;
+    gd.depth.DepthEnable = TRUE;
+    gd.depth.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
+    gd.depth.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
+    gd.blend.RenderTarget[0].BlendEnable = TRUE;
+    gd.blend.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
+    gd.blend.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
+    gd.blend.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+    gd.blend.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
+    gd.blend.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
+    gd.blend.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
+    gd.raster.CullMode = D3D12_CULL_MODE_BACK;
+
+    allowWireframe_ = false;
+
+    SetUniformBinder(std::make_unique<GlassUniformBinder>(scene_, this));
+}
+
+void GlassCube::Init(Renderer* renderer,
+    ID3D12GraphicsCommandList* uploadCmdList,
+    std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive)
+{
+    RenderableObject::Init(renderer, uploadCmdList, uploadKeepAlive);
+    if (renderer && !modelName_.empty())
+    {
+        mesh_ = renderer->GetMeshManager()->Load(modelName_, renderer, uploadCmdList, uploadKeepAlive, { true, false, 0 });
+    }
+    transformDirty_ = true;
+}
+
+void GlassCube::Tick(float deltaTime)
+{
+    rotEuler_.y += rotationSpeed_ * deltaTime;
+    if (rotEuler_.y > XM_2PI)
+    {
+        rotEuler_.y -= XM_2PI;
+    }
+    MarkTransformDirty();
+}
+
+void GlassCube::PostTick(float /*deltaTime*/)
+{
+    if (!transformDirty_)
+    {
+        return;
+    }
+    RebuildModel();
+    transformDirty_ = false;
+}
+
+void GlassCube::PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* /*cl*/, RenderContext& ctx)
+{
+    if (!renderer || !scene_)
+    {
+        return;
+    }
+
+    const auto& deferred = renderer->GetDeferredForFrame();
+    auto* sky = scene_->GetSkybox();
+
+    std::array<D3D12_CPU_DESCRIPTOR_HANDLE, 4> srvs{
+        deferred.sceneOpaqueSRV.ptr != 0 ? deferred.sceneOpaqueSRV : deferred.sceneSRV,
+        deferred.shadowSRV,
+        deferred.spotShadowSRV,
+        sky ? sky->GetTex()->GetSRVCPU() : deferred.sceneSRV
+    };
+    ctx.table[0] = renderer->StageSrvUavTable(srvs).gpu;
+
+    auto& lights = scene_->GetLightManager();
+    const size_t pointCount = lights.PointLights().size();
+    const size_t spotCount = lights.GetSpotLightCount();
+    lights.EnsurePointLightBuffer(renderer, std::max<size_t>(pointCount, size_t(1)));
+    lights.EnsureSpotLightBuffer(renderer, std::max<size_t>(spotCount, size_t(1)));
+
+    std::array<D3D12_CPU_DESCRIPTOR_HANDLE, 2> lightSrvs{
+        lights.GetPointLightSrv(),
+        lights.GetSpotLightSrv()
+    };
+    ctx.table[1] = renderer->StageSrvUavTable(lightSrvs).gpu;
+
+    const auto samplerDescs = std::array{
+        *SamplerManager::LinearClamp(),
+        *SamplerManager::ComparisonLinearClamp(),
+        *SamplerManager::LinearClamp()
+    };
+    ctx.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplerDescs);
+}
+
+void GlassCube::MarkTransformDirty()
+{
+    transformDirty_ = true;
+}
+
+void GlassCube::RebuildModel()
+{
+    mat4 T = mat4::Translation(pos_);
+    mat4 S = mat4::Scaling(scale_);
+    mat4 R = mat4::RotationFromEulerXYZRad(rotEuler_);
+    SetModelMatrix(S * R * T);
+}

--- a/sources/rendering/renderables/GlassCube.h
+++ b/sources/rendering/renderables/GlassCube.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <vector>
+
+#include "rendering/renderables/RenderableObject.h"
+
+class Scene;
+
+class GlassCube final : public RenderableObject
+{
+public:
+    GlassCube(Scene* scene,
+        const std::string& modelName,
+        float3 position,
+        float3 scale,
+        float rotationSpeedRad);
+
+    void Init(Renderer* renderer,
+        ID3D12GraphicsCommandList* uploadCmdList,
+        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>* uploadKeepAlive) override;
+
+    void Tick(float deltaTime) override;
+    void PostTick(float deltaTime) override;
+
+    void SetTint(const float3& tint) { tint_ = tint; }
+    void SetAbsorption(const float3& absorption) { absorption_ = absorption; }
+    void SetThickness(float thickness) { thickness_ = thickness; }
+    void SetReflectionStrength(float strength) { reflectionStrength_ = strength; }
+    void SetRefractionDistortion(float distortion) { refractionDistortion_ = distortion; }
+    void SetRoughness(float roughness) { roughness_ = roughness; }
+    void SetIor(float ior) { ior_ = ior; }
+
+    bool IsSimpleRender() const override { return false; }
+
+protected:
+    void PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* cl, RenderContext& ctx) override;
+
+private:
+    class GlassUniformBinder;
+
+    void MarkTransformDirty();
+    void RebuildModel();
+
+    Scene* scene_ = nullptr;
+    std::string modelName_;
+    float3 pos_{};
+    float3 scale_{};
+    float3 rotEuler_{};
+    bool transformDirty_ = false;
+    float rotationSpeed_ = 0.0f;
+
+    float ior_ = 1.52f;
+    float3 absorption_ = float3(0.25f, 0.08f, 0.04f);
+    float thickness_ = 0.6f;
+    float reflectionStrength_ = 1.0f;
+    float refractionDistortion_ = 0.015f;
+    float3 tint_ = float3(0.85f, 0.93f, 1.0f);
+    float roughness_ = 0.07f;
+};

--- a/sources/rendering/renderables/RenderableObject.h
+++ b/sources/rendering/renderables/RenderableObject.h
@@ -4,6 +4,7 @@
 #include <DirectXMath.h>
 #include <string>
 #include <memory>
+#include <cstdint>
 
 #include "materials/Material.h"
 #include "rendering/meshes/Mesh.h"
@@ -29,6 +30,12 @@ public:
         bool UpdateUniform(RenderableObject& owner, const Material::CBFieldHandle& handle, Material* material, const T& value, uint8_t* cbData) const
         {
             return owner.UpdateUniform(handle, material, value, cbData);
+        }
+
+        template<typename T>
+        bool UpdateUniform(RenderableObject& owner, const Material::CBFieldHandle& handle, Material* material, const T& value, uint8_t* cbData, uint32_t arrayIndex) const
+        {
+            return owner.UpdateUniform(handle, material, value, cbData, arrayIndex);
         }
     };
 
@@ -83,6 +90,15 @@ protected:
         if (!material) { return false; }
         if (!handle.field) { return false; }
         return material->UpdateCBField(handle, value, cbData);
+    }
+
+    template<typename T>
+    bool UpdateUniform(const Material::CBFieldHandle& handle, Material* material, const T& value, uint8_t* cbData, uint32_t arrayIndex)
+    {
+        if (!cbData) { return false; }
+        if (!material) { return false; }
+        if (!handle.field) { return false; }
+        return material->UpdateCBField(handle, value, cbData, arrayIndex);
     }
 
 protected:

--- a/test_cube.vcxproj
+++ b/test_cube.vcxproj
@@ -189,6 +189,7 @@
     <ClCompile Include="sources/rendering/meshes/Mesh.cpp" />
     <ClCompile Include="sources/rendering/meshes/MeshManager.cpp" />
     <ClCompile Include="sources/rendering/meshes/StaticMesh.cpp" />
+    <ClCompile Include="sources/rendering/renderables/GlassCube.cpp" />
     <ClCompile Include="sources/rendering/renderables/GBufferRenderable.cpp" />
     <ClCompile Include="sources/rendering/renderables/RenderableObject.cpp" />
     <ClCompile Include="sources/rendering/renderables/RenderableObjectBase.cpp" />
@@ -244,6 +245,7 @@
     <ClInclude Include="sources/rendering/meshes/MeshManager.h" />
     <ClInclude Include="sources/rendering/meshes/StaticMesh.h" />
     <ClInclude Include="sources/rendering/renderables/GBufferRenderable.h" />
+    <ClInclude Include="sources/rendering/renderables/GlassCube.h" />
     <ClInclude Include="sources/rendering/renderables/RenderableObject.h" />
     <ClInclude Include="sources/rendering/renderables/RenderableObjectBase.h" />
     <ClInclude Include="sources/text/FontAtlas.h" />
@@ -264,6 +266,8 @@
     <None Include="shaders\gbuffer_csm.hlsl" />
     <None Include="shaders\gbuffer_inst.hlsl" />
     <None Include="shaders\gbuffer_inst_csm.hlsl" />
+    <None Include="shaders\glass.hlsl" />
+    <None Include="shaders\glass_csm.hlsl" />
     <None Include="shaders\instance_anim.hlsl" />
     <None Include="shaders\lighting_cs.hlsl" />
     <None Include="shaders\lines.hlsl" />

--- a/test_cube.vcxproj.filters
+++ b/test_cube.vcxproj.filters
@@ -171,6 +171,9 @@
     <ClCompile Include="sources/rendering/meshes/StaticMesh.cpp">
       <Filter>sources\rendering\meshes</Filter>
     </ClCompile>
+    <ClCompile Include="sources/rendering/renderables/GlassCube.cpp">
+      <Filter>sources\rendering\renderables</Filter>
+    </ClCompile>
     <ClCompile Include="sources/rendering/renderables/GBufferRenderable.cpp">
       <Filter>sources\rendering\renderables</Filter>
     </ClCompile>
@@ -332,6 +335,9 @@
     <ClInclude Include="sources/rendering/renderables/GBufferRenderable.h">
       <Filter>sources\rendering\renderables</Filter>
     </ClInclude>
+    <ClInclude Include="sources/rendering/renderables/GlassCube.h">
+      <Filter>sources\rendering\renderables</Filter>
+    </ClInclude>
     <ClInclude Include="sources/rendering/renderables/RenderableObject.h">
       <Filter>sources\rendering\renderables</Filter>
     </ClInclude>
@@ -386,6 +392,12 @@
       <Filter>shaders</Filter>
     </None>
     <None Include="shaders\gbuffer_inst_csm.hlsl">
+      <Filter>shaders</Filter>
+    </None>
+    <None Include="shaders\glass.hlsl">
+      <Filter>shaders</Filter>
+    </None>
+    <None Include="shaders\glass_csm.hlsl">
       <Filter>shaders</Filter>
     </None>
     <None Include="shaders\instance_anim.hlsl">


### PR DESCRIPTION
## Summary
- extract the glass cube renderable into dedicated header/source files so its initialization, uniform binding, and context setup live outside Scene.cpp
- register the new renderable implementation with the Visual Studio project to ensure it builds
- rename the duplicate ShadowPCF3x3 helper functions in the glass shader to use distinct identifiers

## Testing
- not run (MSVC shader compilation/runtime required)


------
https://chatgpt.com/codex/tasks/task_e_68e501146cfc83298d1b75fd52f4d451