### PR TITLE
Adjust glass normal map handling

### DIFF
--- a/shaders/glass.hlsl
+++ b/shaders/glass.hlsl
@@ -1,4 +1,4 @@
-// RootSignature: CBV(b0) TABLE(SRV(t0) SRV(t1) SRV(t2) SRV(t3)) TABLE(SRV(t4) SRV(t5)) TABLE(SAMPLER(s0) SAMPLER(s1) SAMPLER(s2))
+// RootSignature: CBV(b0) TABLE(SRV(t0) SRV(t1) SRV(t2) SRV(t3)) TABLE(SRV(t4) SRV(t5)) TABLE(SRV(t6)) TABLE(SAMPLER(s0) SAMPLER(s1) SAMPLER(s2))
 #pragma pack_matrix(row_major)
 #include "utils.hlsl"
 
@@ -21,7 +21,7 @@ struct SpotLightData
 };
 
 cbuffer GlassParams : register(b0)
-{
+{ 
     float4x4 world;
     float4x4 view;
     float4x4 proj;
@@ -30,7 +30,7 @@ cbuffer GlassParams : register(b0)
     float4 cameraPosIor;          // xyz = camera position, w = IOR
     float4 absorptionThickness;   // xyz = absorption, w = thickness
     float4 tintRoughness;         // xyz = tint color, w = roughness
-    float4 reflectionRefraction;  // x = reflection strength, y = refraction distortion, z = sky intensity, w = unused
+    float4 reflectionRefraction;  // x = reflection strength, y = refraction distortion, z = sky intensity, w = normal map enabled (0=disabled, 1=enabled)
     float4 sunDirAmbient;         // xyz = sun direction, w = ambient intensity
     float4 sunColorExposure;      // xyz = sun color, w = sun exposure
     float4 camDirWS;              // xyz = camera forward, w unused
@@ -51,6 +51,7 @@ Texture2DArray SpotShadowAtlas : register(t2);
 TextureCube SkyboxTex : register(t3);
 StructuredBuffer<PointLightData> PointLights : register(t4);
 StructuredBuffer<SpotLightData> SpotLights : register(t5);
+Texture2D NormalMap : register(t6);
 
 SamplerState LinearSampler : register(s0);
 SamplerComparisonState ShadowSampler : register(s1);
@@ -69,6 +70,9 @@ struct VSOut
     float4 posH : SV_POSITION;
     float3 posWS : TEXCOORD0;
     float3 normalWS : TEXCOORD1;
+    float3 tangentWS : TEXCOORD2;
+    float3 bitangentWS : TEXCOORD3;
+    float2 uv : TEXCOORD4;
 };
 
 VSOut VSMain(VSIn input)
@@ -78,9 +82,21 @@ VSOut VSMain(VSIn input)
     o.posWS = worldPos.xyz;
     o.posH = mul(mul(worldPos, view), proj);
     float3x3 w3 = (float3x3) world;
-    o.normalWS = NormalizeSafe(mul(input.N, w3), float3(0.0f, 1.0f, 0.0f));
+    float3 tangentWS = mul(input.T.xyz, w3);
+    float3 normalWS = mul(input.N, w3);
+    tangentWS = normalize(tangentWS);
+    normalWS = normalize(normalWS);
+    float3 bitangentWS = normalize(cross(normalWS, tangentWS) * input.T.w);
+    o.normalWS = normalWS;
+    o.tangentWS = tangentWS;
+    o.bitangentWS = bitangentWS;
+    o.uv = input.UV;
     return o;
 }
+
+#ifndef NORMALMAP_IS_RG
+#define NORMALMAP_IS_RG 0
+#endif
 
 int ChooseCascadeIndex(float3 Pws)
 {
@@ -184,6 +200,27 @@ float4 PSMain(VSOut i) : SV_Target
     float reflectionStrength = max(reflectionRefraction.x, 0.0f);
     float refractionDistortion = reflectionRefraction.y;
     float skyIntensity = reflectionRefraction.z;
+    float normalInfo = reflectionRefraction.w;
+    float normalStrength = max(refractionDistortion, 0.0f);
+
+    bool useNormalMap = (normalInfo > 0.5f) && (normalStrength > 0.0f);
+    if (useNormalMap)
+    {
+        float3 baseN = N;
+        float3 T = normalize(i.tangentWS);
+        float3 B = normalize(i.bitangentWS);
+#if NORMALMAP_IS_RG
+        float2 nrg = NormalMap.Sample(LinearSampler, i.uv).rg * 2.0f - 1.0f;
+        float2 scaled = nrg * normalStrength;
+        float nz2 = saturate(1.0f - dot(scaled, scaled));
+        float3 nTS = float3(scaled, sqrt(nz2));
+#else
+        float3 nRGB = NormalMap.Sample(LinearSampler, i.uv).xyz * 2.0f - 1.0f;
+        float3 nTS = float3(nRGB.xy * normalStrength, nRGB.z);
+        nTS = normalize(nTS);
+#endif
+        N = normalize(T * nTS.x + B * nTS.y + baseN * nTS.z);
+    }
 
     float3 sunDir = normalize(sunDirAmbient.xyz);
     float ambientIntensity = sunDirAmbient.w;

--- a/sources/app/Scene.cpp
+++ b/sources/app/Scene.cpp
@@ -375,6 +375,7 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
         glass->SetRefractionDistortion(0.02f);
         glass->SetRoughness(0.05f);
         glass->SetIor(1.1f);
+        glass->SetNormalMap(L"textures/damaged_plaster_normal.dds");
         AddObject(std::move(glass));
 
         glass = std::make_unique<GlassCube>(this, "models/sphere.obj", float3(-1.8f, 0.5f, -2.2f), float3(0.8f, 0.8f, 0.8f), 0.0f);
@@ -385,6 +386,7 @@ void Scene::InitAll(Renderer* renderer, ID3D12GraphicsCommandList* uploadCmdList
         glass->SetRefractionDistortion(0.02f);
         glass->SetRoughness(0.05f);
         glass->SetIor(1.1f);
+        glass->SetNormalMap(L"textures/damaged_plaster_normal.dds");
         AddObject(std::move(glass));
     }
 

--- a/sources/rendering/renderables/GlassCube.cpp
+++ b/sources/rendering/renderables/GlassCube.cpp
@@ -103,7 +103,8 @@ public:
         {
             skyIntensity = sky->GetExposure();
         }
-        UpdateUniform(obj, cb_.reflectionRefraction, material, float4(owner_->reflectionStrength_, owner_->refractionDistortion_, skyIntensity, 0.0f), cbData);
+        float normalInfo = owner_->HasNormalMap() ? 1.0f : 0.0f;
+        UpdateUniform(obj, cb_.reflectionRefraction, material, float4(owner_->reflectionStrength_, owner_->refractionDistortion_, skyIntensity, normalInfo), cbData);
 
         const auto& dirLight = scene_->GetDirectionalLight();
         UpdateUniform(obj, cb_.sunDirAmbient, material, float4(dirLight.dir, dirLight.ambient), cbData);
@@ -252,6 +253,15 @@ void GlassCube::Init(Renderer* renderer,
     {
         mesh_ = renderer->GetMeshManager()->Load(modelName_, renderer, uploadCmdList, uploadKeepAlive, { true, false, 0 });
     }
+    hasNormalMap_ = false;
+    if (renderer && uploadCmdList && !normalMapPath_.empty())
+    {
+        Texture2D::CreateDesc desc{};
+        desc.path = normalMapPath_;
+        desc.usage = Texture2D::Usage::NormalMap;
+        desc.normalIsRG = normalMapIsRG_;
+        hasNormalMap_ = normalMap_.CreateFromFile(renderer, uploadCmdList, desc, uploadKeepAlive);
+    }
     transformDirty_ = true;
 }
 
@@ -311,6 +321,15 @@ void GlassCube::PopulateContext(Renderer* renderer, ID3D12GraphicsCommandList* /
         *SamplerManager::LinearClamp()
     };
     ctx.samplerTable[0] = renderer->GetSamplerManager()->GetTable(renderer, samplerDescs);
+
+    if (hasNormalMap_)
+    {
+        auto srv = normalMap_.GetSRVCPU();
+        if (srv.ptr != 0)
+        {
+            ctx.table[6] = renderer->StageSrvUavTable({ srv }).gpu;
+        }
+    }
 }
 
 void GlassCube::MarkTransformDirty()
@@ -324,4 +343,18 @@ void GlassCube::RebuildModel()
     mat4 S = mat4::Scaling(scale_);
     mat4 R = mat4::RotationFromEulerXYZRad(rotEuler_);
     SetModelMatrix(S * R * T);
+}
+
+void GlassCube::SetNormalMap(const std::wstring& path, bool normalIsRG)
+{
+    normalMapPath_ = path;
+    normalMapIsRG_ = normalIsRG;
+    hasNormalMap_ = false;
+
+    auto& defs = GetGraphicsDesc().defines;
+    defs.erase(std::remove_if(defs.begin(), defs.end(), [](const auto& def) { return def.first == "NORMALMAP_IS_RG"; }), defs.end());
+    if (normalMapIsRG_)
+    {
+        defs.emplace_back("NORMALMAP_IS_RG", "1");
+    }
 }

--- a/sources/rendering/renderables/GlassCube.h
+++ b/sources/rendering/renderables/GlassCube.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "materials/Texture2D.h"
 #include "rendering/renderables/RenderableObject.h"
 
 class Scene;
@@ -29,6 +30,10 @@ public:
     void SetRefractionDistortion(float distortion) { refractionDistortion_ = distortion; }
     void SetRoughness(float roughness) { roughness_ = roughness; }
     void SetIor(float ior) { ior_ = ior; }
+    void SetNormalMap(const std::wstring& path, bool normalIsRG = false);
+
+    bool HasNormalMap() const { return hasNormalMap_; }
+    bool IsNormalMapRG() const { return normalMapIsRG_; }
 
     bool IsSimpleRender() const override { return false; }
 
@@ -56,4 +61,9 @@ private:
     float refractionDistortion_ = 0.015f;
     float3 tint_ = float3(0.85f, 0.93f, 1.0f);
     float roughness_ = 0.07f;
+
+    Texture2D normalMap_{};
+    std::wstring normalMapPath_{};
+    bool normalMapIsRG_ = false;
+    bool hasNormalMap_ = false;
 };


### PR DESCRIPTION
## Summary
- extend the glass shader to build the tangent frame in the vertex stage, select RG vs RGB sampling through a `NORMALMAP_IS_RG` define, and rely on standard `normalize` when applying refraction-distortion-driven normal maps.
- load, bind, and expose a normal map resource for glass renderables and assign a demo texture in the scene setup while now passing only a presence flag to the shader and pushing the `NORMALMAP_IS_RG` define when RG textures are requested.

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67f691eac83299f63405e6d91ac84